### PR TITLE
docs: Clarify kspec vs npm run dev usage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,32 +6,32 @@ Read the AGENTS.md file for full project context. Key points:
 
 ## Quick Start
 
-**Note:** Use `npm run dev --` when working on kspec itself (runs TypeScript directly, no build needed). Use `kspec` for normal usage after running `npm link`.
+**Note:** Use `kspec` for all commands. Only use `npm run dev --` when testing uncommitted code changes (it runs TypeScript directly without building).
 
 ```bash
 # First: Get session context (active work, ready tasks, inbox, recent activity)
-npm run dev -- session start
+kspec session start
 
 # Get details on a specific task
-npm run dev -- task get @task-slug
+kspec task get @task-slug
 
 # When starting work
-npm run dev -- task start @task-slug
-npm run dev -- task note @task-slug "What you're doing..."
+kspec task start @task-slug
+kspec task note @task-slug "What you're doing..."
 
 # When done
-npm run dev -- task note @task-slug "What was done, how, why..."
-npm run dev -- task complete @task-slug --reason "Summary"
+kspec task note @task-slug "What was done, how, why..."
+kspec task complete @task-slug --reason "Summary"
 
 # Create a new task
-npm run dev -- task add --title "Task title" --spec-ref "@spec-item" --priority 2
+kspec task add --title "Task title" --spec-ref "@spec-item" --priority 2
 
 # Capture ideas quickly (not yet tasks)
-npm run dev -- inbox add "idea or random thought"
-npm run dev -- inbox promote @ref --title "Task title"
+kspec inbox add "idea or random thought"
+kspec inbox promote @ref --title "Task title"
 
 # Validate spec files
-npm run dev -- validate
+kspec validate
 ```
 
 ## Important
@@ -49,19 +49,19 @@ When a plan is approved, you MUST translate it to specs before implementing:
 
 ```bash
 # 1. Create spec item under appropriate parent
-npm run dev -- item add --under @parent --title "Feature Name" --type feature --slug feature-slug
+kspec item add --under @parent --title "Feature Name" --type feature --slug feature-slug
 
 # 2. Add acceptance criteria (repeat for each AC)
-npm run dev -- item ac add @feature-slug --given "precondition" --when "action" --then "expected result"
+kspec item ac add @feature-slug --given "precondition" --when "action" --then "expected result"
 
 # 3. Derive implementation task
-npm run dev -- derive @feature-slug
+kspec derive @feature-slug
 
 # 4. Add implementation notes from plan to task
-npm run dev -- task note @task-slug "Implementation approach: ..."
+kspec task note @task-slug "Implementation approach: ..."
 
 # 5. Begin implementation
-npm run dev -- task start @task-slug
+kspec task start @task-slug
 ```
 
 **Plans without specs are incomplete.** The spec with acceptance criteria IS the durable artifact - plan files may not persist across sessions. Always capture:


### PR DESCRIPTION
## Summary
- Make `kspec` the default command in all documentation examples
- Only use `npm run dev --` when testing uncommitted code changes during development
- Clarifies when each approach should be used

## Test plan
- [x] Updated note explains the distinction clearly
- [x] All examples in Quick Start use `kspec`
- [x] All examples in Plan Mode Workflow use `kspec`

Generated with [Claude Code](https://claude.ai/code)