### PR TITLE
feat: Increase session start ready task limit from 5 to 10

### DIFF
--- a/src/cli/commands/session.ts
+++ b/src/cli/commands/session.ts
@@ -325,7 +325,7 @@ export async function gatherSessionContext(
   ctx: KspecContext,
   options: SessionOptions
 ): Promise<SessionContext> {
-  const limit = parseInt(options.limit || '5', 10);
+  const limit = parseInt(options.limit || '10', 10);
   const sinceDate = options.since ? parseTimeSpec(options.since) : null;
   const showGit = options.git !== false; // default true
 
@@ -993,7 +993,7 @@ export function registerSessionCommands(program: Command): void {
     .option('--full', 'Comprehensive context dump')
     .option('--since <time>', 'Filter by recency (ISO8601 or relative: 1h, 2d, 1w)')
     .option('--no-git', 'Skip git commit information')
-    .option('-n, --limit <n>', 'Limit items per section', '5')
+    .option('-n, --limit <n>', 'Limit items per section', '10')
     .action(sessionStartAction);
 
   session
@@ -1015,6 +1015,6 @@ export function registerSessionCommands(program: Command): void {
     .option('--full', 'Comprehensive context dump')
     .option('--since <time>', 'Filter by recency (ISO8601 or relative: 1h, 2d, 1w)')
     .option('--no-git', 'Skip git commit information')
-    .option('-n, --limit <n>', 'Limit items per section', '5')
+    .option('-n, --limit <n>', 'Limit items per section', '10')
     .action(sessionStartAction);
 }


### PR DESCRIPTION
## Summary

- Increased default limit for ready tasks shown in `session start` and `context` commands from 5 to 10
- Updated three locations in `src/cli/commands/session.ts`:
  - Default value in `gatherSessionContext()` function
  - Command option default for `session start`
  - Command option default for `context` (alias)

This improves discoverability of available work without requiring manual pagination.

## Test plan

- [x] All 454 tests passing
- [x] Verified `session start` now displays 10 ready tasks by default
- [x] Confirmed `--limit` flag still works to override default

Task: @task-session-ready-limit

🤖 Generated with [Claude Code](https://claude.ai/code)