### PR TITLE
feat: Migrate API routes to use request context

### DIFF
--- a/packages/daemon/src/routes/items.ts
+++ b/packages/daemon/src/routes/items.ts
@@ -22,19 +22,20 @@ import {
   AlignmentIndex,
   type LoadedSpecItem,
 } from '../../parser/index.js';
+import { join } from 'path';
 
-interface ItemsRouteOptions {
-  kspecDir: string;
-}
+interface ItemsRouteOptions {}
 
-export function createItemsRoutes(options: ItemsRouteOptions) {
-  const { kspecDir } = options;
+export function createItemsRoutes(options: ItemsRouteOptions = {}) {
+  // No closure-scoped kspecDir needed - comes from middleware
 
   return new Elysia({ prefix: '/api/items' })
     // AC: @api-contract ac-8, ac-9 - List items with type filter
     .get(
       '/',
-      async ({ query }) => {
+      async ({ query, projectContext }) => {
+        // AC: @multi-directory-daemon ac-1, ac-24 - Use project context from middleware
+        const kspecDir = join(projectContext.path, '.kspec');
         const ctx = await initContext(kspecDir);
         const items = await loadAllItems(ctx);
 
@@ -122,7 +123,9 @@ export function createItemsRoutes(options: ItemsRouteOptions) {
     // AC: @api-contract ac-10 - Get single item by ref
     .get(
       '/:ref',
-      async ({ params, error: errorResponse }) => {
+      async ({ params, error: errorResponse, projectContext }) => {
+        // AC: @multi-directory-daemon ac-1, ac-24 - Use project context from middleware
+        const kspecDir = join(projectContext.path, '.kspec');
         const ctx = await initContext(kspecDir);
         const items = await loadAllItems(ctx);
         const index = new ReferenceIndex(ctx);
@@ -176,7 +179,9 @@ export function createItemsRoutes(options: ItemsRouteOptions) {
     // AC: @api-contract ac-11 - Get tasks linked to spec item
     .get(
       '/:ref/tasks',
-      async ({ params, error: errorResponse }) => {
+      async ({ params, error: errorResponse, projectContext }) => {
+        // AC: @multi-directory-daemon ac-1, ac-24 - Use project context from middleware
+        const kspecDir = join(projectContext.path, '.kspec');
         const ctx = await initContext(kspecDir);
         const items = await loadAllItems(ctx);
         const tasks = await loadAllTasks(ctx);

--- a/packages/daemon/src/routes/meta.ts
+++ b/packages/daemon/src/routes/meta.ts
@@ -20,17 +20,18 @@ import {
   loadMetaContext,
   loadSessionContext,
 } from '../../parser/index.js';
+import { join } from 'path';
 
-interface MetaRouteOptions {
-  kspecDir: string;
-}
+interface MetaRouteOptions {}
 
-export function createMetaRoutes(options: MetaRouteOptions) {
-  const { kspecDir } = options;
+export function createMetaRoutes(options: MetaRouteOptions = {}) {
+  // No closure-scoped kspecDir needed - comes from middleware
 
   return new Elysia({ prefix: '/api/meta' })
     // AC: @api-contract ac-15 - Get session context
-    .get('/session', async () => {
+    .get('/session', async ({ projectContext }) => {
+      // AC: @multi-directory-daemon ac-1, ac-24 - Use project context from middleware
+      const kspecDir = join(projectContext.path, '.kspec');
       const ctx = await initContext(kspecDir);
       const session = await loadSessionContext(ctx);
 
@@ -44,7 +45,9 @@ export function createMetaRoutes(options: MetaRouteOptions) {
     })
 
     // AC: @api-contract ac-16 - List agents
-    .get('/agents', async () => {
+    .get('/agents', async ({ projectContext }) => {
+      // AC: @multi-directory-daemon ac-1, ac-24 - Use project context from middleware
+      const kspecDir = join(projectContext.path, '.kspec');
       const ctx = await initContext(kspecDir);
       const meta = await loadMetaContext(ctx);
 
@@ -58,7 +61,9 @@ export function createMetaRoutes(options: MetaRouteOptions) {
     })
 
     // AC: @api-contract ac-17 - List workflows
-    .get('/workflows', async () => {
+    .get('/workflows', async ({ projectContext }) => {
+      // AC: @multi-directory-daemon ac-1, ac-24 - Use project context from middleware
+      const kspecDir = join(projectContext.path, '.kspec');
       const ctx = await initContext(kspecDir);
       const meta = await loadMetaContext(ctx);
 
@@ -74,7 +79,9 @@ export function createMetaRoutes(options: MetaRouteOptions) {
     // AC: @api-contract ac-18 - List observations with filter
     .get(
       '/observations',
-      async ({ query }) => {
+      async ({ query, projectContext }) => {
+        // AC: @multi-directory-daemon ac-1, ac-24 - Use project context from middleware
+        const kspecDir = join(projectContext.path, '.kspec');
         const ctx = await initContext(kspecDir);
         const meta = await loadMetaContext(ctx);
 

--- a/packages/daemon/src/routes/tasks.ts
+++ b/packages/daemon/src/routes/tasks.ts
@@ -30,20 +30,22 @@ import {
 } from '../../parser/index.js';
 import { commitIfShadow } from '../../parser/shadow.js';
 import type { PubSubManager } from '../websocket/pubsub';
+import { join } from 'path';
 
 interface TasksRouteOptions {
-  kspecDir: string;
   pubsub: PubSubManager;
 }
 
 export function createTasksRoutes(options: TasksRouteOptions) {
-  const { kspecDir, pubsub } = options;
+  const { pubsub } = options;
 
   return new Elysia({ prefix: '/api/tasks' })
     // AC: @api-contract ac-2, ac-3, ac-4 - List tasks with filters and pagination
     .get(
       '/',
-      async ({ query }) => {
+      async ({ query, projectContext }) => {
+        // AC: @multi-directory-daemon ac-1, ac-24 - Use project context from middleware
+        const kspecDir = join(projectContext.path, '.kspec');
         const ctx = await initContext(kspecDir);
         const tasks = await loadAllTasks(ctx);
         const index = new ReferenceIndex(ctx);
@@ -117,7 +119,9 @@ export function createTasksRoutes(options: TasksRouteOptions) {
     // AC: @api-contract ac-5 - Get single task by ref
     .get(
       '/:ref',
-      async ({ params, error: errorResponse }) => {
+      async ({ params, error: errorResponse, projectContext }) => {
+        // AC: @multi-directory-daemon ac-1, ac-24 - Use project context from middleware
+        const kspecDir = join(projectContext.path, '.kspec');
         const ctx = await initContext(kspecDir);
         const tasks = await loadAllTasks(ctx);
         const index = new ReferenceIndex(ctx);
@@ -176,7 +180,9 @@ export function createTasksRoutes(options: TasksRouteOptions) {
     // AC: @api-contract ac-6 - Start task
     .post(
       '/:ref/start',
-      async ({ params, error: errorResponse }) => {
+      async ({ params, error: errorResponse, projectContext }) => {
+        // AC: @multi-directory-daemon ac-1, ac-24 - Use project context from middleware
+        const kspecDir = join(projectContext.path, '.kspec');
         const ctx = await initContext(kspecDir);
         const tasks = await loadAllTasks(ctx);
         const items = await loadAllItems(ctx);
@@ -243,7 +249,9 @@ export function createTasksRoutes(options: TasksRouteOptions) {
     // AC: @api-contract ac-7 - Add note to task
     .post(
       '/:ref/note',
-      async ({ params, body, error: errorResponse }) => {
+      async ({ params, body, error: errorResponse, projectContext }) => {
+        // AC: @multi-directory-daemon ac-1, ac-24 - Use project context from middleware
+        const kspecDir = join(projectContext.path, '.kspec');
         const ctx = await initContext(kspecDir);
         const tasks = await loadAllTasks(ctx);
         const index = new ReferenceIndex(ctx);

--- a/packages/daemon/src/routes/validation.ts
+++ b/packages/daemon/src/routes/validation.ts
@@ -31,19 +31,20 @@ import type {
   LoadedConvention,
 } from '../../parser/meta.js';
 import { grepItem } from '../../utils/grep.js';
+import { join } from 'path';
 
-interface ValidationRouteOptions {
-  kspecDir: string;
-}
+interface ValidationRouteOptions {}
 
-export function createValidationRoutes(options: ValidationRouteOptions) {
-  const { kspecDir } = options;
+export function createValidationRoutes(options: ValidationRouteOptions = {}) {
+  // No closure-scoped kspecDir needed - comes from middleware
 
   return new Elysia({ prefix: '/api' })
     // AC: @api-contract ac-19 - Search across all entities
     .get(
       '/search',
-      async ({ query }) => {
+      async ({ query, projectContext }) => {
+        // AC: @multi-directory-daemon ac-1, ac-24 - Use project context from middleware
+        const kspecDir = join(projectContext.path, '.kspec');
         const ctx = await initContext(kspecDir);
         const { tasks, items } = await buildIndexes(ctx);
 
@@ -205,7 +206,9 @@ export function createValidationRoutes(options: ValidationRouteOptions) {
     )
 
     // AC: @api-contract ac-20 - Run full validation
-    .get('/validate', async () => {
+    .get('/validate', async ({ projectContext }) => {
+      // AC: @multi-directory-daemon ac-1, ac-24 - Use project context from middleware
+      const kspecDir = join(projectContext.path, '.kspec');
       const ctx = await initContext(kspecDir);
 
       // AC: @api-contract ac-20 - Run validation and return ValidationResult
@@ -223,7 +226,9 @@ export function createValidationRoutes(options: ValidationRouteOptions) {
     })
 
     // AC: @api-contract ac-21 - Get alignment stats and warnings
-    .get('/alignment', async () => {
+    .get('/alignment', async ({ projectContext }) => {
+      // AC: @multi-directory-daemon ac-1, ac-24 - Use project context from middleware
+      const kspecDir = join(projectContext.path, '.kspec');
       const ctx = await initContext(kspecDir);
       const { tasks, items, refIndex } = await buildIndexes(ctx);
 


### PR DESCRIPTION
## Summary
- Migrates all API routes to use request-scoped project context from middleware
- Removes closure-scoped `kspecDir` parameter from route factories
- Routes now derive `kspecDir` from `projectContext.path` in each handler

## Implementation
Applied `projectContextMiddleware` in server.ts and updated 5 route files:
- `tasks.ts` - 4 handlers (list, get, start, note)
- `items.ts` - 3 handlers (list, get, tasks)
- `inbox.ts` - 3 handlers (list, create, delete)
- `meta.ts` - 4 handlers (session, agents, workflows, observations)
- `validation.ts` - 3 handlers (search, validate, alignment)

All handlers follow the pattern:
\`\`\`typescript
async ({ projectContext, ...otherParams }) => {
  const kspecDir = join(projectContext.path, '.kspec');
  const ctx = await initContext(kspecDir);
  // ... rest of handler
}
\`\`\`

## AC Coverage
Covers ac-1, ac-2, ac-3, ac-24 from @multi-directory-daemon spec.

## Test Plan
- [x] All 232 daemon tests pass (1 pre-existing unrelated failure)
- [x] Build successful
- [x] Routes properly access project context from middleware
- [x] kspecDir correctly derived from projectContext.path

🤖 Generated with [Claude Code](https://claude.com/claude-code)