### PR TITLE
feat: Add kspec tasks assess automation command

### DIFF
--- a/.claude/skills/triage/SKILL.md
+++ b/.claude/skills/triage/SKILL.md
@@ -3,188 +3,98 @@ name: triage
 description: Triage inbox items systematically. Analyzes items against spec/tasks, categorizes them, and processes using spec-first approach with plan mode for larger features.
 ---
 
-# Inbox Triage
+# Triage
 
-Systematically process inbox items: analyze, categorize, and convert to specs/tasks using spec-first development.
+Systematically process items: inbox, observations, or automation eligibility.
 
-## Workflow
+## Focus Modes
 
-### 1. Gather Context
+Use `/triage <mode>` to focus on a specific area:
+
+| Mode | Purpose | Documentation |
+|------|---------|---------------|
+| `inbox` | Process inbox items → specs/tasks | [docs/inbox.md](docs/inbox.md) |
+| `observations` | Process pending observations | [docs/observations.md](docs/observations.md) |
+| `automation` | Assess task automation eligibility | [docs/automation.md](docs/automation.md) |
+
+Without a mode, follow the full triage session pattern below.
+
+## Full Session Pattern
+
+1. **Get context**
+   ```bash
+   kspec session start --full
+   kspec inbox list
+   kspec meta observations --pending-resolution
+   kspec tasks assess automation
+   ```
+
+2. **Present overview to user**
+   - Inbox items by category
+   - Pending observations by type
+   - Unassessed tasks needing triage
+
+3. **Ask which focus area**
+   - Inbox items
+   - Observations
+   - Automation eligibility
+
+4. **Process that focus area**
+   - Use the relevant sub-document for guidance
+
+5. **Repeat or stop** when user indicates
+
+## Quick Start by Mode
+
+### `/triage inbox`
+
+Process inbox items using spec-first approach. See [docs/inbox.md](docs/inbox.md).
 
 ```bash
-kspec session start --full
 kspec inbox list
-kspec meta observations --pending-resolution
+# For each item: delete, promote, or create spec first
+kspec inbox delete @ref --force
+kspec inbox promote @ref --title "..." --spec-ref @spec
 ```
 
-Understand: current tasks, spec coverage, inbox volume, and any unresolved observations.
+### `/triage observations`
 
-### 2. Categorize Items
-
-Group inbox items by type:
-- **Bugs** - implementation issues, errors
-- **Spec gaps** - missing or incomplete specs
-- **Quick wins** - small, well-defined improvements
-- **Larger features** - need plan mode to design
-- **Process/workflow** - meta improvements
-- **Delete candidates** - outdated, duplicates, already done
-
-Present categories to user for alignment.
-
-### 3. Process Each Item
-
-For each item, follow this decision tree:
-
-```
-Is it still relevant?
-├─ No → Delete: kspec inbox delete @ref --force
-└─ Yes → Does spec cover this?
-         ├─ No spec exists → Create spec first
-         │   └─ Small: item add + ac add
-         │   └─ Large: Enter plan mode
-         ├─ Spec exists but incomplete → Update spec (add AC)
-         └─ Spec complete → Promote to task
-```
-
-### 4. Spec-First Processing
-
-**For each behavior change:**
-
-1. **Check coverage**: `kspec item list | grep <relevant>`
-2. **Identify gaps**: Does spec have description AND acceptance criteria?
-3. **Update spec**:
-   ```bash
-   kspec item set @ref --description "..."
-   kspec item ac add @ref --given "..." --when "..." --then "..."
-   ```
-4. **Derive or promote**:
-   ```bash
-   kspec derive @spec-ref           # If spec exists
-   kspec inbox promote @ref --title "..." --spec-ref @spec  # If from inbox
-   ```
-
-### 5. Plan Mode for Larger Items
-
-When an item needs design work:
-
-1. Enter plan mode
-2. Explore codebase for patterns/context
-3. Design spec structure and implementation approach
-4. Write plan, exit for approval
-5. Execute: create spec, add AC, derive task
-
-### 6. Processing Observations
-
-During triage, also process pending observations:
+Process pending observations. See [docs/observations.md](docs/observations.md).
 
 ```bash
 kspec meta observations --pending-resolution
-```
-
-For each observation type:
-
-| Type | How to Process |
-|------|----------------|
-| **friction** | Does it reveal a spec gap? → Create spec or inbox item. If already addressed → resolve |
-| **success** | Document in relevant spec or AGENTS.md if broadly useful → resolve |
-| **question** | Answer it if you can. If needs investigation → promote to task |
-| **idea** | Evaluate scope. Clear → inbox or task. Unclear → leave or delete |
-
-**Processing commands:**
-
-```bash
-# Promote observation to task (when actionable work is clear)
-kspec meta observations promote @ref --title "Add bulk AC command" --priority 2
-
-# Resolve observation (when addressed or no longer relevant)
+# For each: resolve, promote to task, or leave
 kspec meta observations resolve @ref
-
-# Convert inbox item to observation (if it's friction, not a task)
-kspec meta observe --from-inbox @ref
+kspec meta observations promote @ref --title "..."
 ```
 
-**When to use which:**
-- **Inbox** = future work that becomes tasks
-- **Observations** = systemic patterns that inform improvements
-- **Tasks** = clear, actionable implementation work
+### `/triage automation`
+
+Assess task automation eligibility. See [docs/automation.md](docs/automation.md).
+
+```bash
+kspec tasks assess automation
+# Review criteria, fix issues, or mark status
+kspec task set @ref --automation eligible
+kspec task set @ref --automation needs_review --reason "..."
+```
 
 ## Key Principles
 
-- **Ask one question at a time** - Use AskUserQuestion for decisions, don't batch
-- **Spec before task** - Fill spec gaps before creating implementation tasks
+- **Ask one question at a time** - Don't batch decisions
+- **Spec before task** - Fill spec gaps before creating tasks
 - **AC is required** - Specs without acceptance criteria are incomplete
 - **Use CLI, not YAML** - All changes through kspec commands
-- **Delete freely** - Inbox items that are outdated or duplicates should go
-
-## Quick Commands
-
-```bash
-# Triage decisions
-kspec inbox delete @ref --force     # Remove irrelevant
-kspec inbox promote @ref --title "..." --spec-ref @spec  # Convert to task
-
-# Spec updates
-kspec item set @ref --description "..."
-kspec item ac add @ref --given "..." --when "..." --then "..."
-
-# Create spec for gap
-kspec item add --under @parent --title "..." --type requirement --slug slug
-
-# Derive task from spec (recursive by default - includes children)
-kspec derive @spec-ref
-
-# Preview before deriving
-kspec derive @spec-ref --dry-run
-
-# Derive only this spec, not children
-kspec derive @spec-ref --flat
-```
-
-## Session Pattern
-
-1. Get context: `kspec session start --full`
-2. List inbox: `kspec inbox list`
-3. Present categorized overview to user
-4. Ask which category to tackle
-5. Process items in that category
-6. Repeat or stop when user indicates
+- **Delete freely** - Outdated items should go
 
 ## Progress Tracking
 
 Use TodoWrite to track progress during triage:
-- Create todos for each item being processed
+- Create todos for items being processed
 - Mark completed as you go (don't batch)
-- Keeps both agent and user oriented
-
-Keep a running summary:
-- Items processed (deleted, promoted, spec'd)
-- Tasks created
-- Specs updated
 
 At session end, provide summary:
-- Started with X inbox items, Y observations
-- Processed: Z items (deleted, promoted, spec'd)
-- Tasks created
+- Items processed (deleted, promoted, spec'd)
+- Tasks created/updated
 - Observations resolved
 - Remaining items
-
-## Common Patterns
-
-| Pattern | Action |
-|---------|--------|
-| Already implemented | Verify impl exists → check spec for gaps → fill gaps → delete inbox |
-| Duplicate of existing | Verify original covers scope → reference it → delete inbox |
-| Small flag/option | Update spec description + AC → derive task |
-| New command | Plan mode → design spec → create spec + AC → derive task |
-| Bug report | Check spec coverage → update spec if needed → promote with spec-ref |
-| Friction observation | Check if spec/task exists → create if needed → resolve observation |
-| Success observation | Document pattern if broadly useful → resolve |
-| Question observation | Answer or promote to task if needs investigation → resolve |
-| Vague idea | Ask for clarification or leave in inbox for later |
-
-## Tips
-
-- **Verify before delete**: Quick check that feature really exists
-- **Link related items**: When promoting, add spec-ref and depends-on
-- **Spec status**: Mark as `implemented` if catching up spec to reality
-- **Ask early**: If unsure about user intent, ask before deep work

--- a/.claude/skills/triage/docs/automation.md
+++ b/.claude/skills/triage/docs/automation.md
@@ -1,0 +1,118 @@
+# Automation Triage
+
+Assess and prepare tasks for automation eligibility. Goal: make tasks self-contained so they can be automated.
+
+## Philosophy
+
+- **Eligible is the goal** - Manual-only should be the exception
+- **Criteria are for visibility** - Help identify what's missing, not auto-approve
+- **Fix issues, don't just assess** - Guide toward making tasks automatable
+
+## Eligibility Criteria
+
+A task is ready for automation when:
+1. Has `spec_ref` pointing to resolvable spec
+2. Spec has acceptance criteria (testable outcomes)
+3. Task type is not `spike` (spikes output knowledge, not code)
+
+**Having spec + ACs is necessary but not sufficient** - you must also verify the spec is appropriate and ACs are adequate for the task.
+
+## Workflow
+
+### 1. Get Assessment Overview
+
+```bash
+# Show unassessed pending tasks with criteria status
+kspec tasks assess automation
+
+# See what auto mode would change
+kspec tasks assess automation --auto --dry-run
+```
+
+### 2. Process Each Task
+
+For each task shown:
+
+**If spike:**
+- Mark `manual_only` - spikes are inherently human work
+- `kspec task set @ref --automation manual_only --reason "Spike - output is knowledge"`
+
+**If missing spec_ref or no ACs:**
+- Ask: "Fix now or mark for later?"
+- **Fix now:**
+  1. Create or find appropriate spec: `kspec item add --under @parent --title "..."`
+  2. Add acceptance criteria: `kspec item ac add @spec --given "..." --when "..." --then "..."`
+  3. Link task to spec: `kspec task set @ref --spec-ref @spec`
+  4. Re-assess and mark eligible if appropriate
+- **Mark for later:**
+  - `kspec task set @ref --automation needs_review --reason "Missing spec - needs spec creation"`
+
+**If has spec + ACs:**
+- Review for eligibility:
+  - Is the spec appropriate for this task?
+  - Are the ACs adequate and testable?
+  - Does the task have sufficient context?
+- If yes: `kspec task set @ref --automation eligible`
+- If no: Fix issues or mark `needs_review` with specific reason
+
+### 3. Batch Processing with Auto Mode
+
+For fast triage of obvious cases:
+
+```bash
+# Apply auto mode (spikes → manual_only, missing → needs_review)
+kspec tasks assess automation --auto
+
+# Then manually review the "review_for_eligible" tasks
+kspec tasks ready --unassessed
+```
+
+Auto mode is conservative:
+- Spikes → `manual_only`
+- Missing spec/ACs → `needs_review`
+- Has spec + ACs → **NOT auto-marked** (requires review)
+
+## Quick Commands
+
+```bash
+# Assessment
+kspec tasks assess automation              # Show unassessed with criteria
+kspec tasks assess automation @ref         # Single task
+kspec tasks assess automation --all        # Include already-assessed
+kspec tasks assess automation --auto       # Apply obvious cases
+kspec tasks assess automation --dry-run    # Preview changes
+
+# Setting automation status
+kspec task set @ref --automation eligible
+kspec task set @ref --automation needs_review --reason "Why"
+kspec task set @ref --automation manual_only --reason "Why"
+kspec task set @ref --no-automation        # Clear to unassessed
+
+# Filtering tasks
+kspec tasks ready --unassessed             # Tasks needing assessment
+kspec tasks ready --eligible               # Automation-ready tasks
+kspec tasks ready --needs-review           # Tasks needing human triage
+```
+
+## Assessment Output
+
+```
+@task-slug  "Task title"
+  spec_ref:     ✓ @feature-slug
+  has_acs:      ✓ 3 acceptance criteria
+  not_spike:    ✓ type: task
+  → review_for_eligible (verify spec/AC adequacy)
+```
+
+| Recommendation | Meaning | Auto Mode Action |
+|----------------|---------|------------------|
+| `review_for_eligible` | Passes criteria, needs review | No change (manual review) |
+| `needs_review` | Missing spec or ACs | Sets `needs_review` with reason |
+| `manual_only` | Spike task | Sets `manual_only` |
+
+## Key Principles
+
+- **CLI doesn't auto-mark eligible** - Requires agent/human review
+- **Agents CAN mark eligible** - When reviewing based on user instruction
+- **Add notes when setting status** - Document the "why"
+- **Re-assess after fixes** - After adding spec/ACs, check again

--- a/.claude/skills/triage/docs/inbox.md
+++ b/.claude/skills/triage/docs/inbox.md
@@ -1,0 +1,103 @@
+# Inbox Triage
+
+Process inbox items systematically: analyze, categorize, and convert to specs/tasks.
+
+## Workflow
+
+### 1. Gather Context
+
+```bash
+kspec session start --full
+kspec inbox list
+```
+
+### 2. Categorize Items
+
+Group inbox items by type:
+- **Bugs** - implementation issues, errors
+- **Spec gaps** - missing or incomplete specs
+- **Quick wins** - small, well-defined improvements
+- **Larger features** - need plan mode to design
+- **Process/workflow** - meta improvements
+- **Delete candidates** - outdated, duplicates, already done
+
+Present categories to user for alignment.
+
+### 3. Process Each Item
+
+Decision tree:
+
+```
+Is it still relevant?
+├─ No → Delete: kspec inbox delete @ref --force
+└─ Yes → Does spec cover this?
+         ├─ No spec exists → Create spec first
+         │   └─ Small: item add + ac add
+         │   └─ Large: Enter plan mode
+         ├─ Spec exists but incomplete → Update spec (add AC)
+         └─ Spec complete → Promote to task
+```
+
+### 4. Spec-First Processing
+
+For each behavior change:
+
+1. **Check coverage**: `kspec item list | grep <relevant>`
+2. **Identify gaps**: Does spec have description AND acceptance criteria?
+3. **Update spec**:
+   ```bash
+   kspec item set @ref --description "..."
+   kspec item ac add @ref --given "..." --when "..." --then "..."
+   ```
+4. **Derive or promote**:
+   ```bash
+   kspec derive @spec-ref           # If spec exists
+   kspec inbox promote @ref --title "..." --spec-ref @spec  # If from inbox
+   ```
+
+### 5. Plan Mode for Larger Items
+
+When an item needs design work:
+
+1. Enter plan mode
+2. Explore codebase for patterns/context
+3. Design spec structure and implementation approach
+4. Write plan, exit for approval
+5. Execute: create spec, add AC, derive task
+
+## Quick Commands
+
+```bash
+# Triage decisions
+kspec inbox delete @ref --force     # Remove irrelevant
+kspec inbox promote @ref --title "..." --spec-ref @spec  # Convert to task
+
+# Spec updates
+kspec item set @ref --description "..."
+kspec item ac add @ref --given "..." --when "..." --then "..."
+
+# Create spec for gap
+kspec item add --under @parent --title "..." --type requirement --slug slug
+
+# Derive task from spec
+kspec derive @spec-ref
+```
+
+## Common Patterns
+
+| Pattern | Action |
+|---------|--------|
+| Already implemented | Verify impl exists → check spec for gaps → fill gaps → delete inbox |
+| Duplicate of existing | Verify original covers scope → reference it → delete inbox |
+| Small flag/option | Update spec description + AC → derive task |
+| New command | Plan mode → design spec → create spec + AC → derive task |
+| Bug report | Check spec coverage → update spec if needed → promote with spec-ref |
+| Vague idea | Ask for clarification or leave in inbox for later |
+
+## Key Principles
+
+- **Ask one question at a time** - Use AskUserQuestion for decisions
+- **Spec before task** - Fill spec gaps before creating tasks
+- **AC is required** - Specs without acceptance criteria are incomplete
+- **Use CLI, not YAML** - All changes through kspec commands
+- **Delete freely** - Outdated or duplicate items should go

--- a/.claude/skills/triage/docs/observations.md
+++ b/.claude/skills/triage/docs/observations.md
@@ -1,0 +1,70 @@
+# Observations Triage
+
+Process pending observations: evaluate, resolve, or promote to tasks.
+
+## Workflow
+
+### 1. List Pending Observations
+
+```bash
+kspec meta observations --pending-resolution
+```
+
+### 2. Process by Type
+
+| Type | How to Process |
+|------|----------------|
+| **friction** | Does it reveal a spec gap? → Create spec or inbox item. If already addressed → resolve |
+| **success** | Document in relevant spec or AGENTS.md if broadly useful → resolve |
+| **question** | Answer it if you can. If needs investigation → promote to task |
+| **idea** | Evaluate scope. Clear → inbox or task. Unclear → leave or delete |
+
+### 3. Processing Commands
+
+```bash
+# Promote observation to task (when actionable work is clear)
+kspec meta observations promote @ref --title "Add bulk AC command" --priority 2
+
+# Resolve observation (when addressed or no longer relevant)
+kspec meta observations resolve @ref
+
+# Convert inbox item to observation (if it's friction, not a task)
+kspec meta observe --from-inbox @ref
+```
+
+## When to Use Which
+
+- **Inbox** = future work that becomes tasks
+- **Observations** = systemic patterns that inform improvements
+- **Tasks** = clear, actionable implementation work
+
+## Decision Flow
+
+```
+For each observation:
+├─ Still relevant?
+│   ├─ No → resolve with note
+│   └─ Yes → Does it need action?
+│       ├─ No (just learning) → resolve after documenting
+│       └─ Yes → Is scope clear?
+│           ├─ Yes → promote to task
+│           └─ No → add to inbox for later triage
+```
+
+## Common Patterns
+
+| Pattern | Action |
+|---------|--------|
+| Friction already fixed | Verify fix → resolve with note |
+| Friction needs work | Check spec → create if needed → promote or inbox |
+| Success pattern | Document in AGENTS.md or relevant spec → resolve |
+| Open question | Answer if possible → resolve. If needs investigation → promote |
+| Idea with clear scope | Promote to task or inbox |
+| Vague idea | Leave or delete if stale |
+
+## Key Principles
+
+- **Observations capture learning** - Not just todos
+- **Friction informs improvement** - Turn pain points into better specs
+- **Success patterns are worth documenting** - Help future sessions
+- **Questions should get answers** - Don't let them linger

--- a/src/parser/assess.ts
+++ b/src/parser/assess.ts
@@ -1,0 +1,311 @@
+/**
+ * Task automation assessment logic.
+ *
+ * Provides criteria checking for task automation eligibility.
+ * AC: @tasks-assess-automation
+ */
+
+import type { LoadedTask, LoadedSpecItem } from './yaml.js';
+import type { ReferenceIndex } from './refs.js';
+
+// ============================================================
+// TYPES
+// ============================================================
+
+/**
+ * Criterion check result
+ */
+export interface CriterionResult {
+  pass: boolean;
+  /** For skipped criteria (neutral) */
+  skipped?: boolean;
+  /** Additional context */
+  detail?: string;
+}
+
+/**
+ * Full assessment result for a task
+ * AC: @tasks-assess-automation ac-3, ac-4
+ */
+export interface TaskAssessment {
+  taskRef: string;
+  taskUlid: string;
+  taskTitle: string;
+  taskType: string;
+  criteria: {
+    has_spec_ref: CriterionResult & { spec_ref?: string };
+    spec_has_acs: CriterionResult & { ac_count?: number };
+    not_spike: CriterionResult;
+  };
+  recommendation: 'review_for_eligible' | 'needs_review' | 'manual_only';
+  reason: string;
+}
+
+/**
+ * Assessment summary counts
+ * AC: @tasks-assess-automation ac-5, ac-25
+ */
+export interface AssessmentSummary {
+  review_for_eligible: number;
+  needs_review: number;
+  manual_only: number;
+  total: number;
+}
+
+// ============================================================
+// ASSESSMENT LOGIC
+// ============================================================
+
+/**
+ * Assess a single task's automation eligibility
+ * AC: @tasks-assess-automation ac-8 through ac-16
+ */
+export function assessTask(
+  task: LoadedTask,
+  index: ReferenceIndex,
+  items: LoadedSpecItem[]
+): TaskAssessment {
+  const taskRef = task.slugs.length > 0 ? `@${task.slugs[0]}` : `@${task._ulid.slice(0, 8)}`;
+  const taskType = task.type || 'task';
+
+  // AC: @tasks-assess-automation ac-8, ac-9 - Check has_spec_ref
+  const hasSpecRefResult = checkHasSpecRef(task, index);
+
+  // AC: @tasks-assess-automation ac-10, ac-11 - Check spec_has_acs
+  const specHasAcsResult = checkSpecHasAcs(task, index, items);
+
+  // AC: @tasks-assess-automation ac-12, ac-13 - Check not_spike
+  const notSpikeResult = checkNotSpike(task);
+
+  // Compute recommendation
+  // AC: @tasks-assess-automation ac-14, ac-15, ac-16
+  const { recommendation, reason } = computeRecommendation(
+    hasSpecRefResult,
+    specHasAcsResult,
+    notSpikeResult,
+    taskType
+  );
+
+  return {
+    taskRef,
+    taskUlid: task._ulid,
+    taskTitle: task.title,
+    taskType,
+    criteria: {
+      has_spec_ref: hasSpecRefResult,
+      spec_has_acs: specHasAcsResult,
+      not_spike: notSpikeResult,
+    },
+    recommendation,
+    reason,
+  };
+}
+
+/**
+ * Check if task has spec_ref pointing to resolvable spec
+ * AC: @tasks-assess-automation ac-8, ac-9
+ */
+function checkHasSpecRef(
+  task: LoadedTask,
+  index: ReferenceIndex
+): CriterionResult & { spec_ref?: string } {
+  if (!task.spec_ref) {
+    return { pass: false, detail: 'missing' };
+  }
+
+  const resolved = index.resolve(task.spec_ref);
+  if (!resolved.ok) {
+    return { pass: false, detail: 'unresolvable', spec_ref: task.spec_ref };
+  }
+
+  return { pass: true, spec_ref: task.spec_ref };
+}
+
+/**
+ * Check if linked spec has acceptance criteria
+ * AC: @tasks-assess-automation ac-10, ac-11
+ */
+function checkSpecHasAcs(
+  task: LoadedTask,
+  index: ReferenceIndex,
+  items: LoadedSpecItem[]
+): CriterionResult & { ac_count?: number } {
+  // AC: @tasks-assess-automation ac-11 - skipped if no spec_ref
+  if (!task.spec_ref) {
+    return { pass: false, skipped: true, detail: 'no spec to check' };
+  }
+
+  const resolved = index.resolve(task.spec_ref);
+  if (!resolved.ok) {
+    return { pass: false, skipped: true, detail: 'spec not resolvable' };
+  }
+
+  // Find the spec item
+  const specItem = items.find(i => i._ulid === resolved.ulid);
+  if (!specItem) {
+    return { pass: false, skipped: true, detail: 'spec not found in items' };
+  }
+
+  const acCount = specItem.acceptance_criteria?.length || 0;
+  if (acCount === 0) {
+    return { pass: false, ac_count: 0, detail: 'spec has no acceptance criteria' };
+  }
+
+  return { pass: true, ac_count: acCount };
+}
+
+/**
+ * Check if task type is not spike
+ * AC: @tasks-assess-automation ac-12, ac-13
+ */
+function checkNotSpike(task: LoadedTask): CriterionResult {
+  const taskType = task.type || 'task';
+  if (taskType === 'spike') {
+    return { pass: false, detail: 'type: spike' };
+  }
+  return { pass: true, detail: `type: ${taskType}` };
+}
+
+/**
+ * Compute recommendation based on criteria results
+ * AC: @tasks-assess-automation ac-14, ac-15, ac-16
+ */
+function computeRecommendation(
+  hasSpecRef: CriterionResult,
+  specHasAcs: CriterionResult,
+  notSpike: CriterionResult,
+  taskType: string
+): { recommendation: TaskAssessment['recommendation']; reason: string } {
+  // AC: @tasks-assess-automation ac-14 - Spikes are always manual_only
+  if (!notSpike.pass) {
+    return {
+      recommendation: 'manual_only',
+      reason: 'Spikes output knowledge, not automatable code',
+    };
+  }
+
+  // AC: @tasks-assess-automation ac-15 - Missing spec or no ACs → needs_review
+  const reasons: string[] = [];
+  if (!hasSpecRef.pass) {
+    reasons.push('missing spec_ref');
+  }
+  if (!specHasAcs.pass && !specHasAcs.skipped) {
+    reasons.push('spec has no acceptance criteria');
+  } else if (specHasAcs.skipped && !hasSpecRef.pass) {
+    // Only add this if spec is missing (not if spec is unresolvable)
+  }
+
+  if (reasons.length > 0) {
+    return {
+      recommendation: 'needs_review',
+      reason: reasons.join(', '),
+    };
+  }
+
+  // AC: @tasks-assess-automation ac-16 - All criteria pass → review_for_eligible
+  return {
+    recommendation: 'review_for_eligible',
+    reason: 'Criteria pass - verify spec is appropriate and ACs are adequate',
+  };
+}
+
+/**
+ * Filter tasks for assessment
+ * AC: @tasks-assess-automation ac-1, ac-2, ac-27, ac-28
+ */
+export function filterTasksForAssessment(
+  tasks: LoadedTask[],
+  options: { all?: boolean; taskRef?: string },
+  index: ReferenceIndex
+): LoadedTask[] {
+  let filtered = tasks;
+
+  // AC: @tasks-assess-automation ac-28 - Exclude non-pending tasks
+  filtered = filtered.filter(t => t.status === 'pending');
+
+  // AC: @tasks-assess-automation ac-6 - Single task assessment
+  if (options.taskRef) {
+    const resolved = index.resolve(options.taskRef);
+    if (!resolved.ok) {
+      return []; // Will be handled by caller
+    }
+    filtered = filtered.filter(t => t._ulid === resolved.ulid);
+    return filtered;
+  }
+
+  // AC: @tasks-assess-automation ac-1, ac-27 - Filter by unassessed unless --all
+  if (!options.all) {
+    filtered = filtered.filter(t => !t.automation);
+  }
+
+  return filtered;
+}
+
+/**
+ * Compute summary counts from assessments
+ * AC: @tasks-assess-automation ac-5, ac-25
+ */
+export function computeSummary(assessments: TaskAssessment[]): AssessmentSummary {
+  const summary: AssessmentSummary = {
+    review_for_eligible: 0,
+    needs_review: 0,
+    manual_only: 0,
+    total: assessments.length,
+  };
+
+  for (const assessment of assessments) {
+    summary[assessment.recommendation]++;
+  }
+
+  return summary;
+}
+
+/**
+ * Determine what changes auto mode would make
+ * AC: @tasks-assess-automation ac-17, ac-18, ac-21
+ */
+export interface AutoModeChange {
+  taskRef: string;
+  taskUlid: string;
+  taskTitle: string;
+  action: 'set_manual_only' | 'set_needs_review' | 'no_change';
+  newStatus?: 'manual_only' | 'needs_review';
+  reason: string;
+}
+
+export function computeAutoModeChanges(assessments: TaskAssessment[]): AutoModeChange[] {
+  return assessments.map(assessment => {
+    // AC: @tasks-assess-automation ac-17 - Spikes → manual_only
+    if (assessment.recommendation === 'manual_only') {
+      return {
+        taskRef: assessment.taskRef,
+        taskUlid: assessment.taskUlid,
+        taskTitle: assessment.taskTitle,
+        action: 'set_manual_only' as const,
+        newStatus: 'manual_only' as const,
+        reason: assessment.reason,
+      };
+    }
+
+    // AC: @tasks-assess-automation ac-17 - Missing criteria → needs_review
+    if (assessment.recommendation === 'needs_review') {
+      return {
+        taskRef: assessment.taskRef,
+        taskUlid: assessment.taskUlid,
+        taskTitle: assessment.taskTitle,
+        action: 'set_needs_review' as const,
+        newStatus: 'needs_review' as const,
+        reason: assessment.reason,
+      };
+    }
+
+    // AC: @tasks-assess-automation ac-18, ac-21 - review_for_eligible → no change
+    return {
+      taskRef: assessment.taskRef,
+      taskUlid: assessment.taskUlid,
+      taskTitle: assessment.taskTitle,
+      action: 'no_change' as const,
+      reason: 'Passes criteria - requires agent/human review to mark eligible',
+    };
+  });
+}

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -10,3 +10,4 @@ export * from './fix.js';
 export * from './shadow.js';
 export * from './meta.js';
 export * from './convention-validation.js';
+export * from './assess.js';

--- a/tests/tasks-assess-automation.test.ts
+++ b/tests/tasks-assess-automation.test.ts
@@ -1,0 +1,377 @@
+/**
+ * Tests for kspec tasks assess automation command
+ * AC: @tasks-assess-automation
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import {
+  kspec as kspecRun,
+  kspecOutput as kspec,
+  kspecJson,
+  setupTempFixtures,
+  cleanupTempDir,
+} from './helpers/cli';
+
+describe('kspec tasks assess automation', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await setupTempFixtures();
+  });
+
+  afterEach(async () => {
+    await cleanupTempDir(tempDir);
+  });
+
+  describe('Filtering & Display (AC-1, AC-2, AC-26, AC-27, AC-28)', () => {
+    // AC: @tasks-assess-automation ac-1
+    it('should list pending unassessed tasks by default', () => {
+      // Create unassessed task
+      kspec('task add --title "Unassessed task"', tempDir);
+
+      const output = kspec('tasks assess automation', tempDir);
+      expect(output).toContain('Unassessed task');
+      expect(output).toContain('needs_review');
+    });
+
+    // AC: @tasks-assess-automation ac-2
+    it('should include already-assessed tasks with --all flag', () => {
+      // Create task and set automation
+      kspec('task add --title "Already assessed"', tempDir);
+      const tasks = kspecJson<any[]>('tasks list', tempDir);
+      const task = tasks.find(t => t.title === 'Already assessed');
+      kspec(`task set @${task._ulid.slice(0, 8)} --automation eligible`, tempDir);
+
+      // Without --all, should not appear
+      const output1 = kspec('tasks assess automation', tempDir);
+      expect(output1).not.toContain('Already assessed');
+
+      // With --all, should appear
+      const output2 = kspec('tasks assess automation --all', tempDir);
+      expect(output2).toContain('Already assessed');
+    });
+
+    // AC: @tasks-assess-automation ac-26
+    it('should show message when no unassessed pending tasks', () => {
+      // Mark all pending tasks as assessed (test-task-pending and test-task-blocked)
+      kspec('task set @test-task-pending --automation eligible', tempDir);
+      kspec('task set @test-task-blocked --automation eligible', tempDir);
+
+      const output = kspec('tasks assess automation', tempDir);
+      expect(output).toContain('No unassessed pending tasks');
+    });
+
+    // AC: @tasks-assess-automation ac-27
+    it('should skip already-assessed tasks without --all', () => {
+      kspec('task set @test-task-pending --automation eligible', tempDir);
+      kspec('task add --title "New unassessed"', tempDir);
+
+      const output = kspec('tasks assess automation', tempDir);
+      expect(output).not.toContain('Test pending task');
+      expect(output).toContain('New unassessed');
+    });
+
+    // AC: @tasks-assess-automation ac-28
+    it('should exclude non-pending tasks', () => {
+      // completed task should not appear
+      const output = kspec('tasks assess automation --all', tempDir);
+      expect(output).not.toContain('Test completed task');
+    });
+  });
+
+  describe('Single Task Assessment (AC-6, AC-7)', () => {
+    // AC: @tasks-assess-automation ac-6
+    it('should assess only specified task with ref argument', () => {
+      kspec('task add --title "Task A" --slug task-a-test', tempDir);
+      kspec('task add --title "Task B" --slug task-b-test', tempDir);
+
+      // Assess only Task A by slug
+      const output = kspec('tasks assess automation @task-a-test', tempDir);
+      expect(output).toContain('Task A');
+      expect(output).not.toContain('Task B');
+      expect(output).toContain('total: 1');
+    });
+
+    // AC: @tasks-assess-automation ac-7
+    it('should return non-zero exit code for non-existent task', () => {
+      const result = kspecRun('tasks assess automation @nonexistent-task', tempDir, { expectFail: true });
+      expect(result.exitCode).not.toBe(0);
+      expect(result.stderr).toContain('Task not found');
+    });
+  });
+
+  describe('Criteria Checks (AC-8, AC-9, AC-10, AC-11, AC-12, AC-13)', () => {
+    // AC: @tasks-assess-automation ac-8
+    it('should pass has_spec_ref when task has resolvable spec_ref', () => {
+      kspec('task add --title "With spec" --spec-ref @test-feature', tempDir);
+
+      const output = kspec('tasks assess automation', tempDir);
+      expect(output).toContain('spec_ref:     ✓');
+      expect(output).toContain('@test-feature');
+    });
+
+    // AC: @tasks-assess-automation ac-9
+    it('should fail has_spec_ref when spec_ref is missing', () => {
+      kspec('task add --title "No spec"', tempDir);
+
+      const output = kspec('tasks assess automation', tempDir);
+      expect(output).toContain('spec_ref:     ✗');
+      expect(output).toContain('missing');
+    });
+
+    // AC: @tasks-assess-automation ac-10, ac-11
+    it('should check spec_has_acs only when spec_ref exists', async () => {
+      // Add acceptance criteria to test-feature
+      const coreYamlPath = path.join(tempDir, 'modules', 'core.yaml');
+      const coreYaml = await fs.readFile(coreYamlPath, 'utf-8');
+      const updatedYaml = coreYaml.replace(
+        'implements:\n          - "@test-feature"',
+        `implements:
+          - "@test-feature"
+    acceptance_criteria:
+      - id: ac-1
+        given: test
+        when: test
+        then: test`
+      );
+      await fs.writeFile(coreYamlPath, updatedYaml);
+
+      // Task with spec_ref pointing to spec with ACs
+      kspec('task add --title "Has ACs" --spec-ref @test-requirement', tempDir);
+
+      const output = kspec('tasks assess automation', tempDir);
+      // Should show AC check result
+      expect(output).toContain('has_acs:');
+    });
+
+    // AC: @tasks-assess-automation ac-11
+    it('should skip spec_has_acs when no spec_ref', () => {
+      kspec('task add --title "No spec"', tempDir);
+
+      const output = kspec('tasks assess automation', tempDir);
+      expect(output).toContain('has_acs:      -');
+      expect(output).toContain('no spec to check');
+    });
+
+    // AC: @tasks-assess-automation ac-12
+    it('should pass not_spike for non-spike tasks', () => {
+      kspec('task add --title "Regular task" --type task', tempDir);
+
+      const output = kspec('tasks assess automation', tempDir);
+      expect(output).toContain('not_spike:    ✓');
+    });
+
+    // AC: @tasks-assess-automation ac-13
+    it('should fail not_spike for spike tasks', () => {
+      kspec('task add --title "Spike task" --type spike', tempDir);
+
+      const output = kspec('tasks assess automation', tempDir);
+      expect(output).toContain('not_spike:    ✗');
+      expect(output).toContain('type: spike');
+    });
+  });
+
+  describe('Recommendations (AC-14, AC-15, AC-16)', () => {
+    // AC: @tasks-assess-automation ac-14
+    it('should recommend manual_only for spike tasks', () => {
+      kspec('task add --title "Spike" --type spike', tempDir);
+
+      const output = kspec('tasks assess automation', tempDir);
+      expect(output).toContain('manual_only');
+      expect(output).toContain('Spikes output knowledge');
+    });
+
+    // AC: @tasks-assess-automation ac-15
+    it('should recommend needs_review for missing spec_ref', () => {
+      kspec('task add --title "No spec"', tempDir);
+
+      const output = kspec('tasks assess automation', tempDir);
+      expect(output).toContain('needs_review');
+      expect(output).toContain('missing spec_ref');
+    });
+
+    // AC: @tasks-assess-automation ac-16
+    it('should recommend review_for_eligible when all criteria pass', async () => {
+      // Add acceptance criteria to test-feature
+      const coreYamlPath = path.join(tempDir, 'modules', 'core.yaml');
+      const coreYaml = await fs.readFile(coreYamlPath, 'utf-8');
+      const updatedYaml = coreYaml.replace(
+        'description: A test feature for integration testing',
+        `description: A test feature for integration testing
+    acceptance_criteria:
+      - id: ac-1
+        given: test
+        when: test
+        then: test`
+      );
+      await fs.writeFile(coreYamlPath, updatedYaml);
+
+      kspec('task add --title "Ready task" --spec-ref @test-feature', tempDir);
+
+      const output = kspec('tasks assess automation', tempDir);
+      expect(output).toContain('review_for_eligible');
+      expect(output).toContain('verify spec is appropriate');
+    });
+  });
+
+  describe('Auto Mode (AC-17, AC-18, AC-19, AC-20, AC-21)', () => {
+    // AC: @tasks-assess-automation ac-17
+    it('should apply obvious cases: spike -> manual_only', () => {
+      kspec('task add --title "Spike task" --type spike', tempDir);
+
+      kspec('tasks assess automation --auto', tempDir);
+
+      // Verify task was updated
+      const tasks = kspecJson<any[]>('tasks list', tempDir);
+      const spike = tasks.find(t => t.title === 'Spike task');
+      expect(spike.automation).toBe('manual_only');
+    });
+
+    // AC: @tasks-assess-automation ac-17
+    it('should apply obvious cases: missing criteria -> needs_review', () => {
+      kspec('task add --title "Missing spec"', tempDir);
+
+      kspec('tasks assess automation --auto', tempDir);
+
+      const tasks = kspecJson<any[]>('tasks list', tempDir);
+      const task = tasks.find(t => t.title === 'Missing spec');
+      expect(task.automation).toBe('needs_review');
+    });
+
+    // AC: @tasks-assess-automation ac-18, ac-21
+    it('should NOT auto-mark eligible when all criteria pass', async () => {
+      // Add acceptance criteria to test-feature
+      const coreYamlPath = path.join(tempDir, 'modules', 'core.yaml');
+      const coreYaml = await fs.readFile(coreYamlPath, 'utf-8');
+      const updatedYaml = coreYaml.replace(
+        'description: A test feature for integration testing',
+        `description: A test feature for integration testing
+    acceptance_criteria:
+      - id: ac-1
+        given: test
+        when: test
+        then: test`
+      );
+      await fs.writeFile(coreYamlPath, updatedYaml);
+
+      kspec('task add --title "Ready task" --spec-ref @test-feature', tempDir);
+
+      kspec('tasks assess automation --auto', tempDir);
+
+      // Should NOT be marked eligible
+      const tasks = kspecJson<any[]>('tasks list', tempDir);
+      const task = tasks.find(t => t.title === 'Ready task');
+      expect(task.automation).toBeUndefined(); // Still unassessed
+    });
+
+    // AC: @tasks-assess-automation ac-19
+    it('should add note explaining assessment in auto mode', () => {
+      kspec('task add --title "Note test"', tempDir);
+
+      kspec('tasks assess automation --auto', tempDir);
+
+      const tasks = kspecJson<any[]>('tasks list', tempDir);
+      const task = tasks.find(t => t.title === 'Note test');
+      expect(task.notes.length).toBeGreaterThan(0);
+      expect(task.notes.some((n: any) => n.content.includes('Automation assessment'))).toBe(true);
+    });
+
+    // AC: @tasks-assess-automation ac-20
+    it('should include reason in note for needs_review', () => {
+      kspec('task add --title "Reason test"', tempDir);
+
+      kspec('tasks assess automation --auto', tempDir);
+
+      const tasks = kspecJson<any[]>('tasks list', tempDir);
+      const task = tasks.find(t => t.title === 'Reason test');
+      expect(task.notes.some((n: any) => n.content.includes('missing spec_ref'))).toBe(true);
+    });
+  });
+
+  describe('Dry Run (AC-22, AC-23)', () => {
+    // AC: @tasks-assess-automation ac-22
+    it('should show changes without modifying tasks in dry-run', () => {
+      kspec('task add --title "Dry run test"', tempDir);
+
+      const output = kspec('tasks assess automation --dry-run', tempDir);
+      expect(output).toContain('Dry run test');
+
+      // Task should not be modified
+      const tasks = kspecJson<any[]>('tasks list', tempDir);
+      const task = tasks.find(t => t.title === 'Dry run test');
+      expect(task.automation).toBeUndefined();
+    });
+
+    // AC: @tasks-assess-automation ac-23
+    it('should combine --dry-run with --auto', () => {
+      kspec('task add --title "Dry auto test"', tempDir);
+
+      const output = kspec('tasks assess automation --auto --dry-run', tempDir);
+      expect(output).toContain('Dry run');
+      expect(output).toContain('would make these changes');
+      expect(output).toContain('set automation=needs_review');
+
+      // Task should not be modified
+      const tasks = kspecJson<any[]>('tasks list', tempDir);
+      const task = tasks.find(t => t.title === 'Dry auto test');
+      expect(task.automation).toBeUndefined();
+    });
+  });
+
+  describe('Output Formats (AC-3, AC-4, AC-5, AC-24, AC-25)', () => {
+    // AC: @tasks-assess-automation ac-3
+    it('should display criteria check results for each task', () => {
+      kspec('task add --title "Criteria test"', tempDir);
+
+      const output = kspec('tasks assess automation', tempDir);
+      expect(output).toContain('spec_ref:');
+      expect(output).toContain('has_acs:');
+      expect(output).toContain('not_spike:');
+    });
+
+    // AC: @tasks-assess-automation ac-4
+    it('should show recommendation for each task', () => {
+      kspec('task add --title "Rec test"', tempDir);
+
+      const output = kspec('tasks assess automation', tempDir);
+      expect(output).toMatch(/→.*needs_review/);
+    });
+
+    // AC: @tasks-assess-automation ac-5
+    it('should show summary counts at end', () => {
+      kspec('task add --title "Summary test"', tempDir);
+
+      const output = kspec('tasks assess automation', tempDir);
+      expect(output).toContain('Summary:');
+      expect(output).toContain('review_for_eligible:');
+      expect(output).toContain('needs_review:');
+      expect(output).toContain('manual_only:');
+      expect(output).toContain('total:');
+    });
+
+    // AC: @tasks-assess-automation ac-24
+    it('should output structured JSON with --json', () => {
+      kspec('task add --title "JSON test"', tempDir);
+
+      const result = kspecJson<any>('tasks assess automation', tempDir);
+      expect(result.assessments).toBeDefined();
+      expect(result.assessments.length).toBeGreaterThan(0);
+      expect(result.assessments[0].criteria).toBeDefined();
+      expect(result.assessments[0].criteria.has_spec_ref).toBeDefined();
+      expect(result.assessments[0].recommendation).toBeDefined();
+    });
+
+    // AC: @tasks-assess-automation ac-25
+    it('should include summary counts in JSON', () => {
+      kspec('task add --title "JSON summary test"', tempDir);
+
+      const result = kspecJson<any>('tasks assess automation', tempDir);
+      expect(result.summary).toBeDefined();
+      expect(result.summary.review_for_eligible).toBeDefined();
+      expect(result.summary.needs_review).toBeDefined();
+      expect(result.summary.manual_only).toBeDefined();
+      expect(result.summary.total).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add `kspec tasks assess automation` command for assessing task automation eligibility
- Implement assessment criteria: has_spec_ref, spec_has_acs, not_spike
- Add recommendations: review_for_eligible, needs_review, manual_only
- Support `--auto` mode for obvious cases (spikes → manual_only, missing criteria → needs_review)
- Support `--dry-run` to preview changes
- Add JSON output support
- Enhance `/triage` skill with focus modes (inbox, observations, automation)
- Create sub-documents for each triage focus area

## Test plan

- [x] Run `npm test` - all 765 tests pass
- [x] Run `kspec tasks assess automation` - displays unassessed tasks with criteria
- [x] Run `kspec tasks assess automation --auto --dry-run` - shows planned changes
- [x] Run `kspec tasks assess automation @task-ref` - single task assessment
- [x] Verify JSON output with `--json` flag

Task: @task-task-automation-assessment
Spec: @tasks-assess-automation

🤖 Generated with [Claude Code](https://claude.ai/code)