### PR TITLE
feat: implement ACP Protocol Client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "kspec": "dist/cli/index.js"
       },
       "devDependencies": {
+        "@agentclientprotocol/sdk": "^0.13.0",
         "@types/js-yaml": "^4.0.9",
         "@types/node": "^20.11.0",
         "tsx": "^4.7.0",
@@ -27,6 +28,16 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@agentclientprotocol/sdk": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-0.13.0.tgz",
+      "integrity": "sha512-Z6/Fp4cXLbYdMXr5AK752JM5qG2VKb6ShM0Ql6FimBSckMmLyK54OA20UhPYoH4C37FSFwUTARuwQOwQUToYrw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
+    "@agentclientprotocol/sdk": "^0.13.0",
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^20.11.0",
     "tsx": "^4.7.0",

--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -1,0 +1,311 @@
+/**
+ * ACP (Agent Communication Protocol) Client
+ *
+ * Manages agent lifecycle and communication over JSON-RPC 2.0 stdio.
+ * This is a simplified client focused on core operations:
+ * - Initialize agent connection
+ * - Create sessions
+ * - Send prompts and receive responses
+ * - Handle streaming updates
+ * - Cancel operations (optional)
+ */
+
+import { EventEmitter } from 'node:events';
+import type { JsonRpcFramingOptions } from './framing.js';
+import { JsonRpcFraming } from './framing.js';
+
+import type {
+  AgentCapabilities,
+  ClientCapabilities,
+  InitializeRequest,
+  InitializeResponse,
+  JsonRpcNotification,
+  NewSessionRequest,
+  NewSessionResponse,
+  PromptRequest,
+  PromptResponse,
+  SessionNotification,
+  SessionUpdate,
+} from './types.js';
+
+/**
+ * Session state tracked by the client
+ */
+export interface SessionState {
+  id: string;
+  status: 'idle' | 'prompting' | 'cancelled';
+}
+
+/**
+ * Options for ACPClient
+ */
+export interface ACPClientOptions extends JsonRpcFramingOptions {
+  /** Client capabilities to advertise */
+  capabilities?: ClientCapabilities;
+  /** Client info */
+  clientInfo?: {
+    name: string;
+    version?: string;
+  };
+}
+
+// Event types for type-safe event handling
+export interface ACPClientEvents {
+  update: (sessionId: string, update: SessionUpdate) => void;
+  close: () => void;
+  error: (error: Error) => void;
+}
+
+/**
+ * ACP Client
+ *
+ * Manages agent communication over JSON-RPC 2.0 stdio transport.
+ * Handles initialization, session lifecycle, prompts, and streaming updates.
+ *
+ * Events:
+ * - 'update': Emitted when session updates arrive (sessionId, update)
+ * - 'close': Emitted when the connection is closed
+ * - 'error': Emitted on errors
+ */
+export class ACPClient extends EventEmitter {
+  private framing: JsonRpcFraming;
+  private sessions = new Map<string, SessionState>();
+  private agentCapabilities: AgentCapabilities = {};
+  private clientCapabilities: ClientCapabilities;
+  private clientInfo?: { name: string; version?: string };
+  private initialized = false;
+
+  constructor(options: ACPClientOptions = {}) {
+    super();
+
+    // Default capabilities - we don't handle file/terminal in this simplified client
+    this.clientCapabilities = options.capabilities ?? {};
+    this.clientInfo = options.clientInfo;
+
+    // Create framing layer
+    this.framing = new JsonRpcFraming(options);
+
+    // Wire up notification handler for session updates
+    this.framing.on('notification', (notification: JsonRpcNotification) => {
+      this.handleNotification(notification);
+    });
+
+    // Forward framing events
+    this.framing.on('close', () => this.emit('close'));
+    this.framing.on('error', (err: Error) => this.emit('error', err));
+  }
+
+  /**
+   * Initialize the agent connection
+   *
+   * @returns Agent capabilities including supported features
+   * @throws If already initialized or connection fails
+   */
+  async initialize(): Promise<AgentCapabilities> {
+    if (this.initialized) {
+      throw new Error('Client already initialized');
+    }
+
+    const params: InitializeRequest = {
+      protocolVersion: 1,
+      clientCapabilities: this.clientCapabilities,
+      ...(this.clientInfo && {
+        clientInfo: {
+          name: this.clientInfo.name,
+          version: this.clientInfo.version ?? '0.0.0',
+        },
+      }),
+    };
+
+    const result = (await this.framing.sendRequest(
+      'initialize',
+      params,
+    )) as InitializeResponse;
+
+    this.agentCapabilities = result.agentCapabilities ?? {};
+    this.initialized = true;
+
+    return this.agentCapabilities;
+  }
+
+  /**
+   * Create a new session
+   *
+   * @param params Session parameters including cwd and optional metadata
+   * @returns Session ID
+   * @throws If not initialized or session creation fails
+   */
+  async newSession(params: NewSessionRequest): Promise<string> {
+    if (!this.initialized) {
+      throw new Error('Client not initialized');
+    }
+
+    const result = (await this.framing.sendRequest(
+      'session/new',
+      params,
+    )) as NewSessionResponse;
+
+    // Track session state
+    this.sessions.set(result.sessionId, {
+      id: result.sessionId,
+      status: 'idle',
+    });
+
+    return result.sessionId;
+  }
+
+  /**
+   * Send a prompt to the agent
+   *
+   * @param params Prompt request parameters including sessionId and prompt content
+   * @returns Prompt response with stopReason
+   * @throws If not initialized, session not found, or already prompting
+   */
+  async prompt(params: PromptRequest): Promise<PromptResponse> {
+    if (!this.initialized) {
+      throw new Error('Client not initialized');
+    }
+
+    const session = this.sessions.get(params.sessionId);
+    if (!session) {
+      throw new Error(`Session not found: ${params.sessionId}`);
+    }
+
+    if (session.status === 'prompting') {
+      throw new Error(`Session already prompting: ${params.sessionId}`);
+    }
+
+    // Update session state
+    session.status = 'prompting';
+
+    try {
+      const result = (await this.framing.sendRequest(
+        'session/prompt',
+        params,
+      )) as PromptResponse;
+
+      // Update session state based on stop reason
+      if (result.stopReason === 'cancelled') {
+        session.status = 'cancelled';
+      } else {
+        session.status = 'idle';
+      }
+
+      return result;
+    } catch (err) {
+      // Reset to idle on error
+      session.status = 'idle';
+      throw err;
+    }
+  }
+
+  /**
+   * Cancel an ongoing prompt
+   *
+   * Note: session/cancel is an optional ACP method. If the agent doesn't
+   * support it (returns "Method not found"), we silently ignore the error.
+   * The caller should fall back to process termination (SIGTERM) if needed.
+   *
+   * @param sessionId The session to cancel
+   * @throws If not initialized or session not found
+   */
+  async cancel(sessionId: string): Promise<void> {
+    if (!this.initialized) {
+      throw new Error('Client not initialized');
+    }
+
+    const session = this.sessions.get(sessionId);
+    if (!session) {
+      throw new Error(`Session not found: ${sessionId}`);
+    }
+
+    try {
+      // Use silentMethodNotFound since not all agents implement session/cancel
+      await this.framing.sendRequest(
+        'session/cancel',
+        { sessionId },
+        { silentMethodNotFound: true },
+      );
+
+      // Update session state
+      session.status = 'cancelled';
+    } catch (err: unknown) {
+      // Ignore "Method not found" errors - agent doesn't support cancel
+      const error = err as { code?: number };
+      if (error.code === -32601) {
+        // Agent doesn't support session/cancel, caller should use SIGTERM
+        return;
+      }
+      throw err;
+    }
+  }
+
+  /**
+   * Get session state
+   *
+   * @param sessionId The session to get
+   * @returns Session state or undefined if not found
+   */
+  getSession(sessionId: string): SessionState | undefined {
+    return this.sessions.get(sessionId);
+  }
+
+  /**
+   * Get all sessions
+   *
+   * @returns Array of all session states
+   */
+  getAllSessions(): SessionState[] {
+    return Array.from(this.sessions.values());
+  }
+
+  /**
+   * Get agent capabilities (available after initialize)
+   *
+   * @returns Agent capabilities
+   */
+  getCapabilities(): AgentCapabilities {
+    return this.agentCapabilities;
+  }
+
+  /**
+   * Check if client is initialized
+   *
+   * @returns true if initialize() has been called successfully
+   */
+  isInitialized(): boolean {
+    return this.initialized;
+  }
+
+  /**
+   * Check if the client connection is closed
+   *
+   * @returns true if the connection is closed
+   */
+  isClosed(): boolean {
+    return this.framing.isClosed();
+  }
+
+  /**
+   * Close the client connection
+   *
+   * Rejects any pending requests and cleans up resources.
+   */
+  close(): void {
+    this.framing.close();
+  }
+
+  /**
+   * Handle incoming notifications from the agent
+   */
+  private handleNotification(notification: JsonRpcNotification): void {
+    if (notification.method === 'session/update') {
+      const sessionNotification = notification.params as SessionNotification;
+      this.emit(
+        'update',
+        sessionNotification.sessionId,
+        sessionNotification.update,
+      );
+    }
+  }
+}

--- a/src/acp/framing.ts
+++ b/src/acp/framing.ts
@@ -1,0 +1,403 @@
+/**
+ * JSON-RPC 2.0 Framing Layer
+ *
+ * Handles bidirectional stdio communication with auto-incrementing IDs,
+ * request/response correlation, and timeout handling.
+ */
+
+import { EventEmitter } from 'node:events';
+import type {
+  JsonRpcError,
+  JsonRpcErrorObject,
+  JsonRpcMessage,
+  JsonRpcNotification,
+  JsonRpcRequest,
+  JsonRpcResponse,
+} from './types.js';
+import { isError, isNotification, isRequest, isResponse } from './types.js';
+
+/**
+ * Options for JsonRpcFraming
+ */
+export interface JsonRpcFramingOptions {
+  /** Default timeout for pending requests in milliseconds (default: 30000) */
+  timeout?: number;
+  /** Per-method timeout overrides in milliseconds */
+  methodTimeouts?: Record<string, number>;
+  /** Input stream (default: process.stdin) */
+  stdin?: NodeJS.ReadableStream;
+  /** Output stream (default: process.stdout) */
+  stdout?: NodeJS.WritableStream;
+}
+
+/**
+ * Options for sendRequest
+ */
+export interface SendRequestOptions {
+  /**
+   * If true, don't log "Method not found" errors.
+   * Use for optional methods that may not be supported by all agents.
+   */
+  silentMethodNotFound?: boolean;
+}
+
+/**
+ * Pending request information
+ */
+interface PendingRequest {
+  resolve: (result: unknown) => void;
+  reject: (error: Error) => void;
+  timer: NodeJS.Timeout;
+  method: string;
+  /** Timeout duration for this request (used for timer resets) */
+  timeoutMs: number;
+  /** Request ID for logging */
+  id: string | number;
+  /** Options for this request */
+  options?: SendRequestOptions;
+}
+
+/**
+ * Default timeouts for long-running methods (in milliseconds)
+ * These methods can legitimately take minutes, so they need longer timeouts.
+ */
+const DEFAULT_METHOD_TIMEOUTS: Record<string, number> = {
+  'session/prompt': 5 * 60 * 1000, // 5 minutes
+  'session/resume': 5 * 60 * 1000, // 5 minutes
+};
+
+/**
+ * JSON-RPC 2.0 Framing Layer
+ *
+ * Provides bidirectional JSON-RPC 2.0 communication over stdio with:
+ * - Auto-incrementing request IDs
+ * - Request/response correlation
+ * - Configurable timeout for pending requests (default 30s)
+ * - Per-method timeout overrides for long-running operations
+ * - Activity-based timeout reset (keepalive on incoming messages)
+ * - Event-based message handling
+ */
+export class JsonRpcFraming extends EventEmitter {
+  private nextId = 1;
+  private pending = new Map<string | number, PendingRequest>();
+  private timeout: number;
+  private methodTimeouts: Record<string, number>;
+  private stdin: NodeJS.ReadableStream;
+  private stdout: NodeJS.WritableStream;
+  private buffer = '';
+  private closed = false;
+
+  constructor(options: JsonRpcFramingOptions = {}) {
+    super();
+    this.timeout = options.timeout ?? 30000;
+    // Merge default method timeouts with user-provided overrides
+    this.methodTimeouts = {
+      ...DEFAULT_METHOD_TIMEOUTS,
+      ...options.methodTimeouts,
+    };
+    this.stdin = options.stdin ?? process.stdin;
+    this.stdout = options.stdout ?? process.stdout;
+
+    // Set up stdin to receive data
+    if ('setEncoding' in this.stdin) {
+      (this.stdin as NodeJS.ReadStream).setEncoding('utf8');
+    }
+    this.stdin.on('data', (chunk: string | Buffer) =>
+      this.handleData(chunk.toString()),
+    );
+    this.stdin.on('end', () => this.handleEnd());
+    this.stdin.on('error', (err) => this.handleError(err));
+  }
+
+  /**
+   * Send a JSON-RPC request and wait for response
+   */
+  async sendRequest(
+    method: string,
+    params?: unknown,
+    options?: SendRequestOptions,
+  ): Promise<unknown> {
+    if (this.closed) {
+      throw new Error('JsonRpcFraming is closed');
+    }
+
+    const id = this.nextId++;
+    const request: JsonRpcRequest = {
+      jsonrpc: '2.0',
+      id,
+      method,
+      ...(params !== undefined && { params }),
+    };
+
+    // Get timeout for this method (use per-method override if available)
+    const timeoutMs = this.methodTimeouts[method] ?? this.timeout;
+
+    return new Promise((resolve, reject) => {
+      // Set up timeout
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(
+          new Error(
+            `Request ${id} timed out after ${timeoutMs}ms (method: ${method})`,
+          ),
+        );
+      }, timeoutMs);
+
+      // Store pending request with timeout info for potential resets
+      this.pending.set(id, { resolve, reject, timer, method, timeoutMs, id, options });
+
+      // Send the request
+      this.send(request);
+    });
+  }
+
+  /**
+   * Send a JSON-RPC notification (no response expected)
+   */
+  sendNotification(method: string, params?: unknown): void {
+    if (this.closed) {
+      throw new Error('JsonRpcFraming is closed');
+    }
+
+    const notification: JsonRpcNotification = {
+      jsonrpc: '2.0',
+      method,
+      ...(params !== undefined && { params }),
+    };
+
+    this.send(notification);
+  }
+
+  /**
+   * Send a JSON-RPC response (in response to a request)
+   */
+  sendResponse(id: string | number, result: unknown): void {
+    if (this.closed) {
+      throw new Error('JsonRpcFraming is closed');
+    }
+
+    const response: JsonRpcResponse = {
+      jsonrpc: '2.0',
+      id,
+      result,
+    };
+
+    this.send(response);
+  }
+
+  /**
+   * Send a JSON-RPC error response
+   */
+  sendError(id: string | number | null, error: JsonRpcErrorObject): void {
+    if (this.closed) {
+      throw new Error('JsonRpcFraming is closed');
+    }
+
+    const errorResponse: JsonRpcError = {
+      jsonrpc: '2.0',
+      id,
+      error,
+    };
+
+    this.send(errorResponse);
+  }
+
+  /**
+   * Close the framing layer
+   */
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+
+    // Reject all pending requests
+    for (const [id, pending] of this.pending.entries()) {
+      clearTimeout(pending.timer);
+      pending.reject(new Error('JsonRpcFraming closed'));
+      this.pending.delete(id);
+    }
+
+    this.emit('close');
+  }
+
+  /**
+   * Check if the framing layer is closed
+   */
+  isClosed(): boolean {
+    return this.closed;
+  }
+
+  /**
+   * Reset timeout timers for all pending requests
+   *
+   * Called when activity is detected from the agent (incoming requests/responses),
+   * indicating the agent is still alive and working. This implements a keepalive
+   * mechanism that prevents timeout during long-running operations where the agent
+   * is actively making tool calls.
+   */
+  private resetPendingTimers(): void {
+    for (const pending of this.pending.values()) {
+      // Clear the old timer
+      clearTimeout(pending.timer);
+
+      // Create a new timer with the same timeout duration
+      pending.timer = setTimeout(() => {
+        this.pending.delete(pending.id);
+        pending.reject(
+          new Error(
+            `Request ${pending.id} timed out after ${pending.timeoutMs}ms (method: ${pending.method})`,
+          ),
+        );
+      }, pending.timeoutMs);
+    }
+  }
+
+  /**
+   * Send a JSON-RPC message
+   */
+  private send(message: JsonRpcMessage): void {
+    try {
+      const json = JSON.stringify(message);
+      this.stdout.write(`${json}\n`);
+    } catch (err) {
+      console.error(`Error sending message: ${err}`);
+    }
+  }
+
+  /**
+   * Handle incoming data from stdin
+   */
+  private handleData(chunk: string): void {
+    this.buffer += chunk;
+
+    // Process complete lines
+    let newlineIndex = this.buffer.indexOf('\n');
+    while (newlineIndex !== -1) {
+      const line = this.buffer.slice(0, newlineIndex);
+      this.buffer = this.buffer.slice(newlineIndex + 1);
+
+      if (line.trim()) {
+        this.processLine(line);
+      }
+      newlineIndex = this.buffer.indexOf('\n');
+    }
+  }
+
+  /**
+   * Process a complete line of input
+   */
+  private processLine(line: string): void {
+    try {
+      const message = JSON.parse(line);
+      this.handleMessage(message);
+    } catch {
+      // Malformed JSON - send parse error response
+      this.sendError(null, {
+        code: -32700,
+        message: 'Parse error',
+        data: { line },
+      });
+    }
+  }
+
+  /**
+   * Handle a parsed JSON-RPC message
+   */
+  private handleMessage(message: unknown): void {
+    if (isResponse(message)) {
+      this.handleResponse(message);
+    } else if (isError(message)) {
+      this.handleErrorResponse(message);
+    } else if (isRequest(message)) {
+      // Agent is sending us a request (e.g., tool call) - this proves it's alive
+      // Reset timeout timers for any pending requests
+      this.resetPendingTimers();
+      this.emit('request', message);
+    } else if (isNotification(message)) {
+      // Agent is sending us a notification - also proves it's alive
+      this.resetPendingTimers();
+      this.emit('notification', message);
+    } else {
+      // Invalid message
+      this.sendError(null, {
+        code: -32600,
+        message: 'Invalid Request',
+        data: message,
+      });
+    }
+  }
+
+  /**
+   * Handle a JSON-RPC response
+   */
+  private handleResponse(response: JsonRpcResponse): void {
+    const pending = this.pending.get(response.id);
+    if (pending) {
+      clearTimeout(pending.timer);
+      this.pending.delete(response.id);
+      pending.resolve(response.result);
+    } else {
+      // Unexpected response
+      console.error(
+        `Warning: Received response for unknown request ID: ${response.id}`,
+      );
+    }
+  }
+
+  /**
+   * Handle a JSON-RPC error response
+   */
+  private handleErrorResponse(error: JsonRpcError): void {
+    // JSON-RPC error code for "Method not found"
+    const METHOD_NOT_FOUND = -32601;
+
+    if (error.id === null) {
+      // Error without request ID - emit as event
+      this.emit('error', error.error);
+      return;
+    }
+
+    const pending = this.pending.get(error.id);
+    if (pending) {
+      clearTimeout(pending.timer);
+      this.pending.delete(error.id);
+
+      // Skip logging for expected "Method not found" errors on optional methods
+      const isSilentMethodNotFound =
+        pending.options?.silentMethodNotFound &&
+        error.error.code === METHOD_NOT_FOUND;
+
+      if (!isSilentMethodNotFound) {
+        console.error(
+          `JSON-RPC error: ${error.error.message} (code: ${error.error.code}, method: ${pending.method})`,
+        );
+      }
+
+      const err = Object.assign(new Error(error.error.message), {
+        code: error.error.code,
+        data: error.error.data,
+      });
+      pending.reject(err);
+    } else {
+      // Unexpected error response
+      console.error(
+        `Warning: Received error for unknown request ID: ${error.id}`,
+      );
+    }
+  }
+
+  /**
+   * Handle stdin end
+   */
+  private handleEnd(): void {
+    this.close();
+  }
+
+  /**
+   * Handle stdin error
+   */
+  private handleError(err: Error): void {
+    console.error(`Stdin error: ${err.message}`);
+    this.emit('error', err);
+    this.close();
+  }
+}

--- a/src/acp/index.ts
+++ b/src/acp/index.ts
@@ -1,0 +1,52 @@
+/**
+ * ACP (Agent Communication Protocol) Module
+ *
+ * Provides a JSON-RPC 2.0 based client for Agent Client Protocol communication.
+ * Handles bidirectional stdio communication with ACP-compliant agents.
+ */
+
+// Client
+export { ACPClient } from './client.js';
+export type { ACPClientEvents, ACPClientOptions, SessionState } from './client.js';
+
+// Framing layer
+export { JsonRpcFraming } from './framing.js';
+export type {
+  JsonRpcFramingOptions,
+  SendRequestOptions,
+} from './framing.js';
+
+// Types - JSON-RPC
+export type {
+  JsonRpcError,
+  JsonRpcErrorObject,
+  JsonRpcMessage,
+  JsonRpcNotification,
+  JsonRpcRequest,
+  JsonRpcResponse,
+} from './types.js';
+
+// Types - Type guards
+export {
+  isError,
+  isNotification,
+  isRequest,
+  isResponse,
+} from './types.js';
+
+// Types - ACP (re-exported from SDK)
+export type {
+  AgentCapabilities,
+  ClientCapabilities,
+  ContentBlock,
+  InitializeRequest,
+  InitializeResponse,
+  NewSessionRequest,
+  NewSessionResponse,
+  PromptRequest,
+  PromptResponse,
+  SessionNotification,
+  SessionUpdate,
+  StopReason,
+  TextContent,
+} from './types.js';

--- a/src/acp/types.ts
+++ b/src/acp/types.ts
@@ -1,0 +1,204 @@
+/**
+ * ACP (Agent Communication Protocol) Type Definitions
+ *
+ * This module re-exports types from the official @agentclientprotocol/sdk
+ * to ensure spec compliance. Types are imported at compile-time only
+ * (zero runtime cost since TypeScript types are erased).
+ *
+ * We keep JSON-RPC 2.0 base types and type guards local since the SDK
+ * doesn't export them in the same way we use them.
+ */
+
+// ============================================================================
+// ACP Types from Official SDK
+//
+// Import relevant types from the SDK. These are guaranteed to match the
+// official ACP specification.
+// ============================================================================
+
+export type {
+  AgentCapabilities,
+  ClientCapabilities,
+  ContentBlock,
+  InitializeRequest,
+  InitializeResponse,
+  NewSessionRequest,
+  NewSessionResponse,
+  PromptRequest,
+  PromptResponse,
+  SessionNotification,
+  SessionUpdate,
+  StopReason,
+  TextContent,
+} from '@agentclientprotocol/sdk';
+
+// ============================================================================
+// JSON-RPC 2.0 Base Types
+//
+// These are kept local because:
+// 1. The SDK's internal JSON-RPC types aren't exported the same way
+// 2. We need specific shapes for our type guards
+// 3. These are standard JSON-RPC types, not ACP-specific
+// ============================================================================
+
+/**
+ * JSON-RPC 2.0 Request
+ */
+export interface JsonRpcRequest {
+  jsonrpc: '2.0';
+  id: string | number;
+  method: string;
+  params?: unknown;
+}
+
+/**
+ * JSON-RPC 2.0 Response (success)
+ */
+export interface JsonRpcResponse {
+  jsonrpc: '2.0';
+  id: string | number;
+  result: unknown;
+}
+
+/**
+ * JSON-RPC 2.0 Error object
+ */
+export interface JsonRpcErrorObject {
+  code: number;
+  message: string;
+  data?: unknown;
+}
+
+/**
+ * JSON-RPC 2.0 Error response
+ */
+export interface JsonRpcError {
+  jsonrpc: '2.0';
+  id: string | number | null;
+  error: JsonRpcErrorObject;
+}
+
+/**
+ * JSON-RPC 2.0 Notification (no response expected)
+ */
+export interface JsonRpcNotification {
+  jsonrpc: '2.0';
+  method: string;
+  params?: unknown;
+}
+
+/**
+ * Any JSON-RPC message type
+ */
+export type JsonRpcMessage =
+  | JsonRpcRequest
+  | JsonRpcResponse
+  | JsonRpcError
+  | JsonRpcNotification;
+
+// ============================================================================
+// Validation Helpers
+//
+// Simple runtime type checks used by the JSON-RPC type guards.
+// ============================================================================
+
+/**
+ * Check if a value is a non-null object
+ */
+export function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Check if a value is a string
+ */
+export function isString(value: unknown): value is string {
+  return typeof value === 'string';
+}
+
+/**
+ * Check if a value is a number
+ */
+export function isNumber(value: unknown): value is number {
+  return typeof value === 'number' && !Number.isNaN(value);
+}
+
+/**
+ * Check if an object has a specific property with an optional specific value
+ */
+export function hasProperty<T extends string>(
+  obj: unknown,
+  key: T,
+  value?: unknown,
+): obj is Record<T, unknown> {
+  if (!isObject(obj)) return false;
+  if (!(key in obj)) return false;
+  if (value !== undefined && obj[key] !== value) return false;
+  return true;
+}
+
+// ============================================================================
+// JSON-RPC Type Guards
+//
+// Runtime type guards for validating incoming messages.
+// These work with unknown data and narrow to specific types.
+// ============================================================================
+
+/**
+ * Type guard for JSON-RPC Request
+ */
+export function isRequest(msg: unknown): msg is JsonRpcRequest {
+  return (
+    isObject(msg) &&
+    hasProperty(msg, 'jsonrpc', '2.0') &&
+    'id' in msg &&
+    (isString(msg.id) || isNumber(msg.id)) &&
+    hasProperty(msg, 'method') &&
+    isString(msg.method)
+  );
+}
+
+/**
+ * Type guard for JSON-RPC Response
+ */
+export function isResponse(msg: unknown): msg is JsonRpcResponse {
+  return (
+    isObject(msg) &&
+    hasProperty(msg, 'jsonrpc', '2.0') &&
+    'id' in msg &&
+    (isString(msg.id) || isNumber(msg.id)) &&
+    'result' in msg &&
+    !('error' in msg)
+  );
+}
+
+/**
+ * Type guard for JSON-RPC Error
+ */
+export function isError(msg: unknown): msg is JsonRpcError {
+  return (
+    isObject(msg) &&
+    hasProperty(msg, 'jsonrpc', '2.0') &&
+    'id' in msg &&
+    (msg.id === null || isString(msg.id) || isNumber(msg.id)) &&
+    hasProperty(msg, 'error') &&
+    isObject(msg.error) &&
+    hasProperty(msg.error, 'code') &&
+    isNumber(msg.error.code) &&
+    hasProperty(msg.error, 'message') &&
+    isString(msg.error.message)
+  );
+}
+
+/**
+ * Type guard for JSON-RPC Notification
+ */
+export function isNotification(msg: unknown): msg is JsonRpcNotification {
+  return (
+    isObject(msg) &&
+    hasProperty(msg, 'jsonrpc', '2.0') &&
+    !('id' in msg) &&
+    hasProperty(msg, 'method') &&
+    isString(msg.method)
+  );
+}

--- a/tests/acp.test.ts
+++ b/tests/acp.test.ts
@@ -1,0 +1,710 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { PassThrough } from 'node:stream';
+import {
+  isRequest,
+  isResponse,
+  isError,
+  isNotification,
+  JsonRpcFraming,
+  ACPClient,
+} from '../src/acp/index.js';
+
+// ============================================================================
+// Type Guards Tests
+// ============================================================================
+
+describe('JSON-RPC Type Guards', () => {
+  describe('isRequest', () => {
+    it('should identify valid requests', () => {
+      const request = {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'test',
+        params: { foo: 'bar' },
+      };
+      expect(isRequest(request)).toBe(true);
+    });
+
+    it('should identify requests with string id', () => {
+      const request = {
+        jsonrpc: '2.0',
+        id: 'abc-123',
+        method: 'test',
+      };
+      expect(isRequest(request)).toBe(true);
+    });
+
+    it('should reject requests without method', () => {
+      const request = {
+        jsonrpc: '2.0',
+        id: 1,
+      };
+      expect(isRequest(request)).toBe(false);
+    });
+
+    it('should reject requests without id', () => {
+      const notification = {
+        jsonrpc: '2.0',
+        method: 'test',
+      };
+      expect(isRequest(notification)).toBe(false);
+    });
+
+    it('should reject wrong jsonrpc version', () => {
+      const request = {
+        jsonrpc: '1.0',
+        id: 1,
+        method: 'test',
+      };
+      expect(isRequest(request)).toBe(false);
+    });
+  });
+
+  describe('isResponse', () => {
+    it('should identify valid responses', () => {
+      const response = {
+        jsonrpc: '2.0',
+        id: 1,
+        result: { data: 'test' },
+      };
+      expect(isResponse(response)).toBe(true);
+    });
+
+    it('should identify responses with null result', () => {
+      const response = {
+        jsonrpc: '2.0',
+        id: 1,
+        result: null,
+      };
+      expect(isResponse(response)).toBe(true);
+    });
+
+    it('should reject responses with error field', () => {
+      const error = {
+        jsonrpc: '2.0',
+        id: 1,
+        result: {},
+        error: { code: -1, message: 'fail' },
+      };
+      expect(isResponse(error)).toBe(false);
+    });
+  });
+
+  describe('isError', () => {
+    it('should identify valid errors', () => {
+      const error = {
+        jsonrpc: '2.0',
+        id: 1,
+        error: { code: -32600, message: 'Invalid Request' },
+      };
+      expect(isError(error)).toBe(true);
+    });
+
+    it('should identify errors with null id', () => {
+      const error = {
+        jsonrpc: '2.0',
+        id: null,
+        error: { code: -32700, message: 'Parse error' },
+      };
+      expect(isError(error)).toBe(true);
+    });
+
+    it('should identify errors with data', () => {
+      const error = {
+        jsonrpc: '2.0',
+        id: 1,
+        error: { code: -32600, message: 'Invalid Request', data: { details: 'missing field' } },
+      };
+      expect(isError(error)).toBe(true);
+    });
+
+    it('should reject errors without error object', () => {
+      const response = {
+        jsonrpc: '2.0',
+        id: 1,
+        result: null,
+      };
+      expect(isError(response)).toBe(false);
+    });
+  });
+
+  describe('isNotification', () => {
+    it('should identify valid notifications', () => {
+      const notification = {
+        jsonrpc: '2.0',
+        method: 'session/update',
+        params: { sessionId: 'abc' },
+      };
+      expect(isNotification(notification)).toBe(true);
+    });
+
+    it('should identify notifications without params', () => {
+      const notification = {
+        jsonrpc: '2.0',
+        method: 'ping',
+      };
+      expect(isNotification(notification)).toBe(true);
+    });
+
+    it('should reject notifications with id (those are requests)', () => {
+      const request = {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'test',
+      };
+      expect(isNotification(request)).toBe(false);
+    });
+  });
+});
+
+// ============================================================================
+// JsonRpcFraming Tests
+// ============================================================================
+
+describe('JsonRpcFraming', () => {
+  let stdin: PassThrough;
+  let stdout: PassThrough;
+  let framing: JsonRpcFraming;
+
+  beforeEach(() => {
+    stdin = new PassThrough();
+    stdout = new PassThrough();
+    framing = new JsonRpcFraming({
+      stdin,
+      stdout,
+      timeout: 1000, // Short timeout for tests
+    });
+  });
+
+  afterEach(() => {
+    framing.close();
+  });
+
+  it('should send requests and receive responses', async () => {
+    // Set up to capture outgoing message
+    const outgoingMessages: string[] = [];
+    stdout.on('data', (chunk: Buffer) => {
+      outgoingMessages.push(chunk.toString());
+    });
+
+    // Start the request
+    const resultPromise = framing.sendRequest('test/method', { foo: 'bar' });
+
+    // Wait for the request to be sent
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    // Verify request was sent
+    expect(outgoingMessages.length).toBe(1);
+    const sentRequest = JSON.parse(outgoingMessages[0]);
+    expect(sentRequest.jsonrpc).toBe('2.0');
+    expect(sentRequest.method).toBe('test/method');
+    expect(sentRequest.params).toEqual({ foo: 'bar' });
+    expect(sentRequest.id).toBe(1);
+
+    // Send response
+    const response = JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      result: { success: true },
+    });
+    stdin.write(response + '\n');
+
+    // Verify result
+    const result = await resultPromise;
+    expect(result).toEqual({ success: true });
+  });
+
+  it('should handle error responses', async () => {
+    // Suppress console.error for this test
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const resultPromise = framing.sendRequest('test/method');
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    // Send error response
+    const errorResponse = JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      error: { code: -32600, message: 'Invalid Request' },
+    });
+    stdin.write(errorResponse + '\n');
+
+    // Verify error is thrown
+    await expect(resultPromise).rejects.toThrow('Invalid Request');
+
+    consoleSpy.mockRestore();
+  });
+
+  it('should timeout pending requests', async () => {
+    const shortTimeoutFraming = new JsonRpcFraming({
+      stdin,
+      stdout,
+      timeout: 50, // Very short timeout
+    });
+
+    const resultPromise = shortTimeoutFraming.sendRequest('test/method');
+
+    await expect(resultPromise).rejects.toThrow(/timed out/);
+
+    shortTimeoutFraming.close();
+  });
+
+  it('should emit request events for incoming requests', async () => {
+    const requestPromise = new Promise<unknown>((resolve) => {
+      framing.on('request', resolve);
+    });
+
+    // Send incoming request
+    const request = JSON.stringify({
+      jsonrpc: '2.0',
+      id: 'agent-1',
+      method: 'fs/read_text_file',
+      params: { path: '/test.txt' },
+    });
+    stdin.write(request + '\n');
+
+    const receivedRequest = await requestPromise;
+    expect(receivedRequest).toEqual({
+      jsonrpc: '2.0',
+      id: 'agent-1',
+      method: 'fs/read_text_file',
+      params: { path: '/test.txt' },
+    });
+  });
+
+  it('should emit notification events', async () => {
+    const notificationPromise = new Promise<unknown>((resolve) => {
+      framing.on('notification', resolve);
+    });
+
+    // Send notification
+    const notification = JSON.stringify({
+      jsonrpc: '2.0',
+      method: 'session/update',
+      params: { sessionId: 'test-session', update: { type: 'progress' } },
+    });
+    stdin.write(notification + '\n');
+
+    const receivedNotification = await notificationPromise;
+    expect(receivedNotification).toEqual({
+      jsonrpc: '2.0',
+      method: 'session/update',
+      params: { sessionId: 'test-session', update: { type: 'progress' } },
+    });
+  });
+
+  // AC: @acp-client ac-9
+  it('should send parse error for malformed JSON', async () => {
+    const outgoingMessages: string[] = [];
+    stdout.on('data', (chunk: Buffer) => {
+      outgoingMessages.push(chunk.toString());
+    });
+
+    // Send malformed JSON
+    stdin.write('not valid json\n');
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    // Verify parse error was sent
+    expect(outgoingMessages.length).toBe(1);
+    const errorResponse = JSON.parse(outgoingMessages[0]);
+    expect(errorResponse.jsonrpc).toBe('2.0');
+    expect(errorResponse.id).toBe(null);
+    expect(errorResponse.error.code).toBe(-32700);
+    expect(errorResponse.error.message).toBe('Parse error');
+  });
+
+  // AC: @acp-client ac-8
+  it('should throw when closed', () => {
+    framing.close();
+
+    expect(() => framing.sendRequest('test')).rejects.toThrow('closed');
+    expect(() => framing.sendNotification('test')).toThrow('closed');
+    expect(() => framing.sendResponse(1, {})).toThrow('closed');
+  });
+
+  // AC: @acp-client ac-6
+  it('should reset pending timers on incoming activity', async () => {
+    // Create framing with short timeout
+    const shortFraming = new JsonRpcFraming({
+      stdin,
+      stdout,
+      timeout: 100,
+    });
+
+    // Start a request
+    const resultPromise = shortFraming.sendRequest('test/method');
+
+    // Wait 60ms, then send a notification (activity)
+    await new Promise((resolve) => setTimeout(resolve, 60));
+    stdin.write(JSON.stringify({ jsonrpc: '2.0', method: 'ping' }) + '\n');
+
+    // Wait another 60ms (total 120ms, would have timed out without reset)
+    await new Promise((resolve) => setTimeout(resolve, 60));
+
+    // Send the actual response
+    stdin.write(JSON.stringify({ jsonrpc: '2.0', id: 1, result: 'ok' }) + '\n');
+
+    // Should succeed because timer was reset
+    const result = await resultPromise;
+    expect(result).toBe('ok');
+
+    shortFraming.close();
+  });
+});
+
+// ============================================================================
+// ACPClient Tests
+// ============================================================================
+
+describe('ACPClient', () => {
+  let stdin: PassThrough;
+  let stdout: PassThrough;
+  let client: ACPClient;
+
+  beforeEach(() => {
+    stdin = new PassThrough();
+    stdout = new PassThrough();
+    client = new ACPClient({
+      stdin,
+      stdout,
+      timeout: 1000,
+      clientInfo: {
+        name: 'test-client',
+        version: '1.0.0',
+      },
+    });
+  });
+
+  afterEach(() => {
+    client.close();
+  });
+
+  /**
+   * Helper to respond to the next outgoing request
+   */
+  function respondToNext(result: unknown) {
+    return new Promise<void>((resolve) => {
+      stdout.once('data', (chunk: Buffer) => {
+        const request = JSON.parse(chunk.toString());
+        stdin.write(
+          JSON.stringify({
+            jsonrpc: '2.0',
+            id: request.id,
+            result,
+          }) + '\n',
+        );
+        resolve();
+      });
+    });
+  }
+
+  // AC: @acp-client ac-1
+  describe('initialize', () => {
+    it('should initialize and return agent capabilities', async () => {
+      const initPromise = client.initialize();
+
+      // Respond with capabilities
+      await respondToNext({
+        protocolVersion: 1,
+        agentCapabilities: {
+          streaming: true,
+        },
+      });
+
+      const capabilities = await initPromise;
+      expect(capabilities).toEqual({ streaming: true });
+      expect(client.isInitialized()).toBe(true);
+    });
+
+    it('should throw if already initialized', async () => {
+      const initPromise = client.initialize();
+      await respondToNext({ protocolVersion: 1, agentCapabilities: {} });
+      await initPromise;
+
+      await expect(client.initialize()).rejects.toThrow('already initialized');
+    });
+  });
+
+  // AC: @acp-client ac-2
+  describe('newSession', () => {
+    it('should create session and return sessionId', async () => {
+      // Initialize first
+      const initPromise = client.initialize();
+      await respondToNext({ protocolVersion: 1, agentCapabilities: {} });
+      await initPromise;
+
+      // Create session
+      const sessionPromise = client.newSession({
+        cwd: '/test',
+        _meta: { test: true },
+      });
+
+      await respondToNext({ sessionId: 'session-123' });
+
+      const sessionId = await sessionPromise;
+      expect(sessionId).toBe('session-123');
+
+      // Verify session is tracked
+      const session = client.getSession('session-123');
+      expect(session).toEqual({ id: 'session-123', status: 'idle' });
+    });
+
+    it('should throw if not initialized', async () => {
+      await expect(client.newSession({ cwd: '/' })).rejects.toThrow(
+        'not initialized',
+      );
+    });
+  });
+
+  // AC: @acp-client ac-3
+  describe('prompt', () => {
+    beforeEach(async () => {
+      // Initialize and create session for prompt tests
+      const initPromise = client.initialize();
+      await respondToNext({ protocolVersion: 1, agentCapabilities: {} });
+      await initPromise;
+
+      const sessionPromise = client.newSession({ cwd: '/' });
+      await respondToNext({ sessionId: 'session-123' });
+      await sessionPromise;
+    });
+
+    it('should send prompt and return response with stopReason', async () => {
+      const promptPromise = client.prompt({
+        sessionId: 'session-123',
+        prompt: [{ type: 'text', text: 'Hello' }],
+      });
+
+      await respondToNext({
+        stopReason: 'end_turn',
+      });
+
+      const response = await promptPromise;
+      expect(response.stopReason).toBe('end_turn');
+    });
+
+    it('should update session status during prompt', async () => {
+      // Capture the request without immediately responding
+      let requestId: number | string | undefined;
+      const requestReceived = new Promise<void>((resolve) => {
+        stdout.once('data', (chunk: Buffer) => {
+          const request = JSON.parse(chunk.toString());
+          requestId = request.id;
+          resolve();
+        });
+      });
+
+      const promptPromise = client.prompt({
+        sessionId: 'session-123',
+        prompt: [{ type: 'text', text: 'Hello' }],
+      });
+
+      // Wait for request to be sent
+      await requestReceived;
+
+      // NOW check status - should be prompting since we haven't responded yet
+      expect(client.getSession('session-123')?.status).toBe('prompting');
+
+      // Send response
+      stdin.write(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          id: requestId,
+          result: { stopReason: 'end_turn' },
+        }) + '\n',
+      );
+
+      await promptPromise;
+
+      // Check status is idle after
+      expect(client.getSession('session-123')?.status).toBe('idle');
+    });
+
+    it('should throw if session not found', async () => {
+      await expect(
+        client.prompt({
+          sessionId: 'nonexistent',
+          prompt: [{ type: 'text', text: 'Hello' }],
+        }),
+      ).rejects.toThrow('Session not found');
+    });
+
+    it('should throw if already prompting', async () => {
+      // Capture the first request without immediately responding
+      let requestId: number | string | undefined;
+      const requestReceived = new Promise<void>((resolve) => {
+        stdout.once('data', (chunk: Buffer) => {
+          const request = JSON.parse(chunk.toString());
+          requestId = request.id;
+          resolve();
+        });
+      });
+
+      // Start first prompt (don't await)
+      const firstPrompt = client.prompt({
+        sessionId: 'session-123',
+        prompt: [{ type: 'text', text: 'Hello' }],
+      });
+
+      // Wait for first prompt request to be sent
+      await requestReceived;
+
+      // Try second prompt - should fail because first is still prompting
+      await expect(
+        client.prompt({
+          sessionId: 'session-123',
+          prompt: [{ type: 'text', text: 'Hello again' }],
+        }),
+      ).rejects.toThrow('already prompting');
+
+      // Clean up first prompt by sending response
+      stdin.write(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          id: requestId,
+          result: { stopReason: 'end_turn' },
+        }) + '\n',
+      );
+      await firstPrompt;
+    });
+  });
+
+  // AC: @acp-client ac-4
+  describe('update events', () => {
+    beforeEach(async () => {
+      const initPromise = client.initialize();
+      await respondToNext({ protocolVersion: 1, agentCapabilities: {} });
+      await initPromise;
+
+      const sessionPromise = client.newSession({ cwd: '/' });
+      await respondToNext({ sessionId: 'session-123' });
+      await sessionPromise;
+    });
+
+    it('should emit update events for session updates', async () => {
+      const updatePromise = new Promise<{ sessionId: string; update: unknown }>(
+        (resolve) => {
+          client.on('update', (sessionId, update) => {
+            resolve({ sessionId, update });
+          });
+        },
+      );
+
+      // Send session update notification
+      stdin.write(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          method: 'session/update',
+          params: {
+            sessionId: 'session-123',
+            update: {
+              sessionUpdate: 'assistant_message_chunk',
+              content: { type: 'text', text: 'Hello!' },
+            },
+          },
+        }) + '\n',
+      );
+
+      const { sessionId, update } = await updatePromise;
+      expect(sessionId).toBe('session-123');
+      expect(update).toEqual({
+        sessionUpdate: 'assistant_message_chunk',
+        content: { type: 'text', text: 'Hello!' },
+      });
+    });
+  });
+
+  // AC: @acp-client ac-7
+  describe('cancel', () => {
+    beforeEach(async () => {
+      const initPromise = client.initialize();
+      await respondToNext({ protocolVersion: 1, agentCapabilities: {} });
+      await initPromise;
+
+      const sessionPromise = client.newSession({ cwd: '/' });
+      await respondToNext({ sessionId: 'session-123' });
+      await sessionPromise;
+    });
+
+    it('should send cancel request', async () => {
+      const cancelPromise = client.cancel('session-123');
+      await respondToNext({});
+      await cancelPromise;
+
+      expect(client.getSession('session-123')?.status).toBe('cancelled');
+    });
+
+    it('should silently handle Method not found errors', async () => {
+      // Suppress console.error for this test
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const cancelPromise = client.cancel('session-123');
+
+      // Respond with Method not found
+      stdout.once('data', (chunk: Buffer) => {
+        const request = JSON.parse(chunk.toString());
+        stdin.write(
+          JSON.stringify({
+            jsonrpc: '2.0',
+            id: request.id,
+            error: { code: -32601, message: 'Method not found' },
+          }) + '\n',
+        );
+      });
+
+      // Should not throw
+      await cancelPromise;
+
+      consoleSpy.mockRestore();
+    });
+
+    it('should throw for other errors', async () => {
+      // Suppress console.error for this test
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const cancelPromise = client.cancel('session-123');
+
+      // Respond with different error
+      stdout.once('data', (chunk: Buffer) => {
+        const request = JSON.parse(chunk.toString());
+        stdin.write(
+          JSON.stringify({
+            jsonrpc: '2.0',
+            id: request.id,
+            error: { code: -32603, message: 'Internal error' },
+          }) + '\n',
+        );
+      });
+
+      await expect(cancelPromise).rejects.toThrow('Internal error');
+
+      consoleSpy.mockRestore();
+    });
+  });
+
+  // AC: @acp-client ac-8
+  describe('close', () => {
+    it('should close and emit close event', async () => {
+      const closePromise = new Promise<void>((resolve) => {
+        client.on('close', resolve);
+      });
+
+      client.close();
+
+      await closePromise;
+      expect(client.isClosed()).toBe(true);
+    });
+
+    it('should throw on operations after close', async () => {
+      const initPromise = client.initialize();
+      await respondToNext({ protocolVersion: 1, agentCapabilities: {} });
+      await initPromise;
+
+      client.close();
+
+      await expect(client.newSession({ cwd: '/' })).rejects.toThrow('closed');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add JSON-RPC 2.0 based client for Agent Client Protocol communication
- Implement `src/acp/types.ts` with JSON-RPC types, guards, and SDK re-exports
- Implement `src/acp/framing.ts` with timeout handling and keepalive mechanism
- Implement `src/acp/client.ts` with initialize, newSession, prompt, cancel operations
- Add 37 tests covering all 9 acceptance criteria

## Test plan
- [x] All 37 ACP tests pass
- [x] All 266 existing tests still pass
- [x] Module imports successfully

Task: @task-acp-protocol-client
Spec: @acp-client

🤖 Generated with [Claude Code](https://claude.ai/code)