### PR TITLE
refactor: centralize task alignment guidance strings (phase 2)

### DIFF
--- a/src/cli/commands/task.ts
+++ b/src/cli/commands/task.ts
@@ -26,6 +26,7 @@ import {
 } from '../output.js';
 import { formatCommitGuidance, printCommitGuidance } from '../../utils/commit.js';
 import type { Task, TaskInput } from '../../schema/index.js';
+import { alignmentCheck } from '../../strings/index.js';
 
 /**
  * Find a task by reference with detailed error reporting.
@@ -724,11 +725,10 @@ export function registerTaskCommands(program: Command): void {
         // Proactive alignment guidance for tasks with spec_ref
         if (foundTask.spec_ref) {
           console.log('');
-          console.log('\x1b[33m--- Alignment Check ---\x1b[0m');
-          console.log('Did your implementation add anything beyond the original spec?');
-          console.log('If so, consider updating the spec:');
-          console.log(`  kspec item set ${foundTask.spec_ref} --description "Updated description"`);
-          console.log('Or add acceptance criteria for new features.');
+          console.log(alignmentCheck.header);
+          console.log(alignmentCheck.beyondSpec);
+          console.log(alignmentCheck.updateSpec(foundTask.spec_ref));
+          console.log(alignmentCheck.addAC);
 
           // Check if linked spec has acceptance criteria and remind about test coverage
           const specResult = index.resolve(foundTask.spec_ref);
@@ -736,7 +736,7 @@ export function registerTaskCommands(program: Command): void {
             const specItem = specResult.item as { acceptance_criteria?: unknown[] };
             if (specItem.acceptance_criteria && specItem.acceptance_criteria.length > 0) {
               console.log('');
-              console.log(`Linked spec has ${specItem.acceptance_criteria.length} acceptance criteria - consider test coverage.`);
+              console.log(alignmentCheck.testCoverage(specItem.acceptance_criteria.length));
             }
           }
         }


### PR DESCRIPTION
## Summary

Continues the string centralization refactor by migrating task alignment guidance from `task.ts` to the centralized `src/strings/` module.

- Replaced hardcoded ANSI color codes with `alignmentCheck` from `strings/guidance.ts`
- All 5 alignment guidance messages now use centralized versions
- Maintains existing functionality with improved maintainability

## Changes

- Added import for `alignmentCheck` from `strings` module
- Replaced manual color codes (`\x1b[33m`) with `chalk.gray()` (consistent with centralized design)
- Refactored all alignment check messages to use centralized strings:
  - `alignmentCheck.header`
  - `alignmentCheck.beyondSpec`
  - `alignmentCheck.updateSpec(specRef)`
  - `alignmentCheck.addAC`
  - `alignmentCheck.testCoverage(count)`

## Test Plan

- [x] TypeScript compilation passes
- [x] All tests pass (392 passed, 1 skipped)
- [x] Alignment guidance displays correctly for tasks with `spec_ref`

## Remaining Phases

This is phase 2 of 5 in the centralization effort:
- ✅ Phase 1: Session context headers/hints (merged in #27)
- ✅ Phase 2: Task alignment guidance (this PR)
- ⏳ Phase 3: Validation messages in validate.ts/shadow.ts
- ⏳ Phase 4: Error messages across command files
- ⏳ Phase 5: Output field labels

Task: @01KF00CW

🤖 Generated with [Claude Code](https://claude.ai/code)