### PR TITLE
Merge driver: file type detection

### DIFF
--- a/src/merge/file-type.ts
+++ b/src/merge/file-type.ts
@@ -1,0 +1,71 @@
+/**
+ * File type detection for kspec merge driver.
+ *
+ * Determines which merge strategy to apply based on file path patterns.
+ */
+
+/**
+ * Types of kspec files that require different merge strategies
+ */
+export enum FileType {
+  /** Task files: *.tasks.yaml */
+  Tasks = "tasks",
+  /** Inbox files: *.inbox.yaml */
+  Inbox = "inbox",
+  /** Spec module files: modules/*.yaml */
+  SpecModules = "spec_modules",
+  /** Manifest file: kynetic.yaml */
+  Manifest = "manifest",
+  /** Meta file: kynetic.meta.yaml */
+  Meta = "meta",
+  /** Unrecognized files (fallback to default behavior) */
+  Unknown = "unknown",
+}
+
+/**
+ * Detect the type of a kspec file based on its path.
+ *
+ * @param filePath - Path to the file (can be relative or absolute)
+ * @returns The detected file type
+ */
+export function detectFileType(filePath: string): FileType {
+  // Normalize path separators for cross-platform compatibility
+  const normalizedPath = filePath.replace(/\\/g, "/");
+
+  // Extract just the filename for pattern matching
+  const parts = normalizedPath.split("/");
+  const fileName = parts[parts.length - 1];
+
+  // Check for manifest (exact match)
+  if (fileName === "kynetic.yaml") {
+    return FileType.Manifest;
+  }
+
+  // Check for meta file (exact match)
+  if (fileName === "kynetic.meta.yaml") {
+    return FileType.Meta;
+  }
+
+  // Check for task files (*.tasks.yaml pattern)
+  if (fileName.endsWith(".tasks.yaml")) {
+    return FileType.Tasks;
+  }
+
+  // Check for inbox files (*.inbox.yaml pattern)
+  if (fileName.endsWith(".inbox.yaml")) {
+    return FileType.Inbox;
+  }
+
+  // Check for spec modules (in modules/ directory)
+  // Match both "/modules/" and "modules/" at start of path
+  if (
+    (normalizedPath.includes("/modules/") ||
+      normalizedPath.startsWith("modules/")) &&
+    fileName.endsWith(".yaml")
+  ) {
+    return FileType.SpecModules;
+  }
+
+  // Fallback for unrecognized files
+  return FileType.Unknown;
+}

--- a/src/merge/index.ts
+++ b/src/merge/index.ts
@@ -31,3 +31,5 @@ export {
   formatConflictComment,
 } from "./resolve.js";
 export type { ResolutionChoice, ConflictResolution } from "./resolve.js";
+
+export { detectFileType, FileType } from "./file-type.js";

--- a/tests/merge-file-type.test.ts
+++ b/tests/merge-file-type.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Tests for file type detection in merge driver.
+ */
+
+import { describe, expect, it } from "vitest";
+import { detectFileType, FileType } from "../src/merge/file-type.js";
+
+describe("detectFileType", () => {
+  it("should detect task files (*.tasks.yaml)", () => {
+    // AC: @merge-file-detection ac-1
+    expect(detectFileType("project.tasks.yaml")).toBe(FileType.Tasks);
+    expect(detectFileType("kynetic.tasks.yaml")).toBe(FileType.Tasks);
+    expect(detectFileType(".kspec/project.tasks.yaml")).toBe(FileType.Tasks);
+    expect(detectFileType("/absolute/path/to/my.tasks.yaml")).toBe(
+      FileType.Tasks,
+    );
+  });
+
+  it("should detect inbox files (*.inbox.yaml)", () => {
+    // AC: @merge-file-detection ac-2
+    expect(detectFileType("project.inbox.yaml")).toBe(FileType.Inbox);
+    expect(detectFileType(".kspec/project.inbox.yaml")).toBe(FileType.Inbox);
+    expect(detectFileType("/absolute/path/to/my.inbox.yaml")).toBe(
+      FileType.Inbox,
+    );
+  });
+
+  it("should detect spec module files (modules/*.yaml)", () => {
+    // AC: @merge-file-detection ac-3
+    expect(detectFileType("modules/core.yaml")).toBe(FileType.SpecModules);
+    expect(detectFileType(".kspec/modules/tasks.yaml")).toBe(
+      FileType.SpecModules,
+    );
+    expect(detectFileType("/absolute/path/modules/feature.yaml")).toBe(
+      FileType.SpecModules,
+    );
+    expect(detectFileType("nested/path/modules/spec.yaml")).toBe(
+      FileType.SpecModules,
+    );
+  });
+
+  it("should detect manifest file (kynetic.yaml)", () => {
+    // AC: @merge-file-detection ac-4
+    expect(detectFileType("kynetic.yaml")).toBe(FileType.Manifest);
+    expect(detectFileType(".kspec/kynetic.yaml")).toBe(FileType.Manifest);
+    expect(detectFileType("/absolute/path/to/kynetic.yaml")).toBe(
+      FileType.Manifest,
+    );
+  });
+
+  it("should detect meta file (kynetic.meta.yaml)", () => {
+    // AC: @merge-file-detection ac-5
+    expect(detectFileType("kynetic.meta.yaml")).toBe(FileType.Meta);
+    expect(detectFileType(".kspec/kynetic.meta.yaml")).toBe(FileType.Meta);
+    expect(detectFileType("/absolute/path/to/kynetic.meta.yaml")).toBe(
+      FileType.Meta,
+    );
+  });
+
+  it("should detect unknown files and return Unknown", () => {
+    // AC: @merge-file-detection ac-6
+    expect(detectFileType("README.md")).toBe(FileType.Unknown);
+    expect(detectFileType("config.json")).toBe(FileType.Unknown);
+    expect(detectFileType("random.yaml")).toBe(FileType.Unknown);
+    expect(detectFileType(".gitignore")).toBe(FileType.Unknown);
+    expect(detectFileType("src/index.ts")).toBe(FileType.Unknown);
+  });
+
+  it("should handle Windows-style paths", () => {
+    // Cross-platform compatibility
+    expect(detectFileType("C:\\path\\to\\project.tasks.yaml")).toBe(
+      FileType.Tasks,
+    );
+    expect(detectFileType("C:\\path\\modules\\core.yaml")).toBe(
+      FileType.SpecModules,
+    );
+    expect(detectFileType("D:\\kspec\\kynetic.yaml")).toBe(FileType.Manifest);
+  });
+
+  it("should not confuse similar patterns", () => {
+    // Edge cases - files that might look similar but aren't matches
+    expect(detectFileType("tasks.yaml")).toBe(FileType.Unknown); // Missing dot before tasks
+    expect(detectFileType("project.tasks.yml")).toBe(FileType.Unknown); // Wrong extension
+    expect(detectFileType("kynetic.tasks.yaml.bak")).toBe(FileType.Unknown); // Has extra extension
+    expect(detectFileType("modules.yaml")).toBe(FileType.Unknown); // Not in modules/ directory
+  });
+});


### PR DESCRIPTION
## Summary

Implements file type detection for the semantic YAML merge driver. This enables the driver to identify kspec file types and dispatch to appropriate merge strategies.

- **Tasks files** (`*.tasks.yaml`): Will use task-specific merge strategy
- **Inbox files** (`*.inbox.yaml`): Will use inbox-specific merge strategy  
- **Spec modules** (`modules/*.yaml`): Will use recursive spec item merge
- **Manifest** (`kynetic.yaml`): Will use manifest-specific merge
- **Meta** (`kynetic.meta.yaml`): Will use meta-specific merge
- **Unknown files**: Will fallback to default behavior

## Changes

- Created `src/merge/file-type.ts` with `FileType` enum and `detectFileType()` function
- Added comprehensive test coverage in `tests/merge-file-type.test.ts` (8 test cases)
- Cross-platform path handling (Unix and Windows)
- Exported from public API

## Test plan

- [x] All 1041 tests pass
- [x] All 6 ACs covered with explicit annotations
- [x] Edge cases tested (similar patterns, Windows paths)
- [x] TypeScript builds without errors

Task: @01KFM7GN
Spec: @merge-file-detection

🤖 Generated with [Claude Code](https://claude.ai/code)