### PR TITLE
fix: create fresh ACP session per ralph iteration

### DIFF
--- a/src/cli/commands/ralph.ts
+++ b/src/cli/commands/ralph.ts
@@ -387,14 +387,14 @@ export function registerRalphCommand(program: Command): void {
                       agent!.client.respondError(reqId, -32000, err.message);
                     });
                   });
-
-                  // Create ACP session
-                  info('Creating ACP session...');
-                  acpSessionId = await agent.client.newSession({
-                    cwd: process.cwd(),
-                    mcpServers: [], // No MCP servers for now
-                  });
                 }
+
+                // Create fresh ACP session per iteration to keep context clean
+                info('Creating ACP session...');
+                acpSessionId = await agent.client.newSession({
+                  cwd: process.cwd(),
+                  mcpServers: [], // No MCP servers for now
+                });
 
                 info('Sending prompt to agent...');
 


### PR DESCRIPTION
## Summary

- Creates a fresh ACP session at the start of each ralph iteration instead of reusing one session across all iterations
- Prevents "Prompt is too long" errors by ensuring conversation history doesn't accumulate
- Agent process is still reused for efficiency; only the session is recreated

## Context

When running `kspec ralph` with multiple iterations, the ACP session was accumulating all prompts and responses. By iteration 5, the context exceeded Claude's limit causing the error:
```
Internal error: Prompt is too long (code: -32603, method: session/prompt)
```

## Test plan

- [x] Build passes
- [x] All ralph tests pass (30 tests)
- [ ] Manual test: run `kspec ralph --max-loops 10` and verify it completes without context overflow

Spec: @cli-ralph ac-14

Generated with [Claude Code](https://claude.ai/code)