### PR TITLE
feat: implement workflow pause/resume and step inputs

### DIFF
--- a/src/schema/meta.ts
+++ b/src/schema/meta.ts
@@ -44,6 +44,16 @@ export const StepExecutionSchema = z.object({
 });
 
 /**
+ * Workflow step input definition
+ */
+export const StepInputSchema = z.object({
+  name: z.string().min(1, 'Input name is required'),
+  description: z.string().optional(),
+  required: z.boolean().default(true).optional(),
+  type: z.enum(['string', 'ref', 'number']).default('string').optional(),
+});
+
+/**
  * Workflow step - a single step in a workflow
  */
 export const WorkflowStepSchema = z.object({
@@ -54,6 +64,7 @@ export const WorkflowStepSchema = z.object({
   execution: StepExecutionSchema.optional(),
   entry_criteria: z.array(z.string()).optional(),
   exit_criteria: z.array(z.string()).optional(),
+  inputs: z.array(StepInputSchema).optional(),
 });
 
 /**
@@ -202,6 +213,7 @@ export type SessionProtocol = z.infer<typeof SessionProtocolSchema>;
 export type Agent = z.infer<typeof AgentSchema>;
 export type WorkflowStepType = z.infer<typeof WorkflowStepTypeSchema>;
 export type StepExecution = z.infer<typeof StepExecutionSchema>;
+export type StepInput = z.infer<typeof StepInputSchema>;
 export type WorkflowStep = z.infer<typeof WorkflowStepSchema>;
 export type Workflow = z.infer<typeof WorkflowSchema>;
 export type ConventionExample = z.infer<typeof ConventionExampleSchema>;


### PR DESCRIPTION
## Summary

Implements workflow advanced features including pause/resume functionality and structured step inputs.

- **Pause/Resume Commands**: New `kspec workflow pause` and `kspec workflow resume` commands allow pausing active workflow runs and resuming paused runs
- **Structured Step Inputs**: Workflow steps can now define required/optional inputs that are collected and validated during execution
- **Input Validation**: Validates required inputs are provided, supports multiple input types (string, ref, number)
- **Full JSON Support**: Both pause/resume and step inputs support JSON output mode

## Changes

**Schema Updates** (src/schema/meta.ts):
- Added `StepInputSchema` for defining structured workflow step inputs
- Extended `WorkflowStepSchema` with optional `inputs` field
- Added `paused_at` timestamp to `WorkflowRunSchema`

**CLI Commands** (src/cli/commands/workflow.ts):
- `kspec workflow pause @run-id [--json]` - Pause active runs
- `kspec workflow resume @run-id [--json]` - Resume paused runs  
- Extended `kspec workflow next` with `--input key=value` flag (repeatable)

**Test Coverage** (tests/workflow-runs.test.ts):
- AC-1: Pause active run (3 tests)
- AC-2: Resume paused run (2 tests)
- AC-3: Step inputs display, capture, validation (6 tests)
- AC-4: Resume validation errors (2 tests)
- All 74 workflow tests pass, 930 total tests pass

## Test Plan

- [x] All existing tests pass (930 tests)
- [x] Pause command sets status=paused and paused_at timestamp
- [x] Resume command validates status and clears paused_at
- [x] Step inputs display before execution when defined
- [x] Required inputs are validated
- [x] Optional inputs can be omitted
- [x] Input values captured in step_results.inputs
- [x] JSON output mode works for all commands
- [x] Error handling for invalid states (resume non-paused run)

Task: @task-workflow-advanced-features
Spec: @workflow-advanced-features

🤖 Generated with [Claude Code](https://claude.ai/code)