### PR TITLE
fix: rename publish environment to avoid spaces

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    environment: "Publish Package"
+    environment: publish
     permissions:
       contents: write  # Required for pushing version back to main
       id-token: write  # Required for npm trusted publishers (OIDC)


### PR DESCRIPTION
## Summary

Rename the environment from `Publish Package` to `publish` to avoid potential OIDC subject claim encoding issues with spaces.

## Test plan

- [ ] Re-run v0.1.1 release after merge

🤖 Generated with [Claude Code](https://claude.ai/code)