### PR TITLE
refactor: centralize session context strings (phase 1)

### DIFF
--- a/src/strings/guidance.ts
+++ b/src/strings/guidance.ts
@@ -1,0 +1,80 @@
+/**
+ * Guidance and instructional text shown to users and agents
+ */
+
+import chalk from 'chalk';
+
+/**
+ * Alignment check guidance (shown when adding task notes)
+ */
+export const alignmentCheck = {
+  header: chalk.gray('--- Alignment Check ---'),
+  beyondSpec: chalk.gray('Did your implementation add anything beyond the original spec?'),
+  updateSpec: (specRef: string) =>
+    chalk.gray(`If so, consider updating the spec:\n  kspec item set ${specRef} --description "Updated description"`),
+  addAC: chalk.gray('Or add acceptance criteria for new features.'),
+  testCoverage: (count: number) =>
+    chalk.gray(`Linked spec has ${count} acceptance criteria - consider test coverage.`),
+} as const;
+
+/**
+ * Commit guidance (shown after task completion)
+ */
+export const commitGuidance = {
+  header: chalk.gray('--- Suggested Commit ---'),
+  message: (msg: string) => chalk.cyan(msg),
+  trailers: (trailers: string) => chalk.gray(trailers),
+  noSpecRef: {
+    warning: chalk.yellow("This task has no spec_ref."),
+    consider: chalk.gray("Is this a spec gap? Consider: kspec item add --under @parent ..."),
+    intentional: chalk.gray("Or is this intentional (infra/cleanup)?"),
+  },
+} as const;
+
+/**
+ * Session checkpoint instructions
+ */
+export const checkpoint = {
+  intro: chalk.yellow('Before ending this session, please:'),
+
+  inProgressTasks: {
+    header: chalk.yellow('\n1. In-Progress Tasks:'),
+    action: chalk.gray('   Complete them or add a note explaining current state:'),
+    noteCommand: (ref: string) =>
+      chalk.gray(`   kspec task note ${ref} "WIP: what's done, what remains"`),
+  },
+
+  incompleteTodos: {
+    header: chalk.yellow('\n2. Incomplete Todos:'),
+    action: chalk.gray('   Complete them or convert to tasks:'),
+    command: chalk.gray('   kspec task add --title "..." --spec-ref "@..."'),
+  },
+
+  uncommittedChanges: {
+    header: chalk.yellow('\n3. Uncommitted Changes:'),
+    action: chalk.gray('   Commit your work or create a WIP commit:'),
+    wipCommit: chalk.gray(`   git add -A && git commit -m "WIP: describe state\n\n   Task: @task-ref"`),
+    wipGuidance: chalk.gray('   WIP commits are fine - they show progress and can be squashed later.'),
+  },
+
+  hints: {
+    header: chalk.gray('\nHelpful commands:'),
+    taskNote: chalk.gray('Use: kspec task note @task "Progress notes..." to document state'),
+    taskComplete: chalk.gray('Use: kspec task complete @task --reason "Summary" if task is done'),
+  },
+
+  messages: {
+    retry: (count: number) =>
+      chalk.yellow(`[kspec] Session checkpoint: ${count} issue(s) acknowledged - allowing stop`),
+    success: chalk.green('[kspec] Session checkpoint passed - ready to end session'),
+    issues: (count: number) =>
+      chalk.yellow(`[kspec] Session checkpoint: ${count} issue(s) need attention`),
+  },
+} as const;
+
+/**
+ * Session prompt check (hook message)
+ */
+export const sessionPrompt = {
+  specCheck: '[kspec] Before implementing behavior changes, check spec coverage. Update spec first if needed.',
+} as const;

--- a/src/strings/index.ts
+++ b/src/strings/index.ts
@@ -1,0 +1,11 @@
+/**
+ * Centralized strings and messages for user-facing text
+ *
+ * This module provides a single source of truth for all user-facing text,
+ * making it easier to maintain consistent tone, support i18n in the future,
+ * and review/update messaging across the entire CLI.
+ */
+
+export * from './labels.js';
+export * from './guidance.js';
+export * from './validation.js';

--- a/src/strings/labels.ts
+++ b/src/strings/labels.ts
@@ -1,0 +1,78 @@
+/**
+ * Field labels and section headers used throughout the CLI output
+ */
+
+import chalk from 'chalk';
+
+/**
+ * Session context section headers
+ */
+export const sessionHeaders = {
+  title: chalk.blue.bold('=== Session Context ==='),
+  activeWork: chalk.cyan.bold('--- Active Work ---'),
+  noActiveWork: chalk.gray('--- No Active Work ---'),
+  recentlyCompleted: chalk.green.bold('--- Recently Completed ---'),
+  recentNotes: chalk.cyan.bold('--- Recent Notes ---'),
+  incompleteTodos: chalk.yellow.bold('--- Incomplete Todos ---'),
+  readyTasks: chalk.cyan.bold('--- Ready to Pick Up ---'),
+  blocked: chalk.red.bold('--- Blocked ---'),
+  recentCommits: chalk.cyan.bold('--- Recent Commits ---'),
+  inbox: chalk.magenta.bold('--- Inbox (oldest first) ---'),
+  workingTree: chalk.yellow.bold('--- Working Tree ---'),
+  workingTreeClean: chalk.gray('--- Working Tree: Clean ---'),
+  quickCommands: chalk.gray.bold('--- Quick Commands ---'),
+} as const;
+
+/**
+ * Task/Item detail field labels
+ */
+export const fieldLabels = {
+  ulid: 'ULID:',
+  slugs: 'Slugs:',
+  type: 'Type:',
+  status: 'Status:',
+  priority: 'Priority:',
+  specRef: 'Spec ref:',
+  metaRef: 'Meta ref:',
+  depends: 'Depends:',
+  blocked: 'Blocked:',
+  tags: 'Tags:',
+  created: 'Created:',
+  started: 'Started:',
+  completed: 'Completed:',
+  implementation: 'Implementation: ',
+  description: 'Description:',
+  acceptanceCriteria: 'Acceptance Criteria:',
+  traceability: 'Traceability:',
+} as const;
+
+/**
+ * Output section separators
+ */
+export const sectionHeaders = {
+  specContext: chalk.gray('─── Spec Context ───'),
+  notes: chalk.gray('─── Notes ───'),
+  todos: chalk.gray('─── Todos ───'),
+} as const;
+
+/**
+ * Common CLI hints/suggestions
+ */
+export const hints = {
+  inboxPromote: chalk.gray('Use: kspec inbox promote <ref> to convert to task'),
+  taskNote: (ref: string) =>
+    chalk.gray(`Use: kspec task note ${ref} "<note>" to add context`),
+  taskComplete: (ref: string) =>
+    chalk.gray(`Use: kspec task complete ${ref} --reason "<summary>" when done`),
+  taskStart: (ref: string) =>
+    chalk.gray(`Use: kspec task start ${ref} to begin work`),
+  gitCommit: chalk.gray('Use: git add -A && git commit -m "..." to commit changes'),
+} as const;
+
+/**
+ * Summary/count messages
+ */
+export const summaries = {
+  noTasks: chalk.gray('No tasks found'),
+  taskCount: (count: number) => chalk.gray(`${count} task(s)`),
+} as const;

--- a/src/strings/validation.ts
+++ b/src/strings/validation.ts
@@ -1,0 +1,55 @@
+/**
+ * Validation warning and status messages
+ */
+
+import chalk from 'chalk';
+
+/**
+ * Alignment validation messages
+ */
+export const alignment = {
+  ok: chalk.green('Alignment: OK'),
+  warnings: (count: number) => chalk.yellow(`Alignment warnings: ${count}`),
+
+  orphanedSpecs: {
+    header: chalk.yellow('\nOrphaned specs (no implementation status):'),
+    item: (ref: string, title: string) => `  ${ref}: ${title}`,
+    truncated: (remaining: number) =>
+      chalk.gray(`  ... and ${remaining} more (use --verbose to see all)`),
+  },
+
+  statusMismatches: {
+    header: chalk.yellow('\nStatus mismatches (task status != spec implementation):'),
+    item: (ref: string, title: string, taskStatus: string, specImpl: string) =>
+      `  ${ref}: ${title} (task=${taskStatus}, spec=${specImpl})`,
+  },
+
+  staleImplementation: {
+    header: chalk.yellow('\nStale implementation status (task completed but spec not implemented):'),
+    item: (ref: string, title: string) => `  ${ref}: ${title}`,
+  },
+
+  noFixes: chalk.gray('No auto-fixable issues found.'),
+  fixesApplied: (count: number, files: number) =>
+    chalk.cyan(`✓ Applied ${count} fix(es) to ${files} file(s):`),
+} as const;
+
+/**
+ * Shadow branch status messages
+ */
+export const shadowBranch = {
+  header: chalk.bold('Shadow Branch Status'),
+
+  healthy: chalk.green.bold('✓ Shadow branch is healthy'),
+
+  notInitialized: {
+    status: chalk.yellow('○ Shadow branch not initialized'),
+    hint: chalk.gray('Run `kspec init` to set up shadow branch'),
+  },
+
+  hasIssues: {
+    status: chalk.red.bold('✗ Shadow branch has issues'),
+    repair: chalk.gray('Run `kspec shadow repair` to fix issues'),
+    reinitialize: chalk.gray('Or `kspec init --force` to reinitialize'),
+  },
+} as const;


### PR DESCRIPTION
## Summary

Phase 1 of centralizing user-facing prompts and guidance text. This PR extracts all hardcoded strings from `session.ts` into a centralized `src/strings/` module.

**What changed:**
- Created `src/strings/` module with structured string exports:
  - `labels.ts` - Session headers, field labels, and command hints
  - `guidance.ts` - Alignment checks, commit guidance, checkpoint instructions
  - `validation.ts` - Validation and status messages
  - `index.ts` - Central export point
- Refactored `session.ts` to use centralized strings throughout
- All session context headers, hints, and prompts now sourced from one location

**Benefits:**
- Single source of truth for user-facing text
- Easier to review/update messaging across the CLI
- Consistent tone and formatting
- Foundation for future i18n support
- Reduces duplication and makes changes safer

## Test plan

- [x] Typecheck passes
- [x] `kspec session start` output verified (headers, hints all display correctly)
- [x] No behavioral changes - only moved strings to centralized location

## Next phases

This is phase 1 of the full refactoring. Remaining work:
- Phase 2: Refactor task.ts (alignment guidance)
- Phase 3: Refactor validate.ts and shadow.ts (validation messages)
- Phase 4: Centralize error messages across command files
- Phase 5: Extract output.ts field labels

Task: @task-prompt-refactor

🤖 Generated with [Claude Code](https://claude.ai/code)