### PR TITLE
fix: install latest npm for trusted publishers

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,6 +30,9 @@ jobs:
           node-version: '22'
           cache: 'npm'
 
+      - name: Install latest npm
+        run: npm install -g npm@latest && npm --version
+
       - name: Install dependencies
         run: npm ci
 


### PR DESCRIPTION
Explicitly install npm@latest to get trusted publishers fixes.