### PR TITLE
docs: add merge strategy note to /pr skill

### DIFF
--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -98,6 +98,14 @@ Display:
 - Branch name
 - Summary of what was included
 
+## Merge Strategy
+
+Use merge commits (not squash) to preserve kspec trailers:
+- `Task: @task-slug`
+- `Spec: @spec-ref`
+
+These enable `kspec log @ref` to find related commits. Squashing flattens commit messages and loses traceability.
+
 ## Arguments
 
 - `<branch-name>` (optional): Name for the feature branch


### PR DESCRIPTION
## Summary
- Documents why merge commits (not squash) should be used
- Preserves kspec Task/Spec trailers for `kspec log @ref` traceability

## Test plan
- [x] Read the updated skill

🤖 Generated with [Claude Code](https://claude.ai/code)