### PR TITLE
Fix JSON output consistency: Remove command-specific --json flag

### DIFF
--- a/tests/clone-for-testing.test.ts
+++ b/tests/clone-for-testing.test.ts
@@ -225,9 +225,9 @@ describe('Integration: clone-for-testing', () => {
     const dest = path.join(os.tmpdir(), `clone-test-${Date.now()}`);
 
     try {
-      // Clone with --json flag - run from temp dir
+      // Clone with global --json flag (added by kspecJson helper)
       const result = kspecJson<{ path: string; branch: string }>(
-        `clone-for-testing ${dest} ${sourceRepo} --json`,
+        `clone-for-testing ${dest} ${sourceRepo}`,
         tempDir
       );
 
@@ -255,9 +255,9 @@ describe('Integration: clone-for-testing', () => {
     const dest = path.join(os.tmpdir(), `clone-test-${Date.now()}`);
 
     try {
-      // Clone with both --json and --branch flags - run from temp dir
+      // Clone with --branch and global --json flag (added by kspecJson helper)
       const result = kspecJson<{ path: string; branch: string }>(
-        `clone-for-testing ${dest} ${sourceRepo} --branch feature-json --json`,
+        `clone-for-testing ${dest} ${sourceRepo} --branch feature-json`,
         tempDir
       );
 


### PR DESCRIPTION
## Summary

- Removed command-specific `--json` flag from `clone-for-testing` command
- Updated command to use global `isJsonMode()` helper from output module
- Updated tests to use global `--json` flag (via `kspecJson` helper)

This eliminates the conflict between command-specific and global JSON flags identified during the JSON output consistency audit.

## Changes

- `src/cli/commands/clone-for-testing.ts`: Removed `--json` option, imported `isJsonMode()`, simplified output logic
- `tests/clone-for-testing.test.ts`: Removed redundant `--json` flags from test calls (kspecJson adds it automatically)

## Test Plan

- [x] All 808 tests pass
- [x] `clone-for-testing` tests pass with global `--json` flag
- [x] JSON output correctly formatted when using global flag
- [x] Human-readable output works without flag

Task: @01KFBDM8

🤖 Generated with [Claude Code](https://claude.ai/code)