### PR TITLE
fix: remove registry-url to allow OIDC trusted publisher auth

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,6 @@ jobs:
         with:
           node-version: '18'
           cache: 'npm'
-          registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
         run: npm ci
@@ -56,9 +55,7 @@ jobs:
 
       - name: Publish to npm
         if: ${{ github.event.inputs.dry-run != 'true' }}
-        run: npm publish --access public
-        env:
-          NPM_CONFIG_PROVENANCE: true
+        run: npm publish --provenance --access public
 
       - name: Commit version back to main
         if: github.event_name == 'release'


### PR DESCRIPTION
## Summary

`setup-node` with `registry-url` creates an `.npmrc` file expecting `NODE_AUTH_TOKEN`. This interferes with npm's OIDC-based trusted publisher authentication.

By removing `registry-url`, npm will use OIDC directly for trusted publisher auth.

## Changes

- Removed `registry-url` from setup-node step
- Changed publish command to use `--provenance` flag directly

## Test plan

- [ ] Verify v0.1.1 publishes successfully after merge

🤖 Generated with [Claude Code](https://claude.ai/code)