### PR TITLE
Implement trait type completeness validation

### DIFF
--- a/src/parser/validate.ts
+++ b/src/parser/validate.ts
@@ -570,26 +570,29 @@ async function checkCompleteness(
 
   for (const item of items) {
     const itemRef = item.slugs?.[0] ? `@${item.slugs[0]}` : `@${item._ulid.slice(0, 8)}`;
+    const isTrait = item.type === 'trait';
 
     // AC: @spec-completeness ac-1
+    // AC: @trait-type ac-2 - Traits should have acceptance criteria for completeness
     // Check for missing acceptance criteria
     if (!item.acceptance_criteria || item.acceptance_criteria.length === 0) {
       warnings.push({
         type: 'missing_acceptance_criteria',
         itemRef,
         itemTitle: item.title,
-        message: `Item ${itemRef} has no acceptance criteria`,
+        message: `${isTrait ? 'Trait' : 'Item'} ${itemRef} has no acceptance criteria`,
       });
     }
 
     // AC: @spec-completeness ac-2
+    // AC: @trait-type ac-3 - Traits should have description for completeness
     // Check for missing description
     if (!item.description || item.description.trim() === '') {
       warnings.push({
         type: 'missing_description',
         itemRef,
         itemTitle: item.title,
-        message: `Item ${itemRef} has no description`,
+        message: `${isTrait ? 'Trait' : 'Item'} ${itemRef} has no description`,
       });
     }
 

--- a/tests/trait-validation.test.ts
+++ b/tests/trait-validation.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Tests for trait type validation
+ * AC: @trait-type ac-2, ac-3
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { validate } from '../src/parser/validate.js';
+import { initContext } from '../src/parser/yaml.js';
+import { writeYamlFilePreserveFormat } from '../src/parser/yaml.js';
+
+describe('Trait validation', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'kspec-test-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  // AC: @trait-type ac-2
+  it('should warn when trait item is missing acceptance criteria', async () => {
+    // Setup minimal kspec structure (use spec/ not .kspec/ for simplicity)
+    const specDir = path.join(tempDir, 'spec');
+    const modulesDir = path.join(specDir, 'modules');
+    await fs.mkdir(modulesDir, { recursive: true });
+
+    // Create manifest
+    const manifest = {
+      project: {
+        name: 'test-project',
+      },
+      includes: ['modules/traits.yaml'],
+    };
+    await writeYamlFilePreserveFormat(path.join(specDir, 'kynetic.yaml'), manifest);
+
+    // Create trait without acceptance criteria
+    const trait = {
+      _ulid: '01KFCRVY8ERZEE2MNHEQXSG90T',
+      slugs: ['test-trait'],
+      title: 'Test Trait',
+      type: 'trait',
+      description: 'A test trait with no AC',
+      status: { maturity: 'draft', implementation: 'not_started' },
+    };
+    await writeYamlFilePreserveFormat(path.join(modulesDir, 'traits.yaml'), trait);
+
+    // Run validation
+    const ctx = await initContext(tempDir);
+    const result = await validate(ctx, { completeness: true });
+
+    // Verify warning
+    const acWarnings = result.completenessWarnings.filter(
+      w => w.type === 'missing_acceptance_criteria' && w.itemRef.includes('test-trait')
+    );
+    expect(acWarnings).toHaveLength(1);
+    expect(acWarnings[0].message).toContain('Trait');
+    expect(acWarnings[0].message).toContain('has no acceptance criteria');
+  });
+
+  // AC: @trait-type ac-3
+  it('should warn when trait item is missing description', async () => {
+    // Setup minimal kspec structure
+    const specDir = path.join(tempDir, 'spec');
+    const modulesDir = path.join(specDir, 'modules');
+    await fs.mkdir(modulesDir, { recursive: true });
+
+    // Create manifest
+    const manifest = {
+      project: {
+        name: 'test-project',
+      },
+      includes: ['modules/traits.yaml'],
+    };
+    await writeYamlFilePreserveFormat(path.join(specDir, 'kynetic.yaml'), manifest);
+
+    // Create trait without description
+    const trait = {
+      _ulid: '01KFCRVY8MT49H8N6JW35NN2P3',
+      slugs: ['test-trait-no-desc'],
+      title: 'Test Trait No Description',
+      type: 'trait',
+      status: { maturity: 'draft', implementation: 'not_started' },
+      acceptance_criteria: [
+        {
+          id: 'ac-1',
+          given: 'test condition',
+          when: 'test action',
+          then: 'test result',
+        },
+      ],
+    };
+    await writeYamlFilePreserveFormat(path.join(modulesDir, 'traits.yaml'), trait);
+
+    // Run validation
+    const ctx = await initContext(tempDir);
+    const result = await validate(ctx, { completeness: true });
+
+    // Verify warning
+    const descWarnings = result.completenessWarnings.filter(
+      w => w.type === 'missing_description' && w.itemRef.includes('test-trait-no-desc')
+    );
+    expect(descWarnings).toHaveLength(1);
+    expect(descWarnings[0].message).toContain('Trait');
+    expect(descWarnings[0].message).toContain('has no description');
+  });
+
+  // AC: @trait-type ac-2 and ac-3 combined
+  it('should emit both warnings when trait is missing AC and description', async () => {
+    // Setup minimal kspec structure
+    const specDir = path.join(tempDir, 'spec');
+    const modulesDir = path.join(specDir, 'modules');
+    await fs.mkdir(modulesDir, { recursive: true });
+
+    // Create manifest
+    const manifest = {
+      project: {
+        name: 'test-project',
+      },
+      includes: ['modules/traits.yaml'],
+    };
+    await writeYamlFilePreserveFormat(path.join(specDir, 'kynetic.yaml'), manifest);
+
+    // Create incomplete trait
+    const trait = {
+      _ulid: '01KFCRVY8NPV114TGJJ5FHB4G8',
+      slugs: ['incomplete-trait'],
+      title: 'Incomplete Trait',
+      type: 'trait',
+      status: { maturity: 'draft', implementation: 'not_started' },
+    };
+    await writeYamlFilePreserveFormat(path.join(modulesDir, 'traits.yaml'), trait);
+
+    // Run validation
+    const ctx = await initContext(tempDir);
+    const result = await validate(ctx, { completeness: true });
+
+    // Verify both warnings
+    const traitWarnings = result.completenessWarnings.filter(
+      w => w.itemRef.includes('incomplete-trait')
+    );
+    expect(traitWarnings.length).toBeGreaterThanOrEqual(2);
+
+    const hasAcWarning = traitWarnings.some(
+      w => w.type === 'missing_acceptance_criteria' && w.message.includes('Trait')
+    );
+    const hasDescWarning = traitWarnings.some(
+      w => w.type === 'missing_description' && w.message.includes('Trait')
+    );
+
+    expect(hasAcWarning).toBe(true);
+    expect(hasDescWarning).toBe(true);
+  });
+
+  it('should not warn when trait has both AC and description', async () => {
+    // Setup minimal kspec structure
+    const specDir = path.join(tempDir, 'spec');
+    const modulesDir = path.join(specDir, 'modules');
+    await fs.mkdir(modulesDir, { recursive: true });
+
+    // Create manifest
+    const manifest = {
+      project: {
+        name: 'test-project',
+      },
+      includes: ['modules/traits.yaml'],
+    };
+    await writeYamlFilePreserveFormat(path.join(specDir, 'kynetic.yaml'), manifest);
+
+    // Create complete trait
+    const trait = {
+      _ulid: '01KFCRVY8NH1TKTRKV65KS79ED',
+      slugs: ['complete-trait'],
+      title: 'Complete Trait',
+      type: 'trait',
+      description: 'A complete trait with both AC and description',
+      status: { maturity: 'draft', implementation: 'not_started' },
+      acceptance_criteria: [
+        {
+          id: 'ac-1',
+          given: 'test condition',
+          when: 'test action',
+          then: 'test result',
+        },
+      ],
+    };
+    await writeYamlFilePreserveFormat(path.join(modulesDir, 'traits.yaml'), trait);
+
+    // Run validation
+    const ctx = await initContext(tempDir);
+    const result = await validate(ctx, { completeness: true });
+
+    // Verify no missing AC or description warnings for this trait
+    // (May still have test coverage warning, which is okay)
+    const traitWarnings = result.completenessWarnings.filter(
+      w => w.itemRef.includes('complete-trait') &&
+           (w.type === 'missing_acceptance_criteria' || w.type === 'missing_description')
+    );
+    expect(traitWarnings).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

Implements completeness validation for trait items as specified in @trait-type:
- Traits missing acceptance criteria emit completeness warnings
- Traits missing descriptions emit completeness warnings  
- Warnings use "Trait" prefix to distinguish from general item warnings

## Implementation

- Modified `checkCompleteness()` in `src/parser/validate.ts` to detect trait items
- Added AC annotations linking validation code to spec requirements
- Created comprehensive test suite in `tests/trait-validation.test.ts`

## Test Coverage

All acceptance criteria validated:
- ✓ AC-2: Trait missing acceptance_criteria emits warning
- ✓ AC-3: Trait missing description emits warning
- ✓ Combined: Both warnings when trait is incomplete
- ✓ No warnings when trait has both AC and description

All 634 tests passing.

## Test Plan

- [x] Run full test suite: `npm test`
- [x] Verify trait validation warnings appear for incomplete traits
- [x] Confirm existing validation behavior unchanged
- [ ] Code review

Task: @task-trait-type
Spec: @trait-type

🤖 Generated with [Claude Code](https://claude.ai/claude-code)