### PR TITLE
feat: Add JSON output and fix priority range for kspec meta promote

### DIFF
--- a/src/cli/commands/meta.ts
+++ b/src/cli/commands/meta.ts
@@ -759,7 +759,7 @@ export function registerMetaCommands(program: Command): void {
     .command('promote <ref>')
     .description('Promote observation to a task')
     .requiredOption('--title <title>', 'Task title')
-    .option('--priority <priority>', 'Task priority (1-3)', '2')
+    .option('--priority <priority>', 'Task priority (1-5)', '2')
     .option('--force', 'Force promotion even if observation is resolved')
     .action(async (ref: string, options) => {
       try {
@@ -813,7 +813,11 @@ export function registerMetaCommands(program: Command): void {
         await saveObservation(ctx, observation);
 
         // AC-obs-3: outputs "OK Created task: <ULID-prefix>"
-        success(`Created task: ${taskRef.substring(0, 9)}`);
+        // In JSON mode, return the created task object
+        output(
+          task,
+          () => success(`Created task: ${taskRef.substring(0, 9)}`)
+        );
       } catch (err) {
         error(errors.failures.promoteObservation, err);
         process.exit(1);


### PR DESCRIPTION
## Summary

This PR completes the implementation of `kspec meta promote` to fully align with the spec requirements:

- Fixed priority option description from "1-3" to "1-5" to match spec
- Added JSON output support - returns full task object when `--json` flag is used
- Uses `output()` helper for consistent JSON/human-readable output

## Context

The `meta promote` command was already implemented, but was missing JSON output support and had an incorrect priority range description. This PR addresses both gaps.

## Test Plan

- [x] All existing tests pass (69 tests in meta.test.ts)
- [x] Verified priority help text shows "1-5"
- [x] Tested JSON output returns complete task object
- [x] Verified observation gets `promoted_to` reference
- [x] Verified task gets `meta_ref` from observation's workflow

## Related

Task: @task-kspec-meta-promote
Spec: @meta-promote-cmd

🤖 Generated with [Claude Code](https://claude.ai/code)