### PR TITLE
Add git hook for kspec-meta branch protection

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,0 +1,34 @@
+#!/bin/sh
+#
+# kspec-meta branch protection hook
+#
+# This hook prevents direct commits to the kspec-meta shadow branch.
+# All modifications to spec/task files should go through the kspec CLI,
+# which will set KSPEC_SHADOW_COMMIT=1 to authorize commits.
+#
+# Installation: This hook is automatically installed during 'kspec init'
+# into .git/hooks/pre-commit
+
+# Get current branch name
+BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+
+# Check if we're on kspec-meta branch
+if [ "$BRANCH" = "kspec-meta" ]; then
+  # Allow if KSPEC_SHADOW_COMMIT is set (authorized by CLI)
+  if [ "$KSPEC_SHADOW_COMMIT" != "1" ]; then
+    echo "ERROR: Direct commits to kspec-meta branch are not allowed."
+    echo ""
+    echo "The kspec-meta branch is managed by the kspec CLI."
+    echo "Use kspec commands to modify specs and tasks:"
+    echo ""
+    echo "  kspec task start @ref"
+    echo "  kspec task note @ref \"description\""
+    echo "  kspec task complete @ref --reason \"done\""
+    echo "  kspec item add --title \"New item\""
+    echo ""
+    echo "All kspec operations automatically commit to the shadow branch."
+    exit 1
+  fi
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

Implements a pre-commit hook that protects the kspec-meta shadow branch from direct commits. This safety feature ensures all modifications to spec/task files go through the kspec CLI, which automatically commits changes.

- **Hook script** (`hooks/pre-commit`): Checks branch name and KSPEC_SHADOW_COMMIT env var
- **shadowAutoCommit enhancement**: Sets KSPEC_SHADOW_COMMIT=1 to authorize CLI commits
- **installShadowHook function**: Installs hook to `.git/hooks/` during init and repair
- **Tested**: Blocks unauthorized commits ✓, allows kspec CLI commits ✓, allows main branch commits ✓

## Key Discovery

Git worktrees use hooks from the main `.git/hooks/` directory (via `commondir`), not from `.git/worktrees/-kspec/hooks/`. This is documented in the code comments.

## Test plan

- [x] Hook blocks direct commits to kspec-meta when KSPEC_SHADOW_COMMIT is not set
- [x] Hook allows commits when KSPEC_SHADOW_COMMIT=1 (kspec CLI)
- [x] Hook allows commits on other branches (main, feature branches)
- [x] Hook installs automatically during kspec init
- [x] Hook installs during kspec shadow repair

Task: @01KF9Q39

🤖 Generated with [Claude Code](https://claude.ai/claude-code)