### PR TITLE
Fix: Cleanup checkpoint messaging

### DIFF
--- a/src/cli/commands/session.ts
+++ b/src/cli/commands/session.ts
@@ -572,12 +572,12 @@ export async function performCheckpoint(
   // Build instructions based on issues
   if (issues.length > 0 && !options.force) {
     instructions.push(
-      "If you've been instructed to ignore this message or working on",
+      "If you've been instructed to ignore this message or are working on",
     );
     instructions.push(
-      "unrelated tasks to the following disregard this mesage otherwise",
+      "unrelated things to any in progress tasks then disregard this message,",
     );
-    instructions.push("before ending this session, please:");
+    instructions.push("otherwise before ending this session, please:");
 
     const hasInProgress = issues.some((i) => i.type === "in_progress_task");
     const hasUncommitted = issues.some((i) => i.type === "uncommitted_changes");
@@ -593,9 +593,8 @@ export async function performCheckpoint(
         `${step++}. Add notes documenting current state if any context is missing from this session`,
       );
       instructions.push(
-        `${step++}. Complete the task if you've completed the objectives and no AC are left uncovered`,
+        `${step++}. Complete the task if you've completed the objectives and no AC are left uncovered\notherwise leave it in progress for a future session`,
       );
-      instructions.push(`otherwise leave it in progress for a future session`);
     }
 
     if (hasIncompleteTodos) {


### PR DESCRIPTION
Checkpoint messaging was a bit too strict when it didn't need to be, but also didn't account for checking current status before updating with new notes which lead to excessive notes that added little value.