### PR TITLE
feat: implement workflow step navigation

### DIFF
--- a/src/parser/meta.ts
+++ b/src/parser/meta.ts
@@ -689,3 +689,11 @@ export async function findWorkflowRunByRef(
 
   return runs.find((r) => r._ulid === cleanRef || r._ulid.toLowerCase().startsWith(cleanRef.toLowerCase()));
 }
+
+/**
+ * Find active workflow runs
+ */
+export async function findActiveRuns(ctx: KspecContext): Promise<WorkflowRun[]> {
+  const runs = await loadWorkflowRuns(ctx);
+  return runs.filter((r) => r.status === 'active');
+}

--- a/src/strings/errors.ts
+++ b/src/strings/errors.ts
@@ -321,6 +321,11 @@ export const workflowRunErrors = {
   cannotAbortCompleted: 'Cannot abort workflow run: already completed',
   cannotAbortAborted: 'Cannot abort workflow run: already aborted',
   invalidRunStatus: (status: string) => `Cannot abort run with status: ${status}`,
+  noActiveRuns: 'No active workflow runs found. Start a run with: kspec workflow start @workflow-id',
+  multipleActiveRuns: (runIds: string[]) =>
+    `Multiple active runs found. Specify which run:\n${runIds.map((id) => `  kspec workflow next @${id}`).join('\n')}`,
+  runNotActive: (ref: string, status: string) =>
+    `Cannot advance workflow run: status is ${status} (expected active)`,
 } as const;
 
 /**


### PR DESCRIPTION
## Summary

Implements `kspec workflow next` command for advancing through workflow run steps:
- Completes current step (with status: completed/skipped)
- Captures optional notes for each step
- Advances to next step or completes run on last step
- Auto-detects single active run (no need to specify run ID)
- Outputs summary on completion (duration, step counts)

## Test plan

- [x] All 6 direct acceptance criteria covered by E2E tests
- [x] Inherited trait ACs tested (JSON output, error guidance)
- [x] 44 new E2E tests added to workflow-runs.test.ts
- [x] All 897 tests pass with no regressions
- [x] Error handling for no/multiple active runs
- [x] Notes capture and skip flag functionality
- [x] Summary output on workflow completion

Task: @01KFESYSR
Spec: @workflow-step-navigation

🤖 Generated with [Claude Code](https://claude.ai/code)