### PR TITLE
docs: Update ralph loop instructions and built-in prompt

### DIFF
--- a/src/cli/commands/ralph.ts
+++ b/src/cli/commands/ralph.ts
@@ -60,7 +60,7 @@ ${JSON.stringify(sessionCtx, null, 2)}
 
 2. **Start the task** (if not already in_progress):
    \`\`\`bash
-   npm run dev -- task start @task-ref
+   kspec task start @task-ref
    \`\`\`
 
 3. **Do the work**:
@@ -71,17 +71,17 @@ ${JSON.stringify(sessionCtx, null, 2)}
 
 4. **Document progress**:
    \`\`\`bash
-   npm run dev -- task note @task-ref "What you did, decisions made, etc."
+   kspec task note @task-ref "What you did, decisions made, etc."
    \`\`\`
 
 5. **Complete or checkpoint**:
    - If task is DONE:
      \`\`\`bash
-     npm run dev -- task complete @task-ref --reason "Summary of completion"
+     kspec task complete @task-ref --reason "Summary of completion"
      \`\`\`
    - If task is NOT done (WIP):
      \`\`\`bash
-     npm run dev -- task note @task-ref "WIP: What's done, what remains..."
+     kspec task note @task-ref "WIP: What's done, what remains..."
      \`\`\`
 
 6. **Commit your work**:
@@ -92,10 +92,17 @@ ${JSON.stringify(sessionCtx, null, 2)}
    \`\`\`
 
 7. **Reflect on this iteration**:
-   Think about what you learned, any friction points, or observations worth remembering.
-   Add them to inbox:
+   Think about what you learned, any friction points, or patterns worth remembering.
+
+   For **systemic patterns** (friction or success worth documenting):
    \`\`\`bash
-   npm run dev -- inbox add "Observation: ..."
+   kspec meta observe friction "Description of systemic issue..."
+   kspec meta observe success "Pattern worth replicating..."
+   \`\`\`
+
+   For **actionable improvements** (specific ideas that could become tasks):
+   \`\`\`bash
+   kspec inbox add "Improvement idea..." --tag reflection
    \`\`\`
 
 ## Important Notes
@@ -103,13 +110,13 @@ ${JSON.stringify(sessionCtx, null, 2)}
 - The loop continues automatically - don't worry about picking the next task
 - kspec tracks state across iterations via task status and notes
 - Always commit before the iteration ends
-- Always reflect and add at least one observation to inbox
+- Always reflect and capture at least one observation
 ${isFinal ? `
 ## FINAL ITERATION
 This is the last iteration of the loop. After completing your work:
 1. Commit any remaining changes
 2. Reflect on the overall session
-3. Add any final insights to inbox
+3. Capture any final insights as observations
 ` : ''}`;
 }
 


### PR DESCRIPTION
## Summary
- Update RALPH_LOOP_INSTRUCTIONS.md to align with recent documentation changes
- Update ralph.ts built-in prompt to use kspec commands and meta observations
- Remove obsolete reference directories section
- Simplify reflect guidance (defer details to /reflect skill)

## Changes

**RALPH_LOOP_INSTRUCTIONS.md:**
- Add `kspec session start` as first step
- Replace non-existent `/review` skill with explicit gh commands
- Add merge strategy note (use `--merge` to preserve trailers)
- Simplify reflect guidance (defer to `/reflect` skill)
- Add session context section for `/meta` usage
- Add available skills table matching AGENTS.md
- Remove obsolete reference directories section

**src/cli/commands/ralph.ts:**
- Use `kspec` CLI directly instead of `npm run dev`
- Use `kspec meta observe` for reflections (systemic patterns)
- Add `kspec inbox add` for actionable improvements
- Distinguish patterns vs actionable items in guidance

## Test plan
- [x] Build succeeds
- [x] Changes are documentation/prompt only

Generated with [Claude Code](https://claude.ai/code)