### PR TITLE
feat: add loop mode to reflect skill

### DIFF
--- a/.claude/skills/reflect/SKILL.md
+++ b/.claude/skills/reflect/SKILL.md
@@ -149,3 +149,45 @@ kspec workflow resume
 After reflection, observations can be:
 - Promoted to tasks: `kspec meta promote @ref --title "..."`
 - Resolved when addressed: `kspec meta resolve @ref`
+
+## Loop Mode
+
+You are running in autonomous loop mode. Start the workflow:
+
+```bash
+kspec workflow start @session-reflect-loop
+```
+
+### Key Differences from Interactive Mode
+
+1. **High confidence only** - Only capture friction/successes you're certain about
+2. **Search first** - MUST search existing specs/tasks/inbox before capturing anything
+3. **No user prompts** - Skip discussion step, auto-resolve decisions
+4. **Lower volume** - Better to capture nothing than capture noise
+
+### Workflow Steps
+
+1. **Review session** - What worked well, what caused friction
+2. **Search existing** - For each potential capture:
+   ```bash
+   kspec search "<keyword>"
+   ```
+   If already tracked, skip it.
+3. **Capture high-confidence items only**
+   - Clear friction pattern you encountered multiple times? Capture it
+   - Uncertain or one-off issue? Skip it
+   - Success pattern worth replicating? Capture it
+4. **Exit** - Don't wait for user confirmation
+
+### Exit Conditions
+
+- **Session reviewed** - Reflection complete (normal exit)
+- **Nothing to capture** - No high-confidence items identified
+- **All already tracked** - Search found existing coverage
+
+### What NOT to Capture
+
+- Vague observations ("could be better")
+- One-time issues that won't recur
+- Things you're unsure about
+- Anything already tracked in specs/tasks/inbox


### PR DESCRIPTION
## Summary

- Adds Loop Mode section to `reflect/SKILL.md` for autonomous agent context
- References existing `@session-reflect-loop` workflow
- Key behaviors: high-confidence captures only, must search existing first, no user prompts

Also marks two already-complete tasks as done:
- `@task-skill-loop-mode` - convention already works via args
- `@task-task-work-loop-skill` - already had Loop Mode in SKILL.md

## Test plan

- [ ] Run `/reflect loop` and verify it references `@session-reflect-loop` workflow
- [ ] Verify workflow steps emphasize search-first and high-confidence only

Task: @task-reflect-loop-skill
Spec: @reflect-loop-skill

Generated with [Claude Code](https://claude.ai/code)