### PR TITLE
test: Unskip workflow reference validation test

### DIFF
--- a/tests/meta.test.ts
+++ b/tests/meta.test.ts
@@ -333,10 +333,7 @@ describe('Integration: meta workflows', () => {
   });
 
   // AC: @workflow-definitions ac-workflow-3
-  // NOTE: Skipping negative test for now - meta_ref is in REF_FIELDS and
-  // validation infrastructure is in place, but test has subtle issue with
-  // temp fixture setup. Valid workflow reference test above proves AC-3 works.
-  it.skip('should error on invalid workflow reference in meta_ref', async () => {
+  it('should error on invalid workflow reference in meta_ref', async () => {
     // Add a task with meta_ref pointing to a non-existent workflow
     const tasksPath = path.join(tempDir, 'project.tasks.yaml');
     let tasksContent = await fs.readFile(tasksPath, 'utf-8');


### PR DESCRIPTION
## Summary
- Unskipped test for invalid workflow reference validation in meta_ref
- Test now passes - the "subtle issue with temp fixture setup" has been resolved
- Removed obsolete NOTE comment

## Changes
- Removed `it.skip()` and converted to `it()` for the meta_ref validation test
- Removed outdated comment about skipping the test
- Test validates AC-3 for @workflow-definitions

## Test Plan
- [x] Test runs and passes
- [x] All 784 tests pass

Task: @01KFBJCD

🤖 Generated with [Claude Code](https://claude.com/claude-code)