### PR TITLE
feat: add loop mode workflow support

### DIFF
--- a/src/schema/meta.ts
+++ b/src/schema/meta.ts
@@ -68,6 +68,11 @@ export const WorkflowStepSchema = z.object({
 });
 
 /**
+ * Workflow mode - interactive (default) for human-in-loop, loop for autonomous agents
+ */
+export const WorkflowModeSchema = z.enum(["interactive", "loop"]);
+
+/**
  * Workflow definition - structured process definition
  */
 export const WorkflowSchema = z.object({
@@ -77,6 +82,9 @@ export const WorkflowSchema = z.object({
   description: z.string().optional(),
   steps: z.array(WorkflowStepSchema).default([]),
   enforcement: z.enum(["advisory", "strict"]).default("advisory").optional(),
+  mode: WorkflowModeSchema.default("interactive").optional(),
+  based_on: RefSchema.optional(),
+  tags: z.array(z.string()).default([]).optional(),
 });
 
 /**
@@ -229,6 +237,7 @@ export type WorkflowStepType = z.infer<typeof WorkflowStepTypeSchema>;
 export type StepExecution = z.infer<typeof StepExecutionSchema>;
 export type StepInput = z.infer<typeof StepInputSchema>;
 export type WorkflowStep = z.infer<typeof WorkflowStepSchema>;
+export type WorkflowMode = z.infer<typeof WorkflowModeSchema>;
 export type Workflow = z.infer<typeof WorkflowSchema>;
 export type ConventionExample = z.infer<typeof ConventionExampleSchema>;
 export type ConventionValidation = z.infer<typeof ConventionValidationSchema>;


### PR DESCRIPTION
## Summary

- Add `mode` field to WorkflowSchema with values `interactive` (default) and `loop`
- Add `based_on` field for loop workflows to reference their base interactive workflow
- Add `tags` field for workflow categorization
- Add `--tag` filter to `kspec meta workflows` command (also matches `mode: loop` for `--tag loop`)
- Add Mode column to workflow table output
- Add mode and based_on display in verbose workflow listing
- Add `--mode`, `--based-on`, `--tag` options to `kspec meta add workflow`

## Test plan

- [x] 9 new tests in "Integration: loop mode workflows" describe block
- [x] AC-1: `kspec meta workflows --tag loop` filters correctly
- [x] AC-2: `mode: loop` validates, invalid modes rejected
- [x] AC-3: `based_on` shown in `meta get` and verbose output
- [x] All 127 meta tests pass

Task: @task-loop-mode-workflows
Spec: @loop-mode-workflows

🤖 Generated with [Claude Code](https://claude.ai/code)