### PR TITLE
chore: sync version to 0.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kynetic-ai/spec",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kynetic-ai/spec",
-      "version": "0.1.0",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kynetic-ai/spec",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Kynetic Spec - Structured specification format for human-AI collaboration",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

- Syncs package.json version with published npm package (v0.1.2)

The publish workflow couldn't push the version commit directly due to branch protection rules. This PR manually syncs the version.

## Test plan

- [x] Version in package.json matches git tag and npm package

🤖 Generated with [Claude Code](https://claude.ai/code)