### PR TITLE
chore: use kspec CLI in settings hooks

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "npm run dev -s -- session prompt-check"
+            "command": "kspec session prompt-check"
           }
         ]
       }
@@ -27,7 +27,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "npm run dev -s -- session checkpoint --json"
+            "command": "kspec session checkpoint --json"
           }
         ]
       }


### PR DESCRIPTION
## Summary
- Switch session hooks from `npm run dev -s --` to `kspec` CLI
- Uses the installed CLI directly instead of running through npm dev mode

## Test plan
- [x] Hooks already tested in normal usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)