### PR TITLE
feat: Observation Promotion

### DIFF
--- a/src/cli/commands/meta.ts
+++ b/src/cli/commands/meta.ts
@@ -753,11 +753,13 @@ export function registerMetaCommands(program: Command): void {
           process.exit(1);
         }
 
-        // Create task directly using the API
+        // AC-obs-3: Create task with title, description from observation, meta_ref, and origin
         const task = createTask({
           title: options.title,
+          description: observation.content,
           priority: Number.parseInt(options.priority, 10),
           meta_ref: observation.workflow_ref,
+          origin: 'observation_promotion',
         });
 
         // Save task

--- a/src/schema/task.ts
+++ b/src/schema/task.ts
@@ -54,6 +54,9 @@ export const TaskSchema = z.object({
   // Meta relationship (links to workflow, agent, or convention for process improvement tracking)
   meta_ref: RefSchema.nullable().optional(),
 
+  // Origin tracking (where this task came from)
+  origin: z.enum(['manual', 'derived', 'observation_promotion']).optional(),
+
   // State
   status: TaskStatusSchema.default('pending'),
   blocked_by: z.array(z.string()).default([]),
@@ -104,6 +107,9 @@ export const TaskInputSchema = z.object({
 
   // Meta relationship
   meta_ref: RefSchema.nullable().optional(),
+
+  // Origin tracking
+  origin: z.enum(['manual', 'derived', 'observation_promotion']).optional(),
 
   // State
   status: TaskStatusSchema.optional(),


### PR DESCRIPTION
## Summary

- Implemented observation promotion feature (`kspec meta promote`)
- Added `origin` field to task schema to track task source
- Full acceptance criteria coverage from @observation-promotion spec

## Implementation Details

### Schema Changes
- Added `origin` enum field to TaskSchema and TaskInputSchema
- Supports values: `manual`, `derived`, `observation_promotion`

### Command Behavior
The `kspec meta promote @obs --title "Task title"` command now:
- Creates task with description from observation content (AC-3)
- Sets meta_ref from observation.workflow_ref (AC-3)
- Sets origin='observation_promotion' (AC-3)
- Updates observation.promoted_to field (AC-3)
- Validates observation not already promoted (AC-6)
- Validates observation not resolved, unless --force used (AC-8)

## Testing

Manual testing verified:
- Task creation with correct fields
- promoted_to field updated on observation
- AC-6 validation (already promoted)
- AC-8 validation (resolved observation)
- --force flag bypasses resolved check

## Files Changed
- `src/schema/task.ts` - Added origin field
- `src/cli/commands/meta.ts` - Updated promote command

🤖 Generated with [Claude Code](https://claude.com/claude-code)