### PR TITLE
feat: Add type and workflow filters to kspec meta observations

### DIFF
--- a/src/cli/commands/meta.ts
+++ b/src/cli/commands/meta.ts
@@ -684,6 +684,8 @@ export function registerMetaCommands(program: Command): void {
   meta
     .command('observations')
     .description('List observations (shows unresolved by default)')
+    .option('--type <type>', 'Filter by observation type (friction/success/question/idea)')
+    .option('--workflow <ref>', 'Filter by workflow reference')
     .option('--all', 'Include resolved observations')
     .option('--promoted', 'Show only observations promoted to tasks')
     .option('--pending-resolution', 'Show observations with completed tasks awaiting resolution')
@@ -700,6 +702,14 @@ export function registerMetaCommands(program: Command): void {
         let observations = metaCtx.observations || [];
 
         // Apply filters
+        if (options.type) {
+          observations = observations.filter((obs) => obs.type === options.type);
+        }
+
+        if (options.workflow) {
+          observations = observations.filter((obs) => obs.workflow_ref === options.workflow);
+        }
+
         if (options.promoted) {
           observations = observations.filter((obs) => obs.promoted_to !== undefined);
         }


### PR DESCRIPTION
## Summary
- Added `--type <type>` filter to filter observations by type (friction/success/question/idea)
- Added `--workflow <ref>` filter to filter observations by workflow reference
- Both filters work in combination with existing filters (`--all`, `--promoted`, `--pending-resolution`)

## Implementation
- Added option definitions to the `observations` command
- Implemented filter logic that processes filters sequentially
- Filters are applied before any existing filters (promoted, pending-resolution)

## Test plan
- [x] All existing tests pass (499 passed)
- [x] Manual test: `kspec meta observations --type friction` shows only friction observations
- [x] Manual test: `kspec meta observations --workflow @session-start` shows only observations linked to that workflow
- [x] Manual test: `kspec meta observations --type friction --json` returns proper JSON output

Task: @task-kspec-meta-observations
Spec: @meta-observations-cmd

🤖 Generated with [Claude Code](https://claude.ai/code)