### PR TITLE
feat: implement object merge algorithms for semantic YAML merge

### DIFF
--- a/src/merge/index.ts
+++ b/src/merge/index.ts
@@ -20,3 +20,6 @@ export {
   mergeSetArray,
   detectDeletion,
 } from "./arrays.js";
+
+export { mergeObjects } from "./objects.js";
+export type { ObjectMergeResult } from "./objects.js";

--- a/src/merge/objects.ts
+++ b/src/merge/objects.ts
@@ -1,0 +1,225 @@
+/**
+ * Object merging algorithms for semantic YAML merge.
+ *
+ * Handles field-level merging of objects, recursively merging nested structures
+ * and detecting conflicts when both sides modify the same scalar field.
+ */
+
+import type { ConflictInfo } from "./types.js";
+
+/**
+ * Result of merging two objects
+ */
+export interface ObjectMergeResult {
+  /** The merged object */
+  merged: Record<string, unknown>;
+  /** Conflicts detected during merge */
+  conflicts: ConflictInfo[];
+}
+
+/**
+ * Check if a value is a plain object (not an array, null, or other type)
+ */
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value) &&
+    Object.getPrototypeOf(value) === Object.prototype
+  );
+}
+
+/**
+ * Merge two objects field by field, recursively handling nested objects.
+ *
+ * AC: @yaml-merge-driver ac-3
+ * When both versions modify different fields of the same item, fields are merged.
+ *
+ * AC: @yaml-merge-driver ac-7
+ * Nested objects are merged recursively at field level.
+ *
+ * Strategy:
+ * 1. Collect all keys from base, ours, and theirs
+ * 2. For each key, determine what happened:
+ *    - Added in ours only → include ours value
+ *    - Added in theirs only → include theirs value
+ *    - Added in both (not in base) → conflict if different
+ *    - Modified in ours only → include ours value
+ *    - Modified in theirs only → include theirs value
+ *    - Modified in both → recurse if objects, else conflict
+ *    - Deleted in ours, kept in theirs → include theirs value
+ *    - Deleted in theirs, kept in ours → include ours value
+ *    - Deleted in both → omit from result
+ *
+ * @param base Object from common ancestor
+ * @param ours Object from current branch
+ * @param theirs Object from incoming branch
+ * @param path Path to this object (for conflict reporting)
+ * @returns Merged object and any conflicts detected
+ */
+export function mergeObjects(
+  base: Record<string, unknown> | undefined,
+  ours: Record<string, unknown> | undefined,
+  theirs: Record<string, unknown> | undefined,
+  path = "",
+): ObjectMergeResult {
+  const baseObj = base ?? {};
+  const oursObj = ours ?? {};
+  const theirsObj = theirs ?? {};
+
+  const merged: Record<string, unknown> = {};
+  const conflicts: ConflictInfo[] = [];
+
+  // Collect all keys from all three versions
+  const allKeys = new Set([
+    ...Object.keys(baseObj),
+    ...Object.keys(oursObj),
+    ...Object.keys(theirsObj),
+  ]);
+
+  for (const key of allKeys) {
+    const fieldPath = path ? `${path}.${key}` : key;
+    const inBase = key in baseObj;
+    const inOurs = key in oursObj;
+    const inTheirs = key in theirsObj;
+
+    const baseVal = baseObj[key];
+    const oursVal = oursObj[key];
+    const theirsVal = theirsObj[key];
+
+    // Case 1: Field only in ours (added in ours)
+    if (!inBase && inOurs && !inTheirs) {
+      merged[key] = oursVal;
+      continue;
+    }
+
+    // Case 2: Field only in theirs (added in theirs)
+    if (!inBase && !inOurs && inTheirs) {
+      merged[key] = theirsVal;
+      continue;
+    }
+
+    // Case 3: Field added in both (not in base)
+    if (!inBase && inOurs && inTheirs) {
+      if (valuesEqual(oursVal, theirsVal)) {
+        // Same value added in both - no conflict
+        merged[key] = oursVal;
+      } else if (isPlainObject(oursVal) && isPlainObject(theirsVal)) {
+        // Both added nested objects - try to merge them
+        const result = mergeObjects(undefined, oursVal, theirsVal, fieldPath);
+        merged[key] = result.merged;
+        conflicts.push(...result.conflicts);
+      } else {
+        // Different values added - conflict
+        conflicts.push({
+          type: "scalar_field",
+          path: fieldPath,
+          oursValue: oursVal,
+          theirsValue: theirsVal,
+          description: `Field "${key}" added with different values in both branches`,
+        });
+        // Default to ours for now (will be resolved interactively)
+        merged[key] = oursVal;
+      }
+      continue;
+    }
+
+    // Case 4: Field deleted in ours, kept/modified in theirs
+    if (inBase && !inOurs && inTheirs) {
+      // Deletion in ours, but theirs kept it - include theirs value
+      merged[key] = theirsVal;
+      continue;
+    }
+
+    // Case 5: Field deleted in theirs, kept/modified in ours
+    if (inBase && inOurs && !inTheirs) {
+      // Deletion in theirs, but ours kept it - include ours value
+      merged[key] = oursVal;
+      continue;
+    }
+
+    // Case 6: Field deleted in both
+    if (inBase && !inOurs && !inTheirs) {
+      // Both deleted - omit from result
+      continue;
+    }
+
+    // Case 7: Field exists in all three versions
+    if (inBase && inOurs && inTheirs) {
+      // Check if modified in ours
+      const modifiedInOurs = !valuesEqual(baseVal, oursVal);
+      // Check if modified in theirs
+      const modifiedInTheirs = !valuesEqual(baseVal, theirsVal);
+
+      if (!modifiedInOurs && !modifiedInTheirs) {
+        // No changes in either - keep base value
+        merged[key] = baseVal;
+      } else if (modifiedInOurs && !modifiedInTheirs) {
+        // Only modified in ours - take ours
+        merged[key] = oursVal;
+      } else if (!modifiedInOurs && modifiedInTheirs) {
+        // Only modified in theirs - take theirs
+        merged[key] = theirsVal;
+      } else {
+        // Modified in both - need to check for conflicts
+        if (valuesEqual(oursVal, theirsVal)) {
+          // Same modification in both - no conflict
+          merged[key] = oursVal;
+        } else if (isPlainObject(oursVal) && isPlainObject(theirsVal)) {
+          // Both modified nested objects - recurse
+          const result = mergeObjects(
+            isPlainObject(baseVal) ? baseVal : undefined,
+            oursVal,
+            theirsVal,
+            fieldPath,
+          );
+          merged[key] = result.merged;
+          conflicts.push(...result.conflicts);
+        } else {
+          // Both modified scalar field with different values - conflict
+          conflicts.push({
+            type: "scalar_field",
+            path: fieldPath,
+            oursValue: oursVal,
+            theirsValue: theirsVal,
+            description: `Field "${key}" modified with different values in both branches`,
+          });
+          // Default to ours for now (will be resolved interactively)
+          merged[key] = oursVal;
+        }
+      }
+      continue;
+    }
+  }
+
+  return { merged, conflicts };
+}
+
+/**
+ * Compare two values for equality.
+ * Handles primitives, arrays, and objects.
+ */
+function valuesEqual(a: unknown, b: unknown): boolean {
+  // Handle primitives
+  if (a === b) return true;
+
+  // Handle null/undefined
+  if (a == null || b == null) return a === b;
+
+  // Handle arrays
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) return false;
+    return a.every((val, idx) => valuesEqual(val, b[idx]));
+  }
+
+  // Handle objects
+  if (isPlainObject(a) && isPlainObject(b)) {
+    const aKeys = Object.keys(a);
+    const bKeys = Object.keys(b);
+    if (aKeys.length !== bKeys.length) return false;
+    return aKeys.every((key) => valuesEqual(a[key], b[key]));
+  }
+
+  // Different types or values
+  return false;
+}

--- a/tests/merge-objects.test.ts
+++ b/tests/merge-objects.test.ts
@@ -1,0 +1,539 @@
+/**
+ * Tests for object merging algorithms
+ */
+
+import { describe, expect, it } from "vitest";
+import { mergeObjects } from "../src/merge/objects.js";
+
+describe("mergeObjects", () => {
+  describe("field additions", () => {
+    it("should include field added only in ours", () => {
+      // AC: @yaml-merge-driver ac-3
+      const base = { a: 1 };
+      const ours = { a: 1, b: 2 };
+      const theirs = { a: 1 };
+
+      const result = mergeObjects(base, ours, theirs);
+
+      expect(result.merged).toEqual({ a: 1, b: 2 });
+      expect(result.conflicts).toHaveLength(0);
+    });
+
+    it("should include field added only in theirs", () => {
+      // AC: @yaml-merge-driver ac-3
+      const base = { a: 1 };
+      const ours = { a: 1 };
+      const theirs = { a: 1, c: 3 };
+
+      const result = mergeObjects(base, ours, theirs);
+
+      expect(result.merged).toEqual({ a: 1, c: 3 });
+      expect(result.conflicts).toHaveLength(0);
+    });
+
+    it("should include fields added in both branches", () => {
+      // AC: @yaml-merge-driver ac-3
+      const base = { a: 1 };
+      const ours = { a: 1, b: 2 };
+      const theirs = { a: 1, c: 3 };
+
+      const result = mergeObjects(base, ours, theirs);
+
+      expect(result.merged).toEqual({ a: 1, b: 2, c: 3 });
+      expect(result.conflicts).toHaveLength(0);
+    });
+
+    it("should not conflict when same field added with same value in both", () => {
+      // AC: @yaml-merge-driver ac-3
+      const base = { a: 1 };
+      const ours = { a: 1, b: 2 };
+      const theirs = { a: 1, b: 2 };
+
+      const result = mergeObjects(base, ours, theirs);
+
+      expect(result.merged).toEqual({ a: 1, b: 2 });
+      expect(result.conflicts).toHaveLength(0);
+    });
+
+    it("should conflict when same field added with different values in both", () => {
+      // AC: @yaml-merge-driver ac-3
+      const base = { a: 1 };
+      const ours = { a: 1, b: 2 };
+      const theirs = { a: 1, b: 3 };
+
+      const result = mergeObjects(base, ours, theirs);
+
+      expect(result.merged).toEqual({ a: 1, b: 2 }); // Default to ours
+      expect(result.conflicts).toHaveLength(1);
+      expect(result.conflicts[0]).toMatchObject({
+        type: "scalar_field",
+        path: "b",
+        oursValue: 2,
+        theirsValue: 3,
+      });
+    });
+  });
+
+  describe("field modifications", () => {
+    it("should take ours when only ours modified", () => {
+      // AC: @yaml-merge-driver ac-3
+      const base = { a: 1, b: 2 };
+      const ours = { a: 1, b: 3 };
+      const theirs = { a: 1, b: 2 };
+
+      const result = mergeObjects(base, ours, theirs);
+
+      expect(result.merged).toEqual({ a: 1, b: 3 });
+      expect(result.conflicts).toHaveLength(0);
+    });
+
+    it("should take theirs when only theirs modified", () => {
+      // AC: @yaml-merge-driver ac-3
+      const base = { a: 1, b: 2 };
+      const ours = { a: 1, b: 2 };
+      const theirs = { a: 1, b: 4 };
+
+      const result = mergeObjects(base, ours, theirs);
+
+      expect(result.merged).toEqual({ a: 1, b: 4 });
+      expect(result.conflicts).toHaveLength(0);
+    });
+
+    it("should merge when both sides modify different fields", () => {
+      // AC: @yaml-merge-driver ac-3
+      const base = { a: 1, b: 2, c: 3 };
+      const ours = { a: 10, b: 2, c: 3 };
+      const theirs = { a: 1, b: 20, c: 3 };
+
+      const result = mergeObjects(base, ours, theirs);
+
+      expect(result.merged).toEqual({ a: 10, b: 20, c: 3 });
+      expect(result.conflicts).toHaveLength(0);
+    });
+
+    it("should not conflict when both sides make same modification", () => {
+      // AC: @yaml-merge-driver ac-3
+      const base = { a: 1, b: 2 };
+      const ours = { a: 1, b: 3 };
+      const theirs = { a: 1, b: 3 };
+
+      const result = mergeObjects(base, ours, theirs);
+
+      expect(result.merged).toEqual({ a: 1, b: 3 });
+      expect(result.conflicts).toHaveLength(0);
+    });
+
+    it("should conflict when both sides modify same field with different values", () => {
+      // AC: @yaml-merge-driver ac-3
+      const base = { a: 1, b: 2 };
+      const ours = { a: 1, b: 3 };
+      const theirs = { a: 1, b: 4 };
+
+      const result = mergeObjects(base, ours, theirs);
+
+      expect(result.merged).toEqual({ a: 1, b: 3 }); // Default to ours
+      expect(result.conflicts).toHaveLength(1);
+      expect(result.conflicts[0]).toMatchObject({
+        type: "scalar_field",
+        path: "b",
+        oursValue: 3,
+        theirsValue: 4,
+      });
+    });
+  });
+
+  describe("field deletions", () => {
+    it("should omit field deleted in ours when theirs also deleted it", () => {
+      // AC: @yaml-merge-driver ac-3
+      const base = { a: 1, b: 2 };
+      const ours = { a: 1 };
+      const theirs = { a: 1 };
+
+      const result = mergeObjects(base, ours, theirs);
+
+      expect(result.merged).toEqual({ a: 1 });
+      expect(result.conflicts).toHaveLength(0);
+    });
+
+    it("should include field from theirs when deleted in ours but kept in theirs", () => {
+      // AC: @yaml-merge-driver ac-3
+      const base = { a: 1, b: 2 };
+      const ours = { a: 1 };
+      const theirs = { a: 1, b: 2 };
+
+      const result = mergeObjects(base, ours, theirs);
+
+      expect(result.merged).toEqual({ a: 1, b: 2 });
+      expect(result.conflicts).toHaveLength(0);
+    });
+
+    it("should include field from ours when deleted in theirs but kept in ours", () => {
+      // AC: @yaml-merge-driver ac-3
+      const base = { a: 1, b: 2 };
+      const ours = { a: 1, b: 2 };
+      const theirs = { a: 1 };
+
+      const result = mergeObjects(base, ours, theirs);
+
+      expect(result.merged).toEqual({ a: 1, b: 2 });
+      expect(result.conflicts).toHaveLength(0);
+    });
+
+    it("should include theirs value when field deleted in ours but modified in theirs", () => {
+      // AC: @yaml-merge-driver ac-3
+      const base = { a: 1, b: 2 };
+      const ours = { a: 1 };
+      const theirs = { a: 1, b: 3 };
+
+      const result = mergeObjects(base, ours, theirs);
+
+      expect(result.merged).toEqual({ a: 1, b: 3 });
+      expect(result.conflicts).toHaveLength(0);
+    });
+
+    it("should include ours value when field deleted in theirs but modified in ours", () => {
+      // AC: @yaml-merge-driver ac-3
+      const base = { a: 1, b: 2 };
+      const ours = { a: 1, b: 3 };
+      const theirs = { a: 1 };
+
+      const result = mergeObjects(base, ours, theirs);
+
+      expect(result.merged).toEqual({ a: 1, b: 3 });
+      expect(result.conflicts).toHaveLength(0);
+    });
+  });
+
+  describe("nested objects", () => {
+    it("should recursively merge nested objects when both sides modify different fields", () => {
+      // AC: @yaml-merge-driver ac-7
+      const base = {
+        task: {
+          title: "Task",
+          priority: 1,
+          status: "pending",
+        },
+      };
+
+      const ours = {
+        task: {
+          title: "Updated Task",
+          priority: 1,
+          status: "pending",
+        },
+      };
+
+      const theirs = {
+        task: {
+          title: "Task",
+          priority: 2,
+          status: "pending",
+        },
+      };
+
+      const result = mergeObjects(base, ours, theirs);
+
+      expect(result.merged).toEqual({
+        task: {
+          title: "Updated Task",
+          priority: 2,
+          status: "pending",
+        },
+      });
+      expect(result.conflicts).toHaveLength(0);
+    });
+
+    it("should detect conflicts in nested objects", () => {
+      // AC: @yaml-merge-driver ac-7
+      const base = {
+        task: {
+          title: "Task",
+          priority: 1,
+        },
+      };
+
+      const ours = {
+        task: {
+          title: "Task from ours",
+          priority: 1,
+        },
+      };
+
+      const theirs = {
+        task: {
+          title: "Task from theirs",
+          priority: 1,
+        },
+      };
+
+      const result = mergeObjects(base, ours, theirs);
+
+      expect(result.merged).toEqual({
+        task: {
+          title: "Task from ours", // Default to ours
+          priority: 1,
+        },
+      });
+      expect(result.conflicts).toHaveLength(1);
+      expect(result.conflicts[0]).toMatchObject({
+        type: "scalar_field",
+        path: "task.title",
+        oursValue: "Task from ours",
+        theirsValue: "Task from theirs",
+      });
+    });
+
+    it("should handle deeply nested objects", () => {
+      // AC: @yaml-merge-driver ac-7
+      const base = {
+        metadata: {
+          traceability: {
+            origin: "manual",
+            created_at: "2024-01-01",
+          },
+        },
+      };
+
+      const ours = {
+        metadata: {
+          traceability: {
+            origin: "manual",
+            created_at: "2024-01-01",
+            updated_at: "2024-01-02",
+          },
+        },
+      };
+
+      const theirs = {
+        metadata: {
+          traceability: {
+            origin: "manual",
+            created_at: "2024-01-01",
+            updated_by: "user",
+          },
+        },
+      };
+
+      const result = mergeObjects(base, ours, theirs);
+
+      expect(result.merged).toEqual({
+        metadata: {
+          traceability: {
+            origin: "manual",
+            created_at: "2024-01-01",
+            updated_at: "2024-01-02",
+            updated_by: "user",
+          },
+        },
+      });
+      expect(result.conflicts).toHaveLength(0);
+    });
+
+    it("should merge nested objects added in both branches", () => {
+      // AC: @yaml-merge-driver ac-7
+      const base = { a: 1 };
+
+      const ours = {
+        a: 1,
+        nested: {
+          b: 2,
+        },
+      };
+
+      const theirs = {
+        a: 1,
+        nested: {
+          c: 3,
+        },
+      };
+
+      const result = mergeObjects(base, ours, theirs);
+
+      expect(result.merged).toEqual({
+        a: 1,
+        nested: {
+          b: 2,
+          c: 3,
+        },
+      });
+      expect(result.conflicts).toHaveLength(0);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should handle undefined base", () => {
+      // AC: @yaml-merge-driver ac-3
+      const ours = { a: 1, b: 2 };
+      const theirs = { a: 1, c: 3 };
+
+      const result = mergeObjects(undefined, ours, theirs);
+
+      expect(result.merged).toEqual({ a: 1, b: 2, c: 3 });
+      expect(result.conflicts).toHaveLength(0);
+    });
+
+    it("should handle undefined ours", () => {
+      // AC: @yaml-merge-driver ac-3
+      const base = { a: 1 };
+      const theirs = { a: 1, b: 2 };
+
+      const result = mergeObjects(base, undefined, theirs);
+
+      expect(result.merged).toEqual({ a: 1, b: 2 });
+      expect(result.conflicts).toHaveLength(0);
+    });
+
+    it("should handle undefined theirs", () => {
+      // AC: @yaml-merge-driver ac-3
+      const base = { a: 1 };
+      const ours = { a: 1, b: 2 };
+
+      const result = mergeObjects(base, ours, undefined);
+
+      expect(result.merged).toEqual({ a: 1, b: 2 });
+      expect(result.conflicts).toHaveLength(0);
+    });
+
+    it("should handle all undefined", () => {
+      // AC: @yaml-merge-driver ac-3
+      const result = mergeObjects(undefined, undefined, undefined);
+
+      expect(result.merged).toEqual({});
+      expect(result.conflicts).toHaveLength(0);
+    });
+
+    it("should handle empty objects", () => {
+      // AC: @yaml-merge-driver ac-3
+      const base = {};
+      const ours = {};
+      const theirs = {};
+
+      const result = mergeObjects(base, ours, theirs);
+
+      expect(result.merged).toEqual({});
+      expect(result.conflicts).toHaveLength(0);
+    });
+
+    it("should handle arrays in object values (treat as opaque values)", () => {
+      // AC: @yaml-merge-driver ac-3
+      // Arrays are handled separately by mergeUlidArrays/mergeSetArray
+      const base = { tags: ["a", "b"] };
+      const ours = { tags: ["a", "b", "c"] };
+      const theirs = { tags: ["a", "b"] };
+
+      const result = mergeObjects(base, ours, theirs);
+
+      // Array modified only in ours, so take ours value
+      expect(result.merged).toEqual({ tags: ["a", "b", "c"] });
+      expect(result.conflicts).toHaveLength(0);
+    });
+
+    it("should conflict when arrays differ in both branches", () => {
+      // AC: @yaml-merge-driver ac-3
+      const base = { tags: ["a"] };
+      const ours = { tags: ["a", "b"] };
+      const theirs = { tags: ["a", "c"] };
+
+      const result = mergeObjects(base, ours, theirs);
+
+      expect(result.merged).toEqual({ tags: ["a", "b"] }); // Default to ours
+      expect(result.conflicts).toHaveLength(1);
+      expect(result.conflicts[0]).toMatchObject({
+        type: "scalar_field",
+        path: "tags",
+      });
+    });
+  });
+
+  describe("complex scenarios", () => {
+    it("should handle multiple modifications and additions across branches", () => {
+      // AC: @yaml-merge-driver ac-3, ac-7
+      const base = {
+        title: "Original",
+        priority: 1,
+        metadata: {
+          created_at: "2024-01-01",
+        },
+      };
+
+      const ours = {
+        title: "Updated in ours",
+        priority: 2,
+        status: "in_progress",
+        metadata: {
+          created_at: "2024-01-01",
+          updated_at: "2024-01-02",
+        },
+      };
+
+      const theirs = {
+        title: "Original",
+        priority: 1,
+        tags: ["bug"],
+        metadata: {
+          created_at: "2024-01-01",
+          author: "user",
+        },
+      };
+
+      const result = mergeObjects(base, ours, theirs);
+
+      expect(result.merged).toEqual({
+        title: "Updated in ours",
+        priority: 2,
+        status: "in_progress",
+        tags: ["bug"],
+        metadata: {
+          created_at: "2024-01-01",
+          updated_at: "2024-01-02",
+          author: "user",
+        },
+      });
+      expect(result.conflicts).toHaveLength(0);
+    });
+
+    it("should handle conflicting modifications at multiple nesting levels", () => {
+      // AC: @yaml-merge-driver ac-7
+      const base = {
+        task: {
+          title: "Task",
+          metadata: {
+            priority: 1,
+          },
+        },
+      };
+
+      const ours = {
+        task: {
+          title: "Task from ours",
+          metadata: {
+            priority: 2,
+          },
+        },
+      };
+
+      const theirs = {
+        task: {
+          title: "Task from theirs",
+          metadata: {
+            priority: 3,
+          },
+        },
+      };
+
+      const result = mergeObjects(base, ours, theirs);
+
+      expect(result.merged).toEqual({
+        task: {
+          title: "Task from ours", // Default to ours
+          metadata: {
+            priority: 2, // Default to ours
+          },
+        },
+      });
+      expect(result.conflicts).toHaveLength(2);
+      expect(result.conflicts[0].path).toBe("task.title");
+      expect(result.conflicts[1].path).toBe("task.metadata.priority");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements field-level and recursive object merging for the semantic YAML merge driver.

- **Field-level merge** (AC-3): When both branches modify different fields of the same object, all changes are combined
- **Recursive nested merge** (AC-7): Nested objects are merged recursively at the field level
- **Conflict detection**: Detects when both branches modify the same scalar field with different values
- **Comprehensive edge cases**: Handles field additions, deletions, undefined values, and complex nesting

## Implementation

Created `src/merge/objects.ts` with:
- `mergeObjects()`: Main recursive merge function
- Field-by-field comparison with 3-way merge semantics
- Proper handling of additions, modifications, deletions
- Conflict info generation for interactive resolution (future work)

## Test Coverage

Added `tests/merge-objects.test.ts` with **28 tests** covering:
- Field additions (both branches, same/different values)
- Field modifications (single branch, both branches, conflicts)
- Field deletions (both branches, delete vs keep scenarios)
- Nested objects (recursive merge, conflicts at multiple levels)
- Edge cases (undefined inputs, empty objects, arrays as values)
- Complex scenarios (multiple modifications across nesting levels)

All 1013 tests pass.

## Acceptance Criteria

- ✅ AC-3: Both versions modify different fields → fields are merged
- ✅ AC-7: Nested objects → merged recursively at field level

## Next Steps

Remaining merge driver work (separate tasks):
- AC-4: Interactive conflict resolution for scalar fields
- AC-8: Interactive resolution for delete-modify conflicts
- AC-9-12: CLI driver implementation and git integration

Task: @01KFM7G5
Spec: @yaml-merge-driver

🤖 Generated with [Claude Code](https://claude.ai/code)