### PR TITLE
Improve error messages

### DIFF
--- a/src/cli/commands/item.ts
+++ b/src/cli/commands/item.ts
@@ -1089,7 +1089,7 @@ function parseBulkInput(input: string): PatchOperation[] {
   if (trimmed.startsWith('[')) {
     const parsed = JSON.parse(trimmed);
     if (!Array.isArray(parsed)) {
-      throw new Error('Expected JSON array');
+      throw new Error(errors.validation.expectedJsonArray);
     }
     return parsed.map((item, i) => validatePatchOperation(item, i));
   }
@@ -1100,7 +1100,7 @@ function parseBulkInput(input: string): PatchOperation[] {
     try {
       return validatePatchOperation(JSON.parse(line), i);
     } catch (err) {
-      throw new Error(`Line ${i + 1}: ${err instanceof Error ? err.message : 'Invalid JSON'}`);
+      throw new Error(errors.validation.jsonLineError(i + 1, err instanceof Error ? err.message : 'Invalid JSON'));
     }
   });
 }
@@ -1110,14 +1110,14 @@ function parseBulkInput(input: string): PatchOperation[] {
  */
 function validatePatchOperation(obj: unknown, index: number): PatchOperation {
   if (!obj || typeof obj !== 'object') {
-    throw new Error(`Item ${index + 1}: Patch must be an object`);
+    throw new Error(errors.validation.patchMustBeObject(index));
   }
   const op = obj as Record<string, unknown>;
   if (typeof op.ref !== 'string' || !op.ref) {
-    throw new Error(`Item ${index + 1}: Patch must have "ref" string`);
+    throw new Error(errors.validation.patchMustHaveRef(index));
   }
   if (!op.data || typeof op.data !== 'object') {
-    throw new Error(`Item ${index + 1}: Patch must have "data" object`);
+    throw new Error(errors.validation.patchMustHaveData(index));
   }
   return { ref: op.ref, data: op.data as Record<string, unknown> };
 }

--- a/src/cli/commands/ralph.ts
+++ b/src/cli/commands/ralph.ts
@@ -433,7 +433,7 @@ export function registerRalphCommand(program: Command): void {
 
                 // Check stop reason
                 if (response.stopReason === 'cancelled') {
-                  throw new Error('Agent prompt was cancelled');
+                  throw new Error(errors.usage.agentPromptCancelled);
                 }
 
                 succeeded = true;

--- a/src/strings/errors.ts
+++ b/src/strings/errors.ts
@@ -70,6 +70,11 @@ export const validationErrors = {
   noPatchData: 'No patch data. Use --data or pipe JSON to stdin.',
   noInputProvided: 'No input provided. Use --data for single item or pipe JSONL/JSON for bulk.',
   failedToParseBulk: (err: string) => `Failed to parse bulk input${err ? `: ${err}` : ''}`,
+  expectedJsonArray: 'Expected JSON array',
+  patchMustBeObject: (index: number) => `Item ${index + 1}: Patch must be an object`,
+  patchMustHaveRef: (index: number) => `Item ${index + 1}: Patch must have "ref" string`,
+  patchMustHaveData: (index: number) => `Item ${index + 1}: Patch must have "data" object`,
+  jsonLineError: (line: number, message: string) => `Line ${line}: ${message}`,
 
   // Field validation
   unknownFields: (fields: string[]) => `Unknown field(s): ${fields.join(', ')}`,


### PR DESCRIPTION
## Summary

- Migrated remaining hardcoded error messages to centralized strings module
- Added 5 new validation error helpers in `src/strings/errors.ts`:
  - `expectedJsonArray` - for bulk patch JSON validation
  - `patchMustBeObject` - for patch operation validation
  - `patchMustHaveRef` - for patch ref field validation
  - `patchMustHaveData` - for patch data field validation
  - `jsonLineError` - for JSONL parsing errors
- Updated `src/cli/commands/item.ts` to use centralized validation errors for patch operations
- Updated `src/cli/commands/ralph.ts` to use centralized error for agent prompt cancellation

This completes the migration to centralized error messages, improving consistency and maintainability across the CLI.

## Test plan

- [x] All tests passing (463 tests)
- [x] Error messages display correctly in patch validation scenarios
- [x] Ralph agent cancellation error uses centralized message
- [x] No regressions in error handling behavior

Task: @01KF89NY

🤖 Generated with [Claude Code](https://claude.ai/code)