### PR TITLE
fix: remove environment from publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,6 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    environment: publish
     permissions:
       contents: write  # Required for pushing version back to main
       id-token: write  # Required for npm trusted publishers (OIDC)


### PR DESCRIPTION
Testing npm trusted publishers without environment constraint.