### PR TITLE
chore: CI test runner setup and task cleanup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,37 @@
+name: Tests
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Full history for proper git operations
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run typecheck
+        run: npm run typecheck
+
+      - name: Run tests
+        run: npm test
+
+      - name: Build
+        run: npm run build

--- a/src/cli/commands/meta.ts
+++ b/src/cli/commands/meta.ts
@@ -1137,7 +1137,7 @@ export function registerMetaCommands(program: Command): void {
 
           if (referencingTasks.length > 0) {
             const taskRefs = referencingTasks
-              .map((t) => `@${t.slug || t._ulid.substring(0, 8)}`)
+              .map((t) => `@${t.slugs?.[0] || t._ulid.substring(0, 8)}`)
               .join(', ');
             error(
               `Cannot delete ${itemLabel}: Referenced by ${referencingTasks.length} task(s): ${taskRefs}. Use --confirm to override.`


### PR DESCRIPTION
## Summary
- Committed CI test runner workflow file (.github/workflows/test.yml)
- Completed task @task-ci-test-runner 
- Reset task status from in_progress to completed

## Details
Found an uncommitted CI workflow file that was created in a previous session. This workflow implements the CI test runner requirement:
- Runs on PRs to main and pushes to main
- Executes typecheck, tests, and build
- Uses Node.js 18 with npm caching

The task was marked in_progress but the implementation was already done - just needed to be committed and completed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)