### PR TITLE
test: Add global PID/port management tests

### DIFF
--- a/tests/daemon-global-pid-port.test.ts
+++ b/tests/daemon-global-pid-port.test.ts
@@ -9,7 +9,7 @@
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { createTempDir, cleanupTempDir } from './helpers/cli';
-import { writeFileSync, readFileSync, existsSync, mkdirSync, statSync } from 'fs';
+import { writeFileSync, readFileSync, existsSync, mkdirSync, statSync, unlinkSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
 
@@ -59,7 +59,7 @@ class GlobalPidFileManager {
   }
 
   // AC: @multi-directory-daemon ac-9c, ac-13
-  readPort(): number | null {
+  readPort(): number {
     if (!existsSync(this.portFilePath)) {
       throw new Error('Invalid daemon port file');
     }
@@ -81,12 +81,11 @@ class GlobalPidFileManager {
 
   // AC: @multi-directory-daemon ac-11
   remove(): void {
-    const fs = require('fs');
     if (existsSync(this.pidFilePath)) {
-      fs.unlinkSync(this.pidFilePath);
+      unlinkSync(this.pidFilePath);
     }
     if (existsSync(this.portFilePath)) {
-      fs.unlinkSync(this.portFilePath);
+      unlinkSync(this.portFilePath);
     }
   }
 
@@ -183,7 +182,7 @@ describe('Global PID/Port Management', () => {
     });
 
     // AC: @multi-directory-daemon ac-13
-    it('should return null when port file does not exist', () => {
+    it('should throw error when port file does not exist', () => {
       expect(() => pidManager.readPort()).toThrow('Invalid daemon port file');
     });
 


### PR DESCRIPTION
## Summary

Comprehensive test coverage for multi-directory daemon architecture's global PID/port management:

- Global PID/port file locations at `~/.config/kspec/` instead of per-project `.kspec/`
- Config directory creation with mode 0755
- Invalid port file error handling and validation
- Multiple daemon instance prevention
- Cross-directory daemon operation
- Cleanup on stop (both PID and port files)

## Test Coverage

30 tests covering acceptance criteria:
- **AC-9**: Global PID/port file locations
- **AC-9b**: Config directory creation with proper permissions
- **AC-9c**: Invalid port file error handling and validation (port range 1-65535)
- **AC-10**: Multiple daemon prevention and status detection
- **AC-11**: Cleanup on stop removes both PID and port files
- **AC-13**: CLI port reading from global location

## Implementation Details

Tests use a mock `GlobalPidFileManager` class that demonstrates the required behavior for migration from per-project to global PID/port files. All tests verify:

- Files written to global config directory
- Directory creation is automatic with proper permissions
- Invalid port values are detected and rejected
- Daemon status can be checked from any directory
- Cleanup is complete and idempotent

## Test Plan

- [x] All 30 new tests pass
- [x] No existing tests broken
- [x] AC annotations added to all tests

Task: @01KFQAAM
Spec: @multi-directory-daemon

🤖 Generated with [Claude Code](https://claude.ai/code)