### PR TITLE
fix: Detect and error when running kspec from inside .kspec/ directory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,6 +140,28 @@ git branch --set-upstream-to=origin/kspec-meta kspec-meta
 | Shadow branch exists but no worktree | Run `kspec shadow repair` |
 | Sync conflicts | Run `kspec shadow resolve` (manual resolution) |
 | `.kspec/` not gitignored | `kspec init` adds it automatically |
+| Running kspec from .kspec/ | Run from project root: `cd ..` |
+| kspec commands seem broken | First check `pwd` - ensure you're at project root, not inside .kspec/ |
+
+### Important: Always Run from Project Root
+
+kspec commands must be run from the project root, not from inside `.kspec/`:
+
+```bash
+# Correct
+kspec task list
+
+# Incorrect - will error
+cd .kspec && kspec task list
+```
+
+**Common agent pitfall:** Agents sometimes forget they changed their working directory during a session (e.g., to inspect files in `.kspec/`). Before running kspec commands:
+
+1. Check your current directory: `pwd`
+2. If you're inside `.kspec/`, return to project root: `cd ..`
+3. Then run the kspec command
+
+If you see the error "Cannot run kspec from inside .kspec/ directory", this is the cause.
 
 ### Integration with Main Branch
 

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -71,6 +71,13 @@ export function error(message: string, details?: unknown): void {
     console.error(chalk.red('✗'), message);
     if (details) {
       console.error(chalk.gray(String(details)));
+      // Show suggestion if it's a ShadowError with a suggestion
+      if (details && typeof details === 'object' && 'suggestion' in details) {
+        const suggestion = (details as { suggestion?: string }).suggestion;
+        if (suggestion) {
+          console.error(chalk.yellow('  Suggestion:'), suggestion);
+        }
+      }
     }
   }
 }

--- a/src/parser/yaml.ts
+++ b/src/parser/yaml.ts
@@ -30,10 +30,13 @@ import { TraitIndex } from './traits.js';
 import {
   type ShadowConfig,
   detectShadow,
+  detectRunningFromShadowWorktree,
   shadowAutoCommit,
   generateCommitMessage,
   SHADOW_WORKTREE_DIR,
+  ShadowError,
 } from './shadow.js';
+import { errors } from '../strings/index.js';
 
 /**
  * Spec item with runtime metadata for source tracking.
@@ -217,6 +220,16 @@ export interface KspecContext {
  */
 export async function initContext(startDir?: string): Promise<KspecContext> {
   const cwd = startDir || process.cwd();
+
+  // Check if running from inside the shadow worktree
+  const mainProjectRoot = await detectRunningFromShadowWorktree(cwd);
+  if (mainProjectRoot) {
+    throw new ShadowError(
+      errors.project.runningFromShadow,
+      'RUNNING_FROM_SHADOW',
+      `Run from project root: cd ${path.relative(cwd, mainProjectRoot) || mainProjectRoot}`
+    );
+  }
 
   // Try to detect shadow branch first
   const shadow = await detectShadow(cwd);

--- a/src/strings/errors.ts
+++ b/src/strings/errors.ts
@@ -153,6 +153,9 @@ export const projectErrors = {
   noKspecProject: 'No kspec project found',
   shadowInitFailed: (error: string) => `Shadow initialization failed: ${error}`,
   couldNotGetImplSummary: 'Could not get implementation summary',
+  runningFromShadow: 'Cannot run kspec from inside .kspec/ directory',
+  runningFromShadowHint: (projectRoot: string) =>
+    `The .kspec/ directory is a git worktree. Run from project root: ${projectRoot}`,
 } as const;
 
 /**


### PR DESCRIPTION
## Summary

- Add early detection in `initContext()` when running from inside `.kspec/` worktree directory
- Throw clear `ShadowError` with actionable suggestion instead of silent failure
- Add comprehensive acceptance criteria to `@shadow-errors` spec
- Enhance CLI error output to display ShadowError suggestions

## Problem

When kspec commands were run from inside the `.kspec/` directory, `getGitRoot()` returned the worktree root, causing `detectShadow()` to look for `.kspec/.kspec/` which doesn't exist. This resulted in auto-commit/push silently failing with no error message.

## Solution

Add `detectRunningFromShadowWorktree()` that detects when cwd is inside the shadow worktree by:
1. Checking if `.git` is a file (worktrees have .git files, not directories)
2. Reading the gitdir reference
3. Checking if it points to a shadow worktree pattern

## Test plan

- [x] Unit tests for `detectRunningFromShadowWorktree()` - returns null for regular repos, returns project root for .kspec/ worktree
- [x] Integration test for `initContext()` - throws ShadowError with RUNNING_FROM_SHADOW code
- [x] E2E test - CLI exits with error when run from .kspec/ directory
- [x] All 714 tests pass
- [x] Manual verification from .kspec/ shows error with suggestion

Task: @01KFDQ92
Spec: @shadow-errors

Generated with [Claude Code](https://claude.ai/code)