### PR TITLE
Fix 6 incorrect exit codes from PR #87 review

### DIFF
--- a/src/cli/batch.ts
+++ b/src/cli/batch.ts
@@ -74,7 +74,7 @@ export async function executeBatchOperation<TItem, TContext>(
   // AC: @multi-ref-batch ac-3 - Mutual exclusion check
   if (positionalRef && refsFlag && refsFlag.length > 0) {
     error('Cannot use both positional ref and --refs flag');
-    process.exit(EXIT_CODES.NOT_FOUND);
+    process.exit(EXIT_CODES.USAGE_ERROR);
   }
 
   // Determine which refs to process
@@ -86,7 +86,7 @@ export async function executeBatchOperation<TItem, TContext>(
   } else {
     // AC: @multi-ref-batch ac-7 - Empty refs error
     error('--refs requires at least one reference');
-    process.exit(EXIT_CODES.NOT_FOUND);
+    process.exit(EXIT_CODES.USAGE_ERROR);
   }
 
   // Process each ref
@@ -211,7 +211,7 @@ export function formatBatchOutput(result: BatchResult, operationName: string): v
   if (!result.success) {
     if (result.summary.succeeded > 0) {
       // Partial failure
-      process.exit(EXIT_CODES.USAGE_ERROR);
+      process.exit(EXIT_CODES.ERROR);
     } else {
       // Complete failure
       process.exit(EXIT_CODES.ERROR);

--- a/src/cli/commands/task.ts
+++ b/src/cli/commands/task.ts
@@ -315,7 +315,7 @@ export function registerTaskCommands(program: Command): void {
           const priority = parseInt(options.priority, 10);
           if (isNaN(priority) || priority < 1 || priority > 5) {
             error(errors.validation.priorityOutOfRange);
-            process.exit(EXIT_CODES.NOT_FOUND);
+            process.exit(EXIT_CODES.VALIDATION_FAILED);
           }
           updatedTask.priority = priority;
           changes.push('priority');
@@ -850,7 +850,7 @@ export function registerTaskCommands(program: Command): void {
         // For batch mode (--refs), require --force
         if (options.refs && options.refs.length > 0 && !options.force && !options.dryRun) {
           error('Batch delete requires --force flag');
-          process.exit(EXIT_CODES.NOT_FOUND);
+          process.exit(EXIT_CODES.USAGE_ERROR);
         }
 
         const result = await executeBatchOperation({
@@ -1270,7 +1270,7 @@ export function registerTaskCommands(program: Command): void {
         const id = parseInt(idStr, 10);
         if (isNaN(id)) {
           error(errors.todo.invalidId(idStr));
-          process.exit(EXIT_CODES.NOT_FOUND);
+          process.exit(EXIT_CODES.USAGE_ERROR);
         }
 
         const todoIndex = foundTask.todos.findIndex(t => t.id === id);
@@ -1320,7 +1320,7 @@ export function registerTaskCommands(program: Command): void {
         const id = parseInt(idStr, 10);
         if (isNaN(id)) {
           error(errors.todo.invalidId(idStr));
-          process.exit(EXIT_CODES.NOT_FOUND);
+          process.exit(EXIT_CODES.USAGE_ERROR);
         }
 
         const todoIndex = foundTask.todos.findIndex(t => t.id === id);


### PR DESCRIPTION
## Summary

- Fixed 6 incorrect exit code usages identified in PR #87 review
- Changes ensure scripts/automation integrating with kspec receive semantically correct exit codes
- All tests passing (624 passed, 1 skipped)

## Changes

1. **batch.ts:77** - Mutual exclusion error: `NOT_FOUND` → `USAGE_ERROR`
   - Using both positional ref and --refs flag is a usage error, not "not found"

2. **batch.ts:89** - Missing required arg: `NOT_FOUND` → `USAGE_ERROR`
   - Empty --refs flag is a usage error, not "not found"

3. **batch.ts:214** - Partial batch failure: `USAGE_ERROR` → `ERROR`
   - Partial failures during batch operations should be ERROR, not usage error

4. **task.ts:318** - Priority range validation: `NOT_FOUND` → `VALIDATION_FAILED`
   - Invalid priority value (out of 1-5 range) is a validation failure, not "not found"

5. **task.ts:853** - Missing required flag: `NOT_FOUND` → `USAGE_ERROR`
   - Batch delete without --force flag is a usage error, not "not found"

6. **task.ts:1273,1323** - Invalid number format: `NOT_FOUND` → `USAGE_ERROR` (2 locations)
   - Invalid todo ID format is a usage error, not "not found"

## Exit Code Semantics

- **USAGE_ERROR (2)**: Invalid arguments, flags, or command syntax
- **VALIDATION_FAILED (4)**: Invalid state, schema violation, or business rule violation
- **ERROR (1)**: General error or partial failure
- **NOT_FOUND (3)**: Resource doesn't exist (kept where appropriate - e.g., todo not found after valid ID parse)

## Test Plan

- [x] All existing tests pass (624 passed, 1 skipped)
- [x] Build completes without errors
- [x] Exit codes align with documented semantics in exit-codes.ts

Task: @fix-exit-codes-pr87

🤖 Generated with [Claude Code](https://claude.ai/code)