### PR TITLE
Fix ralph iteration message newline issue

### DIFF
--- a/src/cli/commands/ralph.ts
+++ b/src/cli/commands/ralph.ts
@@ -459,9 +459,9 @@ export function registerRalphCommand(program: Command): void {
             }
 
             if (succeeded) {
+              console.log(); // Newline after streaming output
               success(`Completed iteration ${iteration}`);
               consecutiveFailures = 0;
-              console.log(); // Newline after streaming output
             } else {
               consecutiveFailures++;
               error(errors.failures.iterationFailedAfterRetries(iteration, maxRetries, consecutiveFailures, maxFailures));


### PR DESCRIPTION
## Summary

- Fixed ralph iteration status messages appearing on the same line as streaming output
- Moved newline output before the success message to ensure proper separation

## Changes

The "Completed iteration N" message was appearing directly after the last character of streaming agent output because the newline was printed after the message instead of before it. This fix ensures clean visual separation between streaming content and iteration status.

**Before:** `...agent text hereOK Completed iteration 1`  
**After:** 
```
...agent text here
OK Completed iteration 1
```

## Test Plan

- [x] All 30 ralph tests pass
- [x] TypeScript build succeeds
- [x] Single-line change maintains existing behavior while fixing display issue

Task: @01KF9B4P

🤖 Generated with [Claude Code](https://claude.ai/code)