### PR TITLE
fix: resolve LoadedSpecItem type cast errors

### DIFF
--- a/src/cli/commands/item.ts
+++ b/src/cli/commands/item.ts
@@ -59,7 +59,7 @@ function formatItem(item: LoadedSpecItem, verbose = false, grepPattern?: string)
 
   // Show matched fields if grep pattern provided
   if (grepPattern) {
-    const match = grepItem(item as Record<string, unknown>, grepPattern);
+    const match = grepItem(item as unknown as Record<string, unknown>, grepPattern);
     if (match && match.matchedFields.length > 0) {
       line += '\n  ' + chalk.gray(`matched: ${formatMatchedFields(match.matchedFields)}`);
     }

--- a/src/cli/commands/search.ts
+++ b/src/cli/commands/search.ts
@@ -89,7 +89,7 @@ export function registerSearchCommand(program: Command): void {
             // Apply type filter
             if (options.type && item.type !== options.type) continue;
 
-            const match = grepItem(item as Record<string, unknown>, pattern);
+            const match = grepItem(item as unknown as Record<string, unknown>, pattern);
             if (match) {
               results.push({
                 type: 'item',

--- a/src/parser/items.ts
+++ b/src/parser/items.ts
@@ -239,7 +239,7 @@ export class ItemIndex {
     // Apply grep search (regex across all text content)
     if (filter.grepSearch) {
       results = results.filter(item => {
-        const match = grepItem(item as Record<string, unknown>, filter.grepSearch!);
+        const match = grepItem(item as unknown as Record<string, unknown>, filter.grepSearch!);
         return match !== null;
       });
     }


### PR DESCRIPTION
## Summary
- Fix 3 TypeScript type errors where `LoadedSpecItem` was cast to `Record<string, unknown>`
- Use double assertion pattern (`as unknown as Record<string, unknown>`)

## Test plan
- [x] `npm run typecheck` passes cleanly

🤖 Generated with [Claude Code](https://claude.ai/code)