### PR TITLE
docs: add E2E test and ULID fixture guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -688,12 +688,12 @@ When manually creating YAML fixture files (not TypeScript tests), generate valid
 ```bash
 node -e "
 const CROCKFORD_BASE32 = '0123456789ABCDEFGHJKMNPQRSTVWXYZ';
-function testUlid(prefix = '', seq = 0) {
+function testUlid(prefix = '', sequence = 0) {
   const safe = prefix.toUpperCase().replace(/I/g,'J').replace(/L/g,'K').replace(/O/g,'0').replace(/U/g,'V');
   const base = '01' + safe;
   const padLen = 24 - base.length;
-  const seqStr = seq.toString().padStart(Math.min(padLen, 8), '0').slice(0, padLen);
-  return (base + seqStr).padEnd(25, '0') + CROCKFORD_BASE32[seq % 32];
+  const sequenceStr = sequence.toString().padStart(Math.min(padLen, 8), '0').slice(0, padLen);
+  return (base + sequenceStr).padEnd(25, '0') + CROCKFORD_BASE32[sequence % 32];
 }
 // Generate ULIDs for your fixture
 console.log(testUlid('0BS', 0));  // observations


### PR DESCRIPTION
## Summary

From session reflection after E2E infrastructure work:
- Add ULID generation snippet for YAML fixtures
- Document Playwright/vitest exclusion requirement

## Changes

Added two sections to AGENTS.md under Test Fixture Patterns:
1. **Generating ULIDs for YAML Fixtures** - Node snippet using same pattern as testUlid()
2. **E2E Tests (Playwright)** - Documents vitest exclusion config and how to run E2E tests

---
Generated with [Claude Code](https://claude.com/claude-code)