### PR TITLE
fix: Use actual package name in adapter validation error message

### DIFF
--- a/src/agents/adapters.ts
+++ b/src/agents/adapters.ts
@@ -82,18 +82,26 @@ export function registerAdapter(id: string, adapter: AgentAdapter): void {
 /**
  * Resolve adapter by ID or use default.
  *
- * @param id - Optional adapter ID
+ * If the ID matches a registered adapter, returns that adapter.
+ * If not, treats the ID as an npm package name and creates an ad-hoc npx adapter.
+ * This allows users to use any ACP-compatible package without registering it.
+ *
+ * @param id - Optional adapter ID or npm package name
  * @returns Adapter definition
- * @throws If adapter not found
  */
 export function resolveAdapter(id?: string): AgentAdapter {
   const adapterId = id ?? 'claude-code-acp';
   const adapter = getAdapter(adapterId);
 
-  if (!adapter) {
-    const available = listAdapters().join(', ');
-    throw new Error(`Unknown adapter: ${adapterId}. Available: ${available}`);
+  if (adapter) {
+    return adapter;
   }
 
-  return adapter;
+  // Treat unknown IDs as npm package names - create ad-hoc npx adapter
+  return {
+    command: 'npx',
+    args: [adapterId],
+    shell: process.platform === 'win32',
+    description: `Ad-hoc adapter for ${adapterId}`,
+  };
 }

--- a/src/cli/commands/ralph.ts
+++ b/src/cli/commands/ralph.ts
@@ -302,14 +302,14 @@ export function registerRalphCommand(program: Command): void {
           options.adapter = 'custom';
         }
 
-        // Validate adapter exists before proceeding
-        // Skip validation for custom adapters (--adapter-cmd)
-        if (!options.adapterCmd) {
-          validateAdapter(options.adapter);
-        }
-
         // Resolve adapter
         const adapter = resolveAdapter(options.adapter);
+
+        // Validate adapter package exists before proceeding
+        // Skip validation for custom adapters (--adapter-cmd) and non-npx adapters
+        if (!options.adapterCmd && adapter.command === 'npx' && adapter.args[0]) {
+          validateAdapter(adapter.args[0]);
+        }
 
         // Add yolo flag to adapter args if needed
         if (options.yolo && options.adapter === 'claude-code-acp') {


### PR DESCRIPTION
## Summary

- Fix adapter validation to use the actual npm package name (`@zed-industries/claude-code-acp`) instead of the adapter ID (`claude-code-acp`) in error messages
- Resolve adapter before validation to extract package from `adapter.args[0]`
- Update `resolveAdapter()` to create ad-hoc npx adapters for unknown IDs, treating them as package names for flexibility

**Before:** `npm install -g claude-code-acp` (not a real package)
**After:** `npm install -g @zed-industries/claude-code-acp` (correct)

## Test plan

- [x] All 624 existing tests pass
- [x] Adapter validation tests still pass with the new behavior
- [x] Unknown adapter IDs now work as ad-hoc npx packages

Task: @01KFCNB6
Spec: @ralph-adapter-validation

Generated with [Claude Code](https://claude.ai/code)