### PR TITLE
ci: add npm publish workflow with trusted publishers

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,58 @@
+name: Publish to npm
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: 'Dry run (skip actual publish)'
+        required: false
+        default: 'false'
+        type: boolean
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write  # Required for npm trusted publishers (OIDC)
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Run tests
+        run: npm test
+
+      - name: Verify CLI
+        run: |
+          npm link
+          kspec --version
+
+      - name: Sync version from release tag
+        if: github.event_name == 'release'
+        run: |
+          VERSION="${{ github.event.release.tag_name }}"
+          # Strip leading 'v' if present
+          VERSION="${VERSION#v}"
+          npm version "$VERSION" --no-git-tag-version --allow-same-version
+
+      - name: Publish to npm
+        if: ${{ github.event.inputs.dry-run != 'true' }}
+        run: npm publish --access public
+        env:
+          NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
## Summary

- Add GitHub Actions workflow for npm publishing
- Uses OIDC authentication (`id-token: write`) for npm trusted publishers
- Triggers on GitHub release publish or manual workflow_dispatch
- Syncs version from release tag automatically
- Includes dry-run option for testing

## Setup after merge

1. First manual publish: `npm login && npm publish --access public`
2. Configure trusted publisher on npmjs.com:
   - Organization: `kynetic-ai`
   - Repository: `kynetic-spec`
   - Workflow: `publish.yml`
3. Future releases: Create GitHub release with tag `vX.Y.Z` → auto-publishes

## Test plan

- [ ] Workflow syntax is valid (GitHub validates on push)
- [ ] Manual trigger works with dry-run
- [ ] Release trigger publishes successfully (after trusted publisher configured)

Generated with [Claude Code](https://claude.ai/code)