### PR TITLE
Context Integration

### DIFF
--- a/src/cli/commands/session.ts
+++ b/src/cli/commands/session.ts
@@ -18,8 +18,8 @@ import {
   type LoadedTask,
   type LoadedInboxItem,
   type KspecContext,
-  type SessionContext as StoredSessionContext,
 } from '../../parser/index.js';
+import type { SessionContext as StoredSessionContext } from '../../schema/index.js';
 import { output, error, info, isJsonMode } from '../output.js';
 import { sessionHeaders, hints, sessionPrompt, errors } from '../../strings/index.js';
 import {


### PR DESCRIPTION
## Summary

- Session context now appears in `kspec session start` output
- Displays focus, active threads, and open questions from `.kspec-session`
- JSON output includes context data as well

## Implementation

Modified `src/cli/commands/session.ts`:
1. Import `loadSessionContext` and `StoredSessionContext` type
2. Add `context` field to `SessionContext` interface
3. Load session context in `gatherSessionContext()`
4. Display context section in `formatSessionContext()`

## Test Plan

- [x] All existing session tests pass
- [x] Manual test with sample `.kspec-session` file
- [x] JSON output includes context field
- [x] Context section only shows when data exists

## Spec

Task: @task-context-integration
Spec: @context-integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)