### PR TITLE
feat: implement secondary sort for ready tasks (oldest first within priority)

### DIFF
--- a/src/parser/yaml.ts
+++ b/src/parser/yaml.ts
@@ -701,12 +701,20 @@ export function isTaskReady(task: LoadedTask, allTasks: LoadedTask[]): boolean {
 }
 
 /**
- * Get ready tasks (pending + deps met + not blocked), sorted by priority
+ * Get ready tasks (pending + deps met + not blocked), sorted by priority then creation time.
+ * Within the same priority tier, older tasks come first (FIFO).
  */
 export function getReadyTasks(tasks: LoadedTask[]): LoadedTask[] {
   return tasks
     .filter(task => isTaskReady(task, tasks))
-    .sort((a, b) => a.priority - b.priority);
+    .sort((a, b) => {
+      // Primary: priority (lower number = higher priority)
+      if (a.priority !== b.priority) {
+        return a.priority - b.priority;
+      }
+      // Secondary: creation time (older first - FIFO within priority)
+      return new Date(a.created_at).getTime() - new Date(b.created_at).getTime();
+    });
 }
 
 // ============================================================

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -362,6 +362,67 @@ describe('getReadyTasks', () => {
     expect(ready[1].title).toBe('Medium priority');
     expect(ready[2].title).toBe('Low priority');
   });
+
+  // AC: @task-queries ac-query-3
+  it('should sort by creation time within same priority (oldest first)', () => {
+    const tasks: Task[] = [
+      {
+        _ulid: '01TASK100000000000000000',
+        slugs: ['newer-task'],
+        title: 'Newer task',
+        type: 'task',
+        status: 'pending',
+        blocked_by: [],
+        depends_on: [],
+        context: [],
+        priority: 2,
+        tags: [],
+        vcs_refs: [],
+        created_at: '2025-01-14T12:00:00Z', // Later
+        notes: [],
+        todos: [],
+      },
+      {
+        _ulid: '01TASK200000000000000000',
+        slugs: ['oldest-task'],
+        title: 'Oldest task',
+        type: 'task',
+        status: 'pending',
+        blocked_by: [],
+        depends_on: [],
+        context: [],
+        priority: 2,
+        tags: [],
+        vcs_refs: [],
+        created_at: '2025-01-14T10:00:00Z', // Earliest
+        notes: [],
+        todos: [],
+      },
+      {
+        _ulid: '01TASK300000000000000000',
+        slugs: ['middle-task'],
+        title: 'Middle task',
+        type: 'task',
+        status: 'pending',
+        blocked_by: [],
+        depends_on: [],
+        context: [],
+        priority: 2,
+        tags: [],
+        vcs_refs: [],
+        created_at: '2025-01-14T11:00:00Z', // Middle
+        notes: [],
+        todos: [],
+      },
+    ];
+
+    const ready = getReadyTasks(tasks);
+    expect(ready).toHaveLength(3);
+    // Within same priority, oldest first (FIFO)
+    expect(ready[0].title).toBe('Oldest task');
+    expect(ready[1].title).toBe('Middle task');
+    expect(ready[2].title).toBe('Newer task');
+  });
 });
 
 // ============================================================


### PR DESCRIPTION
## Summary
- Within the same priority tier, tasks are now ordered by creation time ascending (FIFO)
- Prevents task starvation and provides deterministic ordering
- Matches kynetic-internal approach

## Changes
- Updated `getReadyTasks()` in `src/parser/yaml.ts` to sort by priority, then `created_at`
- Added test covering AC `@task-queries ac-query-3`

## Test plan
- [x] Parser tests pass (`npm test -- tests/parser.test.ts`)
- [x] Verified ordering with `kspec tasks ready`

Task: @task-ready-secondary-sort
Spec: @task-queries

🤖 Generated with [Claude Code](https://claude.ai/code)