### PR TITLE
fix: read CLI version from package.json instead of hardcoding

### DIFF
--- a/src/cli/commands/ralph.ts
+++ b/src/cli/commands/ralph.ts
@@ -11,6 +11,11 @@ import { ulid } from 'ulid';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import { spawn, spawnSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+
+// Read version from package.json for ACP client info
+const require = createRequire(import.meta.url);
+const { version: packageVersion } = require('../../../package.json');
 import { initContext } from '../../parser/index.js';
 import { error, info, success } from '../output.js';
 import { gatherSessionContext, type SessionContext } from './session.js';
@@ -414,7 +419,7 @@ export function registerRalphCommand(program: Command): void {
                     clientOptions: {
                       clientInfo: {
                         name: 'kspec-ralph',
-                        version: '0.1.0',
+                        version: packageVersion,
                       },
                     },
                   });

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -3,6 +3,12 @@
 import { Command } from 'commander';
 import chalk from 'chalk';
 import { realpathSync } from 'fs';
+import { createRequire } from 'node:module';
+
+// Read version from package.json at runtime
+// AC: @cli-version ac-2 - version automatically reflects package.json without code changes
+const require = createRequire(import.meta.url);
+const { version } = require('../../package.json');
 import { setJsonMode, setVerboseMode, getVerboseMode } from './output.js';
 import { setVerboseModeGetter } from '../parser/shadow.js';
 import { findClosestCommand, getAllCommands, COMMAND_ALIASES } from './suggest.js';
@@ -38,7 +44,7 @@ setVerboseModeGetter(getVerboseMode);
 program
   .name('kspec')
   .description('Kynetic Spec - Structured specification format CLI')
-  .version('0.1.0')
+  .version(version)
   .option('--json', 'Output in JSON format')
   .option('--debug-shadow', 'Enable debug output for shadow operations')
   .hook('preAction', (thisCommand) => {

--- a/tests/cli-version.test.ts
+++ b/tests/cli-version.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Tests for CLI version display
+ * Spec: @cli-version
+ */
+import { describe, it, expect } from 'vitest';
+import { execSync } from 'node:child_process';
+import * as path from 'node:path';
+import * as fs from 'node:fs';
+import { CLI_PATH } from './helpers/cli.js';
+
+// Read the actual version from package.json
+const packageJsonPath = path.join(__dirname, '..', 'package.json');
+const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
+const expectedVersion = packageJson.version;
+
+describe('CLI version display', () => {
+  // AC: @cli-version ac-1
+  it('should display version from package.json with --version flag', () => {
+    const result = execSync(`node ${CLI_PATH} --version`, {
+      encoding: 'utf-8',
+    }).trim();
+
+    expect(result).toBe(expectedVersion);
+  });
+
+  // AC: @cli-version ac-1
+  it('should display version from package.json with -V flag', () => {
+    const result = execSync(`node ${CLI_PATH} -V`, {
+      encoding: 'utf-8',
+    }).trim();
+
+    expect(result).toBe(expectedVersion);
+  });
+
+  // AC: @cli-version ac-2
+  // This test verifies the implementation reads from package.json dynamically.
+  // If the version were hardcoded, this test would fail when package.json changes.
+  it('should match the version in package.json (verifies dynamic reading)', () => {
+    const cliVersion = execSync(`node ${CLI_PATH} --version`, {
+      encoding: 'utf-8',
+    }).trim();
+
+    // Both should be the same - proves CLI reads from package.json
+    expect(cliVersion).toBe(expectedVersion);
+    // Verify we're not comparing against a hardcoded test value
+    expect(expectedVersion).toMatch(/^\d+\.\d+\.\d+/);
+  });
+});


### PR DESCRIPTION
## Summary

- Read CLI version from package.json at runtime using `createRequire`
- Removes hardcoded `'0.1.0'` that was out of sync with actual version (0.1.1)
- Also fixes ACP client info version in ralph command

## Test plan

- [x] `kspec --version` shows `0.1.1` (matches package.json)
- [x] `kspec -V` shows `0.1.1`
- [x] `npm run dev -- --version` shows `0.1.1`
- [x] All existing tests pass (848 tests)
- [x] New tests added for AC coverage

Task: @task-cli-version-display
Spec: @cli-version

🤖 Generated with [Claude Code](https://claude.ai/code)