### PR TITLE
fix: increase timeout for ref resolution test

### DIFF
--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -2088,7 +2088,7 @@ describe('Integration: Batch operations', () => {
   });
 
   // AC: @multi-ref-batch ac-8 - Ref resolution uses existing logic
-  it('should resolve refs using existing resolution logic (slugs, ULID prefixes)', () => {
+  it('should resolve refs using existing resolution logic (slugs, ULID prefixes)', { timeout: 15000 }, () => {
     // Create two tasks with slugs
     const task1 = kspecJson<{ task: { _ulid: string } }>(
       'task add --title "Slug Test 1" --slug test-slug-1 --priority 3',


### PR DESCRIPTION
## Summary

- Increase timeout for `should resolve refs using existing resolution logic` test from 5s (default) to 15s
- Test runs 14 kspec commands which can exceed 5s on slower CI runners

## Context

Publish workflow failed due to this test timeout: https://github.com/kynetic-ai/kynetic-spec/actions/runs/21228736964

Test passes locally in ~1.5s but CI runners can be slower.

## Test plan

- [x] Test passes locally
- [ ] CI passes after merge

Generated with [Claude Code](https://claude.ai/code)