### PR TITLE
feat: add --steps flag to kspec meta add workflow

### DIFF
--- a/src/strings/errors.ts
+++ b/src/strings/errors.ts
@@ -113,6 +113,12 @@ export const validationErrors = {
   workflowRequiresId: "Workflow requires --id",
   workflowRequiresTrigger: "Workflow requires --trigger",
   conventionRequiresDomain: "Convention requires --domain",
+
+  // Workflow steps validation
+  invalidStepsJson: (err: string) =>
+    `Invalid JSON in --steps${err ? `: ${err}` : ""}`,
+  stepsNotArray: "Steps must be a JSON array",
+  invalidStepsSchema: (issues: string) => `Invalid workflow steps: ${issues}`,
 } as const;
 
 /**


### PR DESCRIPTION
## Summary

- Add `--steps <json>` flag to `kspec meta add workflow` command
- Allow defining workflow steps at creation time instead of requiring manual YAML edits
- Validate JSON syntax, array type, and WorkflowStepSchema compliance
- Add clear error messages for invalid input

## Changes

- `src/strings/errors.ts` - 3 new validation error messages
- `src/cli/commands/meta.ts` - `--steps` option with JSON parsing and schema validation
- `tests/meta.test.ts` - 6 tests covering all 4 acceptance criteria

## Test plan

- [x] Valid multi-step workflow creation (AC-1)
- [x] Optional fields like `on_fail`, `entry_criteria` (AC-1)
- [x] Empty array allowed (AC-1)
- [x] Malformed JSON error (AC-2)
- [x] Non-array error (AC-3)
- [x] Invalid step type and missing content errors (AC-4)
- [x] All 118 meta tests pass

Task: @add-steps-flag-workflow
Spec: @meta-add-cmd

🤖 Generated with [Claude Code](https://claude.ai/code)