### PR TITLE
fix: use /task-work loop and /reflect loop in ralph prompt

### DIFF
--- a/tests/ralph.test.ts
+++ b/tests/ralph.test.ts
@@ -142,7 +142,8 @@ describe('ralph command', () => {
 
     expect(result.stdout).toContain('DRY RUN');
     expect(result.stdout).toContain('Kspec Automation Session');
-    expect(result.stdout).toContain('Working Procedure');
+    expect(result.stdout).toContain('Task Work Prompt');
+    expect(result.stdout).toContain('Reflect Prompt');
     // Should not show completion
     expect(result.stdout).not.toContain('Completed iteration');
   });
@@ -169,11 +170,11 @@ describe('ralph command', () => {
   });
 
   // AC: @ralph-skill-delegation ac-3
-  it('contains literal /task-work and /reflect skill invocations', async () => {
+  it('contains literal /task-work loop and /reflect loop skill invocations', async () => {
     const result = runRalph('--dry-run', tempDir);
 
-    expect(result.stdout).toContain('/task-work');
-    expect(result.stdout).toContain('/reflect');
+    expect(result.stdout).toContain('/task-work loop');
+    expect(result.stdout).toContain('/reflect loop');
   });
 
   // AC: @ralph-skill-delegation ac-4


### PR DESCRIPTION
## Summary

Two key changes to ralph prompting:

### 1. Use loop mode skill invocations
Updates ralph prompt to use loop mode skill invocations as specified in @ralph-skill-delegation ac-3:
- Before: `/task-work`, `/reflect`  
- After: `/task-work loop`, `/reflect loop`

### 2. Send reflect as separate prompt
Ralph now sends **two prompts per iteration**:
1. Task-work prompt with `/task-work loop`
2. Reflect prompt with `/reflect loop` (sent after task-work completes)

This ensures reflection always happens - we don't rely on the agent to remember.

## Flow

```
Iteration N:
  1. ralph → agent: "/task-work loop" prompt
  2. agent works on tasks
  3. agent ends turn
  4. ralph → agent: "/reflect loop" prompt  (NEW)
  5. agent reflects
  6. agent ends turn
  7. Iteration complete
```

## Why this matters

The skills have Loop Mode sections that trigger specific behaviors:
- **task-work loop**: Uses `@task-work-loop` workflow, auto-resolves decisions, filters to eligible tasks
- **reflect loop**: Uses `@session-reflect-loop` workflow, high-confidence only, no user prompts

Without the `loop` argument, the agent would use the interactive mode which expects user confirmations.

By sending reflect as a separate prompt, we guarantee it runs even if the agent forgets or exits early.

## Test plan

- [x] Test updated to check for `/task-work loop` and `/reflect loop`
- [x] Dry-run shows both prompts
- [x] All 50 tests pass

Spec: @ralph-skill-delegation

Generated with [Claude Code](https://claude.ai/code)