### PR TITLE
feat: add merge driver foundation with types and parsing

### DIFF
--- a/src/merge/index.ts
+++ b/src/merge/index.ts
@@ -1,0 +1,16 @@
+/**
+ * Semantic YAML merge driver for kspec files.
+ *
+ * Public API exports for the merge module.
+ */
+
+export type {
+  MergeResult,
+  ConflictInfo,
+  ConflictType,
+  MergeOptions,
+  ParsedVersions,
+  ParseResult,
+} from "./types.js";
+
+export { parseYamlVersions } from "./parse.js";

--- a/src/merge/parse.ts
+++ b/src/merge/parse.ts
@@ -1,0 +1,85 @@
+/**
+ * Parsing utilities for merge driver.
+ *
+ * Handles reading and parsing all three versions (base, ours, theirs)
+ * of a YAML file, with graceful fallback when parsing fails.
+ */
+
+import * as fs from "node:fs/promises";
+import { parseYaml } from "../parser/yaml.js";
+import type { ParseResult, ParsedVersions } from "./types.js";
+
+/**
+ * Parse all three versions of a YAML file.
+ *
+ * AC: @yaml-merge-driver ac-1
+ * Parses base, ours, and theirs as structured data instead of text.
+ *
+ * AC: @yaml-merge-driver ac-11
+ * Returns parse failure if any file cannot be parsed.
+ *
+ * @param basePath Path to base version (common ancestor)
+ * @param oursPath Path to ours version (current branch)
+ * @param theirsPath Path to theirs version (incoming branch)
+ * @returns ParseResult with parsed versions or error
+ */
+export async function parseYamlVersions(
+  basePath: string,
+  oursPath: string,
+  theirsPath: string,
+): Promise<ParseResult> {
+  try {
+    // Read all three files
+    const [baseContent, oursContent, theirsContent] = await Promise.all([
+      fs.readFile(basePath, "utf-8"),
+      fs.readFile(oursPath, "utf-8"),
+      fs.readFile(theirsPath, "utf-8"),
+    ]);
+
+    // Parse all three versions
+    let base: unknown;
+    let ours: unknown;
+    let theirs: unknown;
+
+    try {
+      base = parseYaml(baseContent);
+    } catch (err) {
+      return {
+        success: false,
+        error: `Failed to parse base: ${err instanceof Error ? err.message : String(err)}`,
+        failedFile: "base",
+      };
+    }
+
+    try {
+      ours = parseYaml(oursContent);
+    } catch (err) {
+      return {
+        success: false,
+        error: `Failed to parse ours: ${err instanceof Error ? err.message : String(err)}`,
+        failedFile: "ours",
+      };
+    }
+
+    try {
+      theirs = parseYaml(theirsContent);
+    } catch (err) {
+      return {
+        success: false,
+        error: `Failed to parse theirs: ${err instanceof Error ? err.message : String(err)}`,
+        failedFile: "theirs",
+      };
+    }
+
+    return {
+      success: true,
+      versions: { base, ours, theirs },
+    };
+  } catch (err) {
+    // File read error
+    return {
+      success: false,
+      error: `Failed to read files: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+}

--- a/src/merge/types.ts
+++ b/src/merge/types.ts
@@ -1,0 +1,90 @@
+/**
+ * Types for semantic YAML merge driver.
+ *
+ * The merge driver parses kspec YAML files and merges them semantically,
+ * understanding the structure of tasks, items, and other entities.
+ */
+
+/**
+ * Result of a merge operation
+ */
+export interface MergeResult {
+  /** The merged YAML content */
+  content: string;
+  /** Whether conflicts were detected */
+  hasConflicts: boolean;
+  /** Conflict information (empty if no conflicts) */
+  conflicts: ConflictInfo[];
+  /** Whether parsing failed (triggers fallback) */
+  parseFailed: boolean;
+  /** Error message if parse failed */
+  parseError?: string;
+}
+
+/**
+ * Information about a conflict that requires resolution
+ */
+export interface ConflictInfo {
+  /** Type of conflict */
+  type: ConflictType;
+  /** Path to the conflicting field (e.g., "tasks[0].title") */
+  path: string;
+  /** ULID of the item with conflict (if applicable) */
+  ulid?: string;
+  /** Value from "ours" branch */
+  oursValue: unknown;
+  /** Value from "theirs" branch */
+  theirsValue: unknown;
+  /** Description of the conflict */
+  description: string;
+}
+
+/**
+ * Types of conflicts that can occur during merge
+ */
+export type ConflictType =
+  | "scalar_field" // Both sides modified same scalar field
+  | "delete_modify" // One side deleted, other modified
+  | "nested_conflict"; // Conflict in nested object
+
+/**
+ * Options for merge operations
+ */
+export interface MergeOptions {
+  /** Whether to run in non-interactive mode (no prompts) */
+  nonInteractive?: boolean;
+  /** Output file path for merged result */
+  outputPath: string;
+  /** Path to "base" version (common ancestor) */
+  basePath: string;
+  /** Path to "ours" version (current branch) */
+  oursPath: string;
+  /** Path to "theirs" version (incoming branch) */
+  theirsPath: string;
+}
+
+/**
+ * Parsed versions of a file for merging
+ */
+export interface ParsedVersions {
+  /** Common ancestor version */
+  base: unknown;
+  /** Current branch version */
+  ours: unknown;
+  /** Incoming branch version */
+  theirs: unknown;
+}
+
+/**
+ * Result of parsing all three versions
+ */
+export interface ParseResult {
+  /** Whether parsing succeeded */
+  success: boolean;
+  /** Parsed versions (undefined if parse failed) */
+  versions?: ParsedVersions;
+  /** Error message if parse failed */
+  error?: string;
+  /** Which file failed to parse (if applicable) */
+  failedFile?: "base" | "ours" | "theirs";
+}

--- a/tests/merge-parse.test.ts
+++ b/tests/merge-parse.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Tests for merge driver parsing functionality.
+ */
+
+import { describe, expect, it } from "vitest";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { parseYamlVersions } from "../src/merge/parse.js";
+import { createTempDir, cleanupTempDir } from "./helpers/cli.js";
+
+describe("parseYamlVersions", () => {
+  it("should parse all three versions successfully", async () => {
+    // AC: @yaml-merge-driver ac-1
+    const tempDir = await createTempDir();
+    try {
+      // Create three valid YAML files
+      const base = path.join(tempDir, "base.yaml");
+      const ours = path.join(tempDir, "ours.yaml");
+      const theirs = path.join(tempDir, "theirs.yaml");
+
+      await fs.writeFile(base, "version: '1.0'\ndata: base");
+      await fs.writeFile(ours, "version: '1.0'\ndata: ours");
+      await fs.writeFile(theirs, "version: '1.0'\ndata: theirs");
+
+      const result = await parseYamlVersions(base, ours, theirs);
+
+      expect(result.success).toBe(true);
+      expect(result.versions).toBeDefined();
+      expect(result.versions?.base).toEqual({ version: "1.0", data: "base" });
+      expect(result.versions?.ours).toEqual({ version: "1.0", data: "ours" });
+      expect(result.versions?.theirs).toEqual({
+        version: "1.0",
+        data: "theirs",
+      });
+    } finally {
+      await cleanupTempDir(tempDir);
+    }
+  });
+
+  it("should return error when base file fails to parse", async () => {
+    // AC: @yaml-merge-driver ac-11
+    const tempDir = await createTempDir();
+    try {
+      const base = path.join(tempDir, "base.yaml");
+      const ours = path.join(tempDir, "ours.yaml");
+      const theirs = path.join(tempDir, "theirs.yaml");
+
+      // Invalid YAML in base
+      await fs.writeFile(base, "invalid: yaml: content: [");
+      await fs.writeFile(ours, "version: '1.0'");
+      await fs.writeFile(theirs, "version: '1.0'");
+
+      const result = await parseYamlVersions(base, ours, theirs);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Failed to parse base");
+      expect(result.failedFile).toBe("base");
+      expect(result.versions).toBeUndefined();
+    } finally {
+      await cleanupTempDir(tempDir);
+    }
+  });
+
+  it("should return error when ours file fails to parse", async () => {
+    // AC: @yaml-merge-driver ac-11
+    const tempDir = await createTempDir();
+    try {
+      const base = path.join(tempDir, "base.yaml");
+      const ours = path.join(tempDir, "ours.yaml");
+      const theirs = path.join(tempDir, "theirs.yaml");
+
+      await fs.writeFile(base, "version: '1.0'");
+      // Invalid YAML in ours
+      await fs.writeFile(ours, "invalid: yaml: content: [");
+      await fs.writeFile(theirs, "version: '1.0'");
+
+      const result = await parseYamlVersions(base, ours, theirs);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Failed to parse ours");
+      expect(result.failedFile).toBe("ours");
+      expect(result.versions).toBeUndefined();
+    } finally {
+      await cleanupTempDir(tempDir);
+    }
+  });
+
+  it("should return error when theirs file fails to parse", async () => {
+    // AC: @yaml-merge-driver ac-11
+    const tempDir = await createTempDir();
+    try {
+      const base = path.join(tempDir, "base.yaml");
+      const ours = path.join(tempDir, "ours.yaml");
+      const theirs = path.join(tempDir, "theirs.yaml");
+
+      await fs.writeFile(base, "version: '1.0'");
+      await fs.writeFile(ours, "version: '1.0'");
+      // Invalid YAML in theirs
+      await fs.writeFile(theirs, "invalid: yaml: content: [");
+
+      const result = await parseYamlVersions(base, ours, theirs);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Failed to parse theirs");
+      expect(result.failedFile).toBe("theirs");
+      expect(result.versions).toBeUndefined();
+    } finally {
+      await cleanupTempDir(tempDir);
+    }
+  });
+
+  it("should return error when file cannot be read", async () => {
+    // AC: @yaml-merge-driver ac-11
+    const tempDir = await createTempDir();
+    try {
+      const base = path.join(tempDir, "nonexistent-base.yaml");
+      const ours = path.join(tempDir, "ours.yaml");
+      const theirs = path.join(tempDir, "theirs.yaml");
+
+      await fs.writeFile(ours, "version: '1.0'");
+      await fs.writeFile(theirs, "version: '1.0'");
+
+      const result = await parseYamlVersions(base, ours, theirs);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Failed to read files");
+      expect(result.versions).toBeUndefined();
+    } finally {
+      await cleanupTempDir(tempDir);
+    }
+  });
+
+  it("should parse complex kspec task file structures", async () => {
+    // AC: @yaml-merge-driver ac-1
+    const tempDir = await createTempDir();
+    try {
+      const base = path.join(tempDir, "base.yaml");
+      const ours = path.join(tempDir, "ours.yaml");
+      const theirs = path.join(tempDir, "theirs.yaml");
+
+      const taskContent = `tasks:
+  - _ulid: 01TASK0000000000000000000
+    title: Example task
+    type: task
+    status: pending
+    priority: 2
+    tags: []
+    notes: []
+`;
+
+      await fs.writeFile(base, taskContent);
+      await fs.writeFile(ours, taskContent);
+      await fs.writeFile(theirs, taskContent);
+
+      const result = await parseYamlVersions(base, ours, theirs);
+
+      expect(result.success).toBe(true);
+      expect(result.versions).toBeDefined();
+      expect(result.versions?.base).toHaveProperty("tasks");
+      expect(result.versions?.ours).toHaveProperty("tasks");
+      expect(result.versions?.theirs).toHaveProperty("tasks");
+    } finally {
+      await cleanupTempDir(tempDir);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Created merge module foundation for semantic YAML merge driver
- Implemented core types: `MergeResult`, `ConflictInfo`, `MergeOptions`, `ParseResult`
- Added `parseYamlVersions()` function with graceful error handling for all three versions (base, ours, theirs)
- Comprehensive test coverage: 6 tests covering successful parsing and error scenarios

## Acceptance Criteria Covered

- **AC ac-1**: parseYamlVersions() parses all three versions (base, ours, theirs) as structured data
- **AC ac-11**: Returns ParseResult with success=false when parsing fails, includes error details and which file failed

## Test Plan

- [x] All existing tests pass (962 tests)
- [x] New merge-parse.test.ts added with 6 tests
- [x] Tests cover successful parsing of all three versions
- [x] Tests cover error cases for each file (base, ours, theirs)
- [x] Tests cover file read errors
- [x] Tests handle complex kspec task file structures
- [x] TypeScript compilation succeeds with no errors

Task: @01KFM7FQ
Spec: @yaml-merge-driver

🤖 Generated with [Claude Code](https://claude.com/claude-code)