### PR TITLE
fix: filter active tasks by automation eligibility in ralph loop

### DIFF
--- a/src/cli/commands/ralph.ts
+++ b/src/cli/commands/ralph.ts
@@ -732,12 +732,13 @@ export function registerRalphCommand(program: Command): void {
               break;
             }
 
-            // Check for ready tasks or active tasks
+            // Check for automation-eligible tasks (ready or in_progress)
+            // AC: @cli-ralph ac-19
             const hasActiveTasks = sessionCtx.active_tasks.length > 0;
             const hasReadyTasks = sessionCtx.ready_tasks.length > 0;
 
             if (!hasActiveTasks && !hasReadyTasks) {
-              info("No active or eligible ready tasks. Exiting loop.");
+              info("No automation-eligible tasks (ready or in_progress). Exiting loop.");
               break;
             }
 

--- a/src/cli/commands/session.ts
+++ b/src/cli/commands/session.ts
@@ -361,9 +361,11 @@ export async function gatherSessionContext(
     inbox_items: inboxItems.length,
   };
 
-  // Get active tasks
+  // Get active tasks (optionally filtered to automation-eligible only)
+  // AC: @cli-ralph ac-16
   const activeTasks = allTasks
     .filter((t) => t.status === "in_progress")
+    .filter((t) => !options.eligible || t.automation === "eligible")
     .sort((a, b) => a.priority - b.priority)
     .slice(0, options.full ? undefined : limit)
     .map((t) => toActiveTaskSummary(t, index));


### PR DESCRIPTION
## Summary

- Fix ralph loop exit condition to filter `in_progress` tasks by automation eligibility
- Previously, the loop continued running even when all active tasks were `automation:needs_review`
- This caused overnight sessions to run 30 iterations with no actionable work

## Changes

- `session.ts`: Add automation eligibility filter to `activeTasks` query (same as `readyTasks`)
- `ralph.ts`: Update exit message to clarify both ready and in_progress tasks are considered
- `ralph.test.ts`: Add test for needs_review in_progress tasks, update message expectations

## Test plan

- [x] All 75 ralph tests pass
- [x] New test verifies loop exits when in_progress task is needs_review
- [x] Full test suite: 1428 passed

Task: @01KFV6CZ
Spec: @cli-ralph (AC-16, AC-19)

Generated with [Claude Code](https://claude.ai/code)