### PR TITLE
fix: add scope expansion guidance to task-work skill

### DIFF
--- a/.claude/skills/task-work/SKILL.md
+++ b/.claude/skills/task-work/SKILL.md
@@ -107,6 +107,38 @@ git log --oneline -- path/to/relevant/files
 
 This prevents duplicate work and wasted effort.
 
+## Scope Expansion During Work
+
+Tasks describe expected outcomes, not rigid boundaries. During work, you may discover:
+
+- **Tests need implementation**: A "testing" task may reveal missing functionality. **Implementing that functionality is in scope** - the goal is verified behavior, not just test files.
+
+- **Implementation needs tests**: An "implementation" task includes proving it works. Add tests.
+
+- **DoD constraints are hard requirements**: If the task notes include Definition of Done criteria, those are not suggestions. Never produce deliverables that violate DoD.
+
+### When to Expand vs Escalate
+
+**Expand scope** (do it yourself) when:
+- The additional work is clearly implied by the goal
+- It's proportional to the original task (not 10x larger)
+- You have the context to do it correctly
+
+**Escalate** (ask user) when:
+- Scope expansion is major (testing task becomes architecture redesign)
+- You're uncertain about the right approach
+- DoD is ambiguous and requires judgment calls
+
+### Anti-patterns to Avoid
+
+- **`test.skip()` as a deliverable**: Never use `test.skip()` to document missing functionality unless explicitly approved by user. Skipped tests give false coverage and fail the goal of verification.
+
+- **Literal task title interpretation**: "Add tests for X" means "ensure X is verified." If X doesn't exist, implement it first.
+
+- **Checkbox completion**: Completing *something* is not the goal. Completing the *right thing* is. If you can't achieve the actual goal, ask for guidance rather than delivering a hollow artifact.
+
+- **Automation mode shortcuts**: Automation mode means "make good decisions autonomously" - the same decisions a skilled human would make. It does NOT mean take shortcuts, skip hard problems, or produce placeholder deliverables.
+
 ## Notes Best Practices
 
 Add notes **during** work, not just at the end:


### PR DESCRIPTION
## Summary

- Adds new "Scope Expansion During Work" section to task-work skill
- Provides guidance on when tests need implementation (implementation is in scope)
- Documents when to expand scope vs escalate to user
- Lists explicit anti-patterns to avoid:
  - `test.skip()` as a deliverable
  - Literal task title interpretation
  - Checkbox completion
  - Automation mode shortcuts

## Context

Addresses failure mode where autonomous agent produced `test.skip()` instead of implementing missing file locking for ac-10b. The agent interpreted "add tests" literally and when it found no implementation, documented the gap with skipped tests rather than implementing the functionality.

This change makes explicit that:
- "Add tests for X" means "ensure X is verified" - if X doesn't exist, implement it
- DoD constraints are hard requirements, not suggestions
- Automation mode means good decisions, not shortcuts

## Test plan

- [ ] Run ralph on @01KFQAAM task (the one that previously produced test.skip)
- [ ] Verify agent recognizes missing implementation and implements it
- [ ] Verify no test.skip() in output

Note: Companion change to task-work-loop workflow in shadow branch (kspec-meta) adds DoD check step.

---

Generated with [Claude Code](https://claude.ai/code)