### PR TITLE
fix: add environment for npm trusted publishers OIDC

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,7 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: "Publish Package"
     permissions:
       contents: write  # Required for pushing version back to main
       id-token: write  # Required for npm trusted publishers (OIDC)


### PR DESCRIPTION
## Summary

The publish workflow was failing because npm trusted publishers requires the OIDC token subject to match the configured trust policy. When the trust policy includes an environment constraint (e.g., "Publish Package"), the workflow must declare `environment: "Publish Package"` for the subject claim to match.

## Changes

Added `environment: "Publish Package"` to the publish job.

## Test plan

- [ ] After merge, re-run the release workflow for v0.1.1 to verify npm publish succeeds

🤖 Generated with [Claude Code](https://claude.ai/code)