### PR TITLE
Implement session context and observations panel

### DIFF
--- a/packages/web-ui/src/lib/api.ts
+++ b/packages/web-ui/src/lib/api.ts
@@ -11,6 +11,8 @@ import type {
 	ItemSummary,
 	ItemDetail,
 	InboxItem,
+	SessionContext,
+	Observation,
 	PaginatedResponse,
 	ErrorResponse
 } from '@kynetic-ai/shared';
@@ -216,4 +218,45 @@ export async function deleteInboxItem(ref: string): Promise<void> {
 		const error: ErrorResponse = await response.json();
 		throw new Error(error.message || error.error);
 	}
+}
+
+/**
+ * Fetch session context
+ * AC: @web-dashboard ac-20
+ */
+export async function fetchSessionContext(): Promise<SessionContext> {
+	const response = await fetch(`${API_BASE}/api/meta/session`);
+	if (!response.ok) {
+		const error: ErrorResponse = await response.json();
+		throw new Error(error.message || error.error);
+	}
+
+	return response.json();
+}
+
+/**
+ * Fetch observations
+ * AC: @web-dashboard ac-21, ac-22
+ */
+export async function fetchObservations(params?: {
+	type?: 'friction' | 'success' | 'question' | 'idea';
+	resolved?: boolean;
+}): Promise<PaginatedResponse<Observation>> {
+	const url = new URL(`${API_BASE}/api/meta/observations`);
+
+	if (params) {
+		Object.entries(params).forEach(([key, value]) => {
+			if (value !== undefined && value !== '') {
+				url.searchParams.set(key, String(value));
+			}
+		});
+	}
+
+	const response = await fetch(url.toString());
+	if (!response.ok) {
+		const error: ErrorResponse = await response.json();
+		throw new Error(error.message || error.error);
+	}
+
+	return response.json();
 }

--- a/packages/web-ui/src/routes/observations/+page.svelte
+++ b/packages/web-ui/src/routes/observations/+page.svelte
@@ -1,0 +1,126 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import type { Observation } from '@kynetic-ai/shared';
+	import { fetchObservations } from '$lib/api';
+	import { Card, CardContent, CardHeader, CardTitle } from '$lib/components/ui/card';
+	import { Badge } from '$lib/components/ui/badge';
+	import {
+		Lightbulb,
+		Zap,
+		AlertTriangle,
+		HelpCircle
+	} from 'lucide-svelte';
+
+	// AC: @web-dashboard ac-22
+	let observations: Observation[] = [];
+	let loading = true;
+	let error = '';
+
+	// Type icons mapping
+	const typeIcons = {
+		friction: AlertTriangle,
+		success: Zap,
+		question: HelpCircle,
+		idea: Lightbulb
+	};
+
+	const typeColors = {
+		friction: 'text-red-600',
+		success: 'text-green-600',
+		question: 'text-blue-600',
+		idea: 'text-yellow-600'
+	};
+
+	const typeLabels = {
+		friction: 'Friction',
+		success: 'Success',
+		question: 'Question',
+		idea: 'Idea'
+	};
+
+	onMount(async () => {
+		await loadObservations();
+	});
+
+	async function loadObservations() {
+		try {
+			loading = true;
+			error = '';
+			// AC: @web-dashboard ac-22 - Show unresolved observations
+			const response = await fetchObservations({ resolved: false });
+			observations = response.items;
+		} catch (err) {
+			error = err instanceof Error ? err.message : 'Failed to load observations';
+		} finally {
+			loading = false;
+		}
+	}
+
+	function formatDate(dateString: string): string {
+		const date = new Date(dateString);
+		const now = new Date();
+		const diffMs = now.getTime() - date.getTime();
+		const diffMins = Math.floor(diffMs / 60000);
+		const diffHours = Math.floor(diffMs / 3600000);
+		const diffDays = Math.floor(diffMs / 86400000);
+
+		if (diffMins < 1) return 'just now';
+		if (diffMins < 60) return `${diffMins}m ago`;
+		if (diffHours < 24) return `${diffHours}h ago`;
+		if (diffDays < 7) return `${diffDays}d ago`;
+
+		return date.toLocaleDateString();
+	}
+</script>
+
+<!-- AC: @web-dashboard ac-22 - Observations panel with type icons -->
+<div class="flex flex-col gap-4">
+	<div class="flex items-center justify-between">
+		<h1 class="text-3xl font-bold">Observations</h1>
+		<Badge variant="secondary">
+			{observations.length} unresolved
+		</Badge>
+	</div>
+
+	{#if error}
+		<div class="rounded-md bg-red-50 p-4 text-sm text-red-800">
+			{error}
+		</div>
+	{/if}
+
+	{#if loading}
+		<div class="text-center text-muted-foreground">Loading observations...</div>
+	{:else if observations.length === 0}
+		<div class="text-center text-muted-foreground">
+			<p>No unresolved observations.</p>
+			<p class="text-sm">Observations are captured during work sessions.</p>
+		</div>
+	{:else}
+		<div class="flex flex-col gap-3">
+			{#each observations as obs (obs._ulid)}
+				<!-- AC: @web-dashboard ac-22 - Show type icons -->
+				<Card>
+					<CardHeader class="pb-3">
+						<div class="flex items-start gap-3">
+							<div class={`mt-0.5 ${typeColors[obs.type]}`}>
+								<svelte:component this={typeIcons[obs.type]} class="h-5 w-5" />
+							</div>
+							<div class="flex-1">
+								<div class="flex items-center gap-2 mb-2">
+									<Badge variant="outline">{typeLabels[obs.type]}</Badge>
+									<span class="text-xs text-muted-foreground">{formatDate(obs.created_at)}</span>
+								</div>
+								<p class="text-sm leading-relaxed">{obs.content}</p>
+								{#if obs.context}
+									<p class="mt-2 text-xs text-muted-foreground border-l-2 border-muted pl-3">
+										{obs.context}
+									</p>
+								{/if}
+							</div>
+						</div>
+					</CardHeader>
+				</Card>
+			{/each}
+		</div>
+	{/if}
+</div>


### PR DESCRIPTION
## Summary
- Session focus prominently displayed in sidebar header when set
- Observations count badge in sidebar (shows unresolved count)
- Dedicated observations page with type-specific icons (friction/success/question/idea)
- Auto-refresh session data every 30s (will be replaced with WebSocket later)
- Relative timestamp formatting for user-friendly dates

## Test plan
- [ ] Verify session focus appears in sidebar when `kspec meta focus "text"` is set
- [ ] Verify observations badge appears in sidebar when unresolved observations exist
- [ ] Verify clicking observations badge navigates to /observations page
- [ ] Verify observations page shows type-specific icons and colors
- [ ] Verify observations page filters to unresolved only
- [ ] Verify relative timestamps display correctly

## Implementation Details
Added API client methods for session context and observations. Updated Sidebar component to fetch and display session data. Created new observations page with type-based icons using lucide-svelte.

Covers acceptance criteria: ac-20, ac-21, ac-22

Task: @01KFMMTJ
Spec: @web-dashboard

🤖 Generated with [Claude Code](https://claude.ai/code)