### PR TITLE
WIP: Context Integration

### DIFF
--- a/src/cli/commands/session.ts
+++ b/src/cli/commands/session.ts
@@ -671,6 +671,29 @@ function formatSessionContext(ctx: SessionContext, options: SessionOptions): voi
     )
   );
 
+  // Session context section (focus, threads, questions)
+  if (ctx.context && (ctx.context.focus || ctx.context.threads.length > 0 || ctx.context.open_questions.length > 0)) {
+    console.log('\n--- Session Context ---');
+
+    if (ctx.context.focus) {
+      console.log(`  ${chalk.cyan('Focus:')} ${ctx.context.focus}`);
+    }
+
+    if (ctx.context.threads.length > 0) {
+      console.log(`  ${chalk.cyan('Active Threads:')}`);
+      for (const thread of ctx.context.threads) {
+        console.log(`    - ${thread}`);
+      }
+    }
+
+    if (ctx.context.open_questions.length > 0) {
+      console.log(`  ${chalk.cyan('Open Questions:')}`);
+      for (const question of ctx.context.open_questions) {
+        console.log(`    - ${question}`);
+      }
+    }
+  }
+
   // Active tasks section
   if (ctx.active_tasks.length > 0) {
     console.log(`\n${sessionHeaders.activeWork}`);


### PR DESCRIPTION
## Summary
**This is a draft/WIP PR** - incomplete work from iteration 32.

Partial implementation of session context integration into `kspec session start` command.

## Changes So Far
- Added `loadSessionContext` import to session.ts
- Added `SessionContext` type (aliased as `StoredSessionContext`)
- Added `context` field to `SessionContext` interface

## Still Needed
- [ ] Load session context in `gatherSessionContext` function
- [ ] Display context in session output (focus, threads, open_questions)
- [ ] Format context section per spec example
- [ ] Handle empty/missing context gracefully
- [ ] Add tests for context display

## Notes
This was auto-started when completing the previous task but not finished in iteration 32. Left as draft PR for continuation in next session.

Task: @task-context-integration (in_progress)
Spec: @context-integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)