### PR TITLE
Add confirmation prompt for AC deletion without --force

### DIFF
--- a/tests/ac-delete-confirmation.test.ts
+++ b/tests/ac-delete-confirmation.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Tests for AC delete confirmation prompt
+ *
+ * Validates the confirmation prompt behavior when removing acceptance criteria.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  kspec,
+  setupTempFixtures,
+  cleanupTempDir,
+} from './helpers/cli';
+
+describe('AC Delete Confirmation', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await setupTempFixtures();
+    // Add a test spec item with an AC under the existing test-core module
+    kspec('item add --under @test-core --title "AC Test Feature" --type feature --slug ac-test-feature', tempDir);
+    kspec('item ac add @ac-test-feature --id ac-1 --given "user exists" --when "action performed" --then "expected result"', tempDir);
+  });
+
+  afterEach(async () => {
+    await cleanupTempDir(tempDir);
+  });
+
+  // AC: @spec-ac-delete-confirmation ac-1
+  it('should prompt for confirmation when removing AC without --force', () => {
+    // When user confirms
+    const result = kspec('item ac remove @ac-test-feature ac-1', tempDir, {
+      stdin: 'y',
+      env: { KSPEC_TEST_TTY: '1' } // Simulate TTY for testing
+    });
+
+    expect(result.stdout).toContain('Remove acceptance criterion ac-1? [y/N]');
+    expect(result.stdout).toContain('Removed acceptance criterion');
+    expect(result.exitCode).toBe(0);
+
+    // Verify AC was removed
+    const listResult = kspec('item ac list @ac-test-feature', tempDir);
+    expect(listResult.stdout).toContain('0 acceptance criteria');
+  });
+
+  // AC: @spec-ac-delete-confirmation ac-2
+  it('should remove AC when user confirms with y', () => {
+    const result = kspec('item ac remove @ac-test-feature ac-1', tempDir, {
+      stdin: 'y',
+      env: { KSPEC_TEST_TTY: '1' }
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('Removed acceptance criterion');
+
+    // Verify removal
+    const listResult = kspec('item ac list @ac-test-feature', tempDir);
+    expect(listResult.stdout).toContain('0 acceptance criteria');
+  });
+
+  // AC: @spec-ac-delete-confirmation ac-3
+  it('should cancel operation when user declines with n', () => {
+    const result = kspec('item ac remove @ac-test-feature ac-1', tempDir, {
+      stdin: 'n',
+      expectFail: true,
+      env: { KSPEC_TEST_TTY: '1' }
+    });
+
+    expect(result.exitCode).toBe(2); // USAGE_ERROR (user cancelled)
+    // Check both stdout and stderr for the message
+    const output = result.stdout + result.stderr;
+    expect(output).toContain('Operation cancelled');
+
+    // Verify AC still exists
+    const listResult = kspec('item ac list @ac-test-feature', tempDir);
+    expect(listResult.stdout).toContain('[ac-1]');
+  });
+
+  // AC: @spec-ac-delete-confirmation ac-3
+  it('should cancel operation when user enters empty response', () => {
+    const result = kspec('item ac remove @ac-test-feature ac-1', tempDir, {
+      stdin: '',
+      expectFail: true,
+      env: { KSPEC_TEST_TTY: '1' }
+    });
+
+    expect(result.exitCode).toBe(2); // USAGE_ERROR (user cancelled)
+    // Check both stdout and stderr for the message
+    const output = result.stdout + result.stderr;
+    expect(output).toContain('Operation cancelled');
+
+    // Verify AC still exists
+    const listResult = kspec('item ac list @ac-test-feature', tempDir);
+    expect(listResult.stdout).toContain('[ac-1]');
+  });
+
+  // AC: @spec-ac-delete-confirmation ac-4
+  it('should remove AC immediately with --force flag', () => {
+    const result = kspec('item ac remove @ac-test-feature ac-1 --force', tempDir);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('Removed acceptance criterion');
+    expect(result.stdout).not.toContain('Remove acceptance criterion ac-1? [y/N]');
+
+    // Verify removal
+    const listResult = kspec('item ac list @ac-test-feature', tempDir);
+    expect(listResult.stdout).toContain('0 acceptance criteria');
+  });
+
+  // AC: @spec-ac-delete-confirmation ac-5
+  it('should error in JSON mode without --force', () => {
+    const result = kspec('item ac remove @ac-test-feature ac-1 --json', tempDir, {
+      expectFail: true
+    });
+
+    expect(result.exitCode).toBe(1); // ERROR
+    // Check both stdout and stderr for the message
+    const output = result.stdout + result.stderr;
+    expect(output).toContain('Confirmation required. Use --force with --json');
+
+    // Verify AC still exists
+    const listResult = kspec('item ac list @ac-test-feature', tempDir);
+    expect(listResult.stdout).toContain('[ac-1]');
+  });
+
+  // AC: @spec-ac-delete-confirmation ac-6
+  it('should error in non-interactive environment without --force', () => {
+    // Don't provide KSPEC_TEST_TTY, stdin won't be a TTY
+    const result = kspec('item ac remove @ac-test-feature ac-1', tempDir, {
+      expectFail: true
+    });
+
+    expect(result.exitCode).toBe(1); // ERROR
+    // Check both stdout and stderr for the message
+    const output = result.stdout + result.stderr;
+    expect(output).toContain('Non-interactive environment. Use --force to proceed');
+
+    // Verify AC still exists
+    const listResult = kspec('item ac list @ac-test-feature', tempDir);
+    expect(listResult.stdout).toContain('[ac-1]');
+  });
+
+  // AC: @spec-ac-delete-confirmation ac-4
+  it('should work in non-interactive environment with --force', () => {
+    const result = kspec('item ac remove @ac-test-feature ac-1 --force', tempDir);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('Removed acceptance criterion');
+
+    // Verify removal
+    const listResult = kspec('item ac list @ac-test-feature', tempDir);
+    expect(listResult.stdout).toContain('0 acceptance criteria');
+  });
+});


### PR DESCRIPTION
## Summary

Implements confirmation prompt when removing acceptance criteria without the `--force` flag, with proper handling for JSON mode and non-interactive environments.

- Prompts user for confirmation in interactive mode (y/N)
- Requires `--force` flag in JSON mode or non-interactive environments
- Exit code 2 (USAGE_ERROR) when user cancels
- Exit code 1 (ERROR) for validation errors
- Added `KSPEC_TEST_TTY` environment variable for testing interactive prompts

## Changes

- **src/cli/commands/item.ts**: Added confirmation logic to `item ac remove` command
  - Checks for JSON mode without --force (AC-5)
  - Checks for non-interactive environment without --force (AC-6)
  - Prompts for confirmation in interactive mode (AC-1)
  - Accepts 'y' to proceed (AC-2)
  - Cancels on 'n' or empty with exit code 2 (AC-3)
  - Skips prompt with --force flag (AC-4)

- **tests/ac-delete-confirmation.test.ts**: Created comprehensive E2E test suite
  - 8 tests covering all 6 acceptance criteria
  - Tests for user confirmation, cancellation, --force flag
  - Tests for JSON mode and non-interactive environment errors
  - All tests properly annotated with AC references

## Test Coverage

All 6 acceptance criteria have E2E test coverage:
- ✅ AC-1: Prompt displayed in interactive mode
- ✅ AC-2: Proceeds when user confirms with 'y'
- ✅ AC-3: Cancels with exit code 2 when user declines
- ✅ AC-4: Skips prompt with --force flag
- ✅ AC-5: Errors in JSON mode without --force
- ✅ AC-6: Errors in non-interactive environment without --force

## Test Results

All 831 tests pass including 8 new AC-specific tests.

Task: @ac-delete-confirm
Spec: @spec-ac-delete-confirmation

🤖 Generated with [Claude Code](https://claude.ai/code)