### PR TITLE
Fix spec status persistence on task state changes

### DIFF
--- a/src/cli/commands/task.ts
+++ b/src/cli/commands/task.ts
@@ -469,6 +469,8 @@ export function registerTaskCommands(program: Command): void {
           );
           if (syncResult) {
             info(`Synced spec "${syncResult.specTitle}" implementation: ${syncResult.previousStatus} -> ${syncResult.newStatus}`);
+            // Commit the spec status change
+            await commitIfShadow(ctx.shadow, 'spec-sync', syncResult.specUlid.slice(0, 8), `${syncResult.previousStatus} -> ${syncResult.newStatus}`);
           }
         }
       } catch (err) {
@@ -538,6 +540,8 @@ export function registerTaskCommands(program: Command): void {
           );
           if (syncResult) {
             info(`Synced spec "${syncResult.specTitle}" implementation: ${syncResult.previousStatus} -> ${syncResult.newStatus}`);
+            // Commit the spec status change
+            await commitIfShadow(ctx.shadow, 'spec-sync', syncResult.specUlid.slice(0, 8), `${syncResult.previousStatus} -> ${syncResult.newStatus}`);
           }
         }
 


### PR DESCRIPTION
## Summary

- Spec implementation status changes are now committed immediately to the shadow branch after task state changes
- Fixes persistence gap where spec status updates from `kspec task start` or `kspec task complete` were written to YAML but not committed
- Status changes are now captured in the commit stream with message format: `spec-sync @<ulid-prefix> <status-change>`

## Test plan

- [x] All 561 existing tests pass
- [x] Spec status changes committed after `task start`
- [x] Spec status changes committed after `task complete`
- [x] Changes only occur when sync succeeds (syncResult is not null)

Task: @01KF9B44

🤖 Generated with [Claude Code](https://claude.ai/code)