### PR TITLE
feat: Return observation object in JSON mode for meta observe

### DIFF
--- a/src/cli/commands/meta.ts
+++ b/src/cli/commands/meta.ts
@@ -669,7 +669,11 @@ export function registerMetaCommands(program: Command): void {
         await saveObservation(ctx, observation);
 
         // AC-obs-1: outputs "OK Created observation: <ULID-prefix>"
-        success(`Created observation: ${observation._ulid.substring(0, 8)}`);
+        // In JSON mode, return the created observation object
+        output(
+          observation,
+          () => success(`Created observation: ${observation._ulid.substring(0, 8)}`)
+        );
       } catch (err) {
         error(errors.failures.createObservation, err);
         process.exit(1);


### PR DESCRIPTION
## Summary
- Enhanced `kspec meta observe` to return the full observation object when `--json` flag is used
- Previously only returned a success message in JSON mode
- Now matches spec requirement: "Options: --json: Return created observation"

## Changes
- Modified `meta observe` command to use `output()` helper instead of `success()`
- Observation object now returned in JSON mode with all fields (_ulid, type, content, etc.)
- Human-readable mode unchanged (still shows "OK Created observation: <ULID-prefix>")

## Test plan
- [x] Tested `kspec meta observe --json success "test"` returns observation object
- [x] Tested `kspec meta observe friction "test"` shows success message
- [x] All existing tests pass (500 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)