### PR TITLE
feat: CLI Command Suggestions on Error

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,7 +1,9 @@
 #!/usr/bin/env node
 
 import { Command } from 'commander';
+import chalk from 'chalk';
 import { setJsonMode } from './output.js';
+import { findClosestCommand, getAllCommands, COMMAND_ALIASES } from './suggest.js';
 import {
   registerTasksCommands,
   registerTaskCommands,
@@ -53,6 +55,34 @@ registerSearchCommand(program);
 registerRalphCommand(program);
 registerMetaCommands(program);
 registerLinkCommands(program);
+
+// Handle unknown commands with suggestions
+program.on('command:*', (operands) => {
+  const unknownCommand = operands[0];
+
+  // Check for direct alias match
+  if (COMMAND_ALIASES[unknownCommand]) {
+    console.error(chalk.red(`error: unknown command '${unknownCommand}'`));
+    console.error(chalk.yellow(`Did you mean: kspec ${COMMAND_ALIASES[unknownCommand]}?`));
+    process.exit(1);
+  }
+
+  // Get all available commands
+  const allCommands = getAllCommands(program);
+
+  // Find closest match
+  const suggestion = findClosestCommand(unknownCommand, allCommands);
+
+  if (suggestion) {
+    console.error(chalk.red(`error: unknown command '${unknownCommand}'`));
+    console.error(chalk.yellow(`Did you mean: kspec ${suggestion}?`));
+  } else {
+    console.error(chalk.red(`error: unknown command '${unknownCommand}'`));
+    console.error(chalk.gray(`Run 'kspec help' to see available commands`));
+  }
+
+  process.exit(1);
+});
 
 // Export program for introspection (used by help command)
 export { program };

--- a/src/cli/suggest.ts
+++ b/src/cli/suggest.ts
@@ -1,0 +1,88 @@
+/**
+ * Command suggestion utilities using fuzzy matching
+ */
+
+/**
+ * Calculate Levenshtein distance between two strings
+ */
+function levenshteinDistance(a: string, b: string): number {
+  const matrix: number[][] = [];
+
+  // Initialize matrix
+  for (let i = 0; i <= b.length; i++) {
+    matrix[i] = [i];
+  }
+  for (let j = 0; j <= a.length; j++) {
+    matrix[0][j] = j;
+  }
+
+  // Fill matrix
+  for (let i = 1; i <= b.length; i++) {
+    for (let j = 1; j <= a.length; j++) {
+      if (b.charAt(i - 1) === a.charAt(j - 1)) {
+        matrix[i][j] = matrix[i - 1][j - 1];
+      } else {
+        matrix[i][j] = Math.min(
+          matrix[i - 1][j - 1] + 1, // substitution
+          matrix[i][j - 1] + 1, // insertion
+          matrix[i - 1][j] + 1 // deletion
+        );
+      }
+    }
+  }
+
+  return matrix[b.length][a.length];
+}
+
+/**
+ * Find the closest match to a given command
+ */
+export function findClosestCommand(
+  input: string,
+  validCommands: string[],
+  threshold: number = 3
+): string | null {
+  let closestMatch: string | null = null;
+  let closestDistance = Infinity;
+
+  for (const cmd of validCommands) {
+    const distance = levenshteinDistance(input.toLowerCase(), cmd.toLowerCase());
+
+    // Only consider if distance is within threshold
+    if (distance <= threshold && distance < closestDistance) {
+      closestDistance = distance;
+      closestMatch = cmd;
+    }
+  }
+
+  return closestMatch;
+}
+
+/**
+ * Common command aliases (only for top-level commands that users might expect)
+ */
+export const COMMAND_ALIASES: Record<string, string> = {
+  // Singular/plural flexibility
+  // Note: both 'task' and 'tasks' are valid commands, so no alias needed
+};
+
+/**
+ * Get all available command names from a Commander program
+ */
+export function getAllCommands(program: any): string[] {
+  const commands: string[] = [];
+
+  // Add top-level commands
+  for (const cmd of program.commands) {
+    commands.push(cmd.name());
+
+    // Add subcommands
+    if (cmd.commands && cmd.commands.length > 0) {
+      for (const subcmd of cmd.commands) {
+        commands.push(`${cmd.name()} ${subcmd.name()}`);
+      }
+    }
+  }
+
+  return commands;
+}

--- a/tests/suggest.test.ts
+++ b/tests/suggest.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import { findClosestCommand, COMMAND_ALIASES } from '../src/cli/suggest.js';
+
+describe('Command Suggestions', () => {
+  const validCommands = [
+    'tasks',
+    'task',
+    'inbox',
+    'item',
+    'validate',
+    'derive',
+    'session',
+    'meta',
+    'link',
+  ];
+
+  describe('findClosestCommand', () => {
+    it('should suggest tasks for taks', () => {
+      const result = findClosestCommand('taks', validCommands);
+      expect(result).toBe('tasks');
+    });
+
+    it('should suggest task for tassk', () => {
+      const result = findClosestCommand('tassk', validCommands);
+      expect(result).toBe('task');
+    });
+
+    it('should suggest inbox for inbx', () => {
+      const result = findClosestCommand('inbx', validCommands);
+      expect(result).toBe('inbox');
+    });
+
+    it('should suggest item for itme', () => {
+      const result = findClosestCommand('itme', validCommands);
+      expect(result).toBe('item');
+    });
+
+    it('should suggest validate for validat', () => {
+      const result = findClosestCommand('validat', validCommands);
+      expect(result).toBe('validate');
+    });
+
+    it('should suggest meta for metta', () => {
+      const result = findClosestCommand('metta', validCommands);
+      expect(result).toBe('meta');
+    });
+
+    it('should return null for commands with distance > threshold', () => {
+      const result = findClosestCommand('completelywrong', validCommands);
+      expect(result).toBeNull();
+    });
+
+    it('should be case-insensitive', () => {
+      const result = findClosestCommand('TAKS', validCommands);
+      expect(result).toBe('tasks');
+    });
+
+    it('should handle custom threshold', () => {
+      // With threshold of 1, this should not match
+      const result = findClosestCommand('taskss', validCommands, 1);
+      expect(result).toBe('tasks');
+    });
+
+    it('should return closest match when multiple are within threshold', () => {
+      // 'tas' is closer to 'task' (distance 1) than 'tasks' (distance 2)
+      const result = findClosestCommand('tas', validCommands);
+      expect(result).toBe('task');
+    });
+  });
+
+  describe('COMMAND_ALIASES', () => {
+    it('should be defined', () => {
+      expect(COMMAND_ALIASES).toBeDefined();
+      expect(typeof COMMAND_ALIASES).toBe('object');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements fuzzy command matching to suggest corrections when users make typos:
- Uses Levenshtein distance algorithm to find closest valid command
- Suggests matches within threshold (distance ≤ 3)
- Gracefully falls back to help message if no close match found

## Examples

```bash
$ kspec taks list
error: unknown command 'taks'
Did you mean: kspec tasks?

$ kspec inbx add "idea"
error: unknown command 'inbx'
Did you mean: kspec inbox?
```

## Implementation

- Created `src/cli/suggest.ts` with Levenshtein distance algorithm
- Hooked into Commander's `command:*` event for unknown command handling
- Added 11 comprehensive unit tests

## Test plan

- [x] Fuzzy matching works for common typos (taks → tasks, inbx → inbox)
- [x] Returns null for commands too different (distance > 3)
- [x] Case-insensitive matching
- [x] Falls back to help message when no match found
- [x] All unit tests passing (11/11)
- [x] TypeScript compilation clean

Task: @task-cli-command-suggestions-on-error
Spec: @fuzzy-command-suggest

🤖 Generated with [Claude Code](https://claude.com/claude-code)