### PR TITLE
Deduplicate formatRelativeTime in inbox.ts

### DIFF
--- a/src/cli/commands/inbox.ts
+++ b/src/cli/commands/inbox.ts
@@ -26,23 +26,13 @@ import * as readline from 'node:readline';
 import { errors } from '../../strings/index.js';
 import { fieldLabels } from '../../strings/labels.js';
 import { EXIT_CODES } from '../exit-codes.js';
+import { formatRelativeTime as formatRelativeTimeUtil } from '../../utils/time.js';
 
 /**
- * Format relative time for display
+ * Format relative time for display (wrapper for utils function)
  */
 function formatRelativeTime(dateStr: string): string {
-  const date = new Date(dateStr);
-  const now = new Date();
-  const diffMs = now.getTime() - date.getTime();
-  const diffMins = Math.floor(diffMs / 60000);
-  const diffHours = Math.floor(diffMs / 3600000);
-  const diffDays = Math.floor(diffMs / 86400000);
-
-  if (diffMins < 1) return 'just now';
-  if (diffMins < 60) return `${diffMins} minute${diffMins === 1 ? '' : 's'} ago`;
-  if (diffHours < 24) return `${diffHours} hour${diffHours === 1 ? '' : 's'} ago`;
-  if (diffDays < 7) return `${diffDays} day${diffDays === 1 ? '' : 's'} ago`;
-  return date.toLocaleDateString();
+  return formatRelativeTimeUtil(new Date(dateStr));
 }
 
 /**


### PR DESCRIPTION
## Summary
- Removed duplicate `formatRelativeTime` function from inbox.ts
- Now imports and wraps the version from utils/time.ts
- Gains week-level formatting that was missing in the duplicate
- All 823 tests pass

## Test plan
- [x] Run all tests: `npm test` ✅ 823 tests pass
- [x] Verify TypeScript compilation: `npm run typecheck` ✅
- [x] Verify inbox commands still work with relative time display

Task: @dedupe-format-relative-time

🤖 Generated with [Claude Code](https://claude.ai/code)