### PR TITLE
feat: implement GitHub Pages export for static site hosting

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,81 @@
+# GitHub Pages Deployment
+#
+# Deploys static site from kspec-meta shadow branch to GitHub Pages.
+# Triggers on push to kspec-meta, builds JSON snapshot + SPA.
+#
+# AC: @gh-pages-export ac-8, ac-9, ac-10
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [kspec-meta]
+
+# AC: @gh-pages-export ac-10 - Debounce rapid commits
+# Cancel in-progress deployments for same branch
+concurrency:
+  group: gh-pages
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  pages: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checkout code from main branch (contains CLI and web-ui source)
+      - name: Checkout main branch
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      # Checkout kspec-meta branch to .kspec directory (spec/task data)
+      # AC: @gh-pages-export ac-8 - Triggered on kspec-meta push
+      - name: Checkout kspec-meta branch
+        uses: actions/checkout@v4
+        with:
+          ref: kspec-meta
+          path: .kspec
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build CLI
+        run: npm run build
+
+      - name: Create output directory
+        run: mkdir -p gh-pages-output
+
+      # AC: @gh-pages-export ac-8 - Run kspec export
+      - name: Generate JSON snapshot
+        run: |
+          ./dist/cli/index.js export \
+            --format json \
+            --include-validation \
+            -o gh-pages-output/kspec-snapshot.json
+
+      # AC: @gh-pages-export ac-9 - Build and copy SPA assets
+      - name: Build web UI
+        run: npm run build -w packages/web-ui
+
+      - name: Copy SPA assets
+        run: cp -r packages/web-ui/build/* gh-pages-output/
+
+      # AC: @gh-pages-export ac-8 - Deploy to gh-pages branch
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./gh-pages-output
+          publish_branch: gh-pages
+          force_orphan: true
+          commit_message: 'Deploy kspec dashboard - ${{ github.sha }}'

--- a/packages/web-ui/src/lib/api-static.ts
+++ b/packages/web-ui/src/lib/api-static.ts
@@ -1,0 +1,437 @@
+/**
+ * Static API Provider
+ *
+ * Provides API responses from a static JSON snapshot.
+ * Used when daemon is unavailable (GitHub Pages mode).
+ *
+ * AC Coverage:
+ * - ac-11 (@gh-pages-export): Render from JSON snapshot
+ * - ac-12, ac-13 (@gh-pages-export): Deep linking with ref resolution
+ */
+
+import type {
+	TaskSummary,
+	TaskDetail,
+	ItemSummary,
+	ItemDetail,
+	InboxItem,
+	SessionContext,
+	Observation,
+	PaginatedResponse,
+	SearchResponse,
+	SearchResult
+} from '@kynetic-ai/shared';
+import type { KspecSnapshot, ExportedTask, ExportedItem } from '$lib/types/snapshot';
+import { getSnapshot, ReadOnlyModeError } from '$lib/stores/mode.svelte';
+
+/**
+ * Convert ExportedTask to TaskSummary
+ */
+function toTaskSummary(task: ExportedTask): TaskSummary {
+	return {
+		_ulid: task._ulid,
+		slugs: task.slugs,
+		title: task.title,
+		type: task.type,
+		status: task.status,
+		priority: task.priority,
+		spec_ref: task.spec_ref ?? undefined,
+		tags: task.tags,
+		depends_on: task.depends_on,
+		created_at: task.created_at,
+		started_at: task.started_at ?? undefined,
+		notes_count: task.notes?.length ?? 0,
+		todos_count: task.todos?.length ?? 0
+	};
+}
+
+/**
+ * Convert ExportedItem to ItemSummary
+ */
+function toItemSummary(item: ExportedItem): ItemSummary {
+	return {
+		_ulid: item._ulid,
+		slugs: item.slugs,
+		title: item.title,
+		type: item.type,
+		status: item.status,
+		tags: item.tags,
+		created_at: item.created_at ?? new Date().toISOString()
+	};
+}
+
+/**
+ * Filter helper for tasks
+ */
+function filterTasks(
+	tasks: ExportedTask[],
+	params?: {
+		status?: string;
+		type?: string;
+		tag?: string;
+		assignee?: string;
+		automation?: string;
+	}
+): ExportedTask[] {
+	let result = tasks;
+
+	if (params?.status) {
+		result = result.filter((t) => t.status === params.status);
+	}
+	if (params?.type) {
+		result = result.filter((t) => t.type === params.type);
+	}
+	if (params?.tag) {
+		result = result.filter((t) => t.tags.includes(params.tag!));
+	}
+	if (params?.assignee) {
+		result = result.filter((t) => t.assignee === params.assignee);
+	}
+	if (params?.automation) {
+		result = result.filter((t) => t.automation === params.automation);
+	}
+
+	return result;
+}
+
+/**
+ * Filter helper for items
+ */
+function filterItems(
+	items: ExportedItem[],
+	params?: {
+		type?: string | string[];
+		tag?: string;
+	}
+): ExportedItem[] {
+	let result = items;
+
+	if (params?.type) {
+		const types = Array.isArray(params.type) ? params.type : [params.type];
+		result = result.filter((i) => types.includes(i.type));
+	}
+	if (params?.tag) {
+		result = result.filter((i) => i.tags.includes(params.tag!));
+	}
+
+	return result;
+}
+
+/**
+ * Paginate array
+ */
+function paginate<T>(
+	items: T[],
+	params?: { limit?: number; offset?: number }
+): PaginatedResponse<T> {
+	const limit = params?.limit ?? 50;
+	const offset = params?.offset ?? 0;
+	const paged = items.slice(offset, offset + limit);
+
+	return {
+		items: paged,
+		total: items.length,
+		offset,
+		limit
+	};
+}
+
+/**
+ * Find task by reference (slug or ULID prefix)
+ * AC: @gh-pages-export ac-12
+ */
+function findTaskByRef(tasks: ExportedTask[], ref: string): ExportedTask | null {
+	const normalizedRef = ref.startsWith('@') ? ref.slice(1) : ref;
+
+	// Try exact slug match first
+	const bySlug = tasks.find((t) => t.slugs.includes(normalizedRef));
+	if (bySlug) return bySlug;
+
+	// Try ULID prefix match
+	const byUlid = tasks.find((t) => t._ulid.startsWith(normalizedRef.toUpperCase()));
+	if (byUlid) return byUlid;
+
+	return null;
+}
+
+/**
+ * Find item by reference (slug or ULID prefix)
+ * AC: @gh-pages-export ac-13
+ */
+function findItemByRef(items: ExportedItem[], ref: string): ExportedItem | null {
+	const normalizedRef = ref.startsWith('@') ? ref.slice(1) : ref;
+
+	// Try exact slug match first
+	const bySlug = items.find((i) => i.slugs.includes(normalizedRef));
+	if (bySlug) return bySlug;
+
+	// Try ULID prefix match
+	const byUlid = items.find((i) => i._ulid.startsWith(normalizedRef.toUpperCase()));
+	if (byUlid) return byUlid;
+
+	return null;
+}
+
+// ============================================================
+// Static API Functions
+// ============================================================
+
+/**
+ * Fetch tasks from static snapshot
+ * AC: @gh-pages-export ac-11
+ */
+export function fetchTasksStatic(params?: {
+	status?: string;
+	type?: string;
+	tag?: string;
+	assignee?: string;
+	automation?: string;
+	limit?: number;
+	offset?: number;
+}): PaginatedResponse<TaskSummary> {
+	const snapshot = getSnapshot();
+	if (!snapshot) {
+		return { items: [], total: 0, offset: 0, limit: 50 };
+	}
+
+	const filtered = filterTasks(snapshot.tasks, params);
+	const paginated = paginate(filtered, params);
+
+	return {
+		...paginated,
+		items: paginated.items.map(toTaskSummary)
+	};
+}
+
+/**
+ * Fetch single task from static snapshot
+ * AC: @gh-pages-export ac-12
+ */
+export function fetchTaskStatic(ref: string): TaskDetail | null {
+	const snapshot = getSnapshot();
+	if (!snapshot) return null;
+
+	const task = findTaskByRef(snapshot.tasks, ref);
+	if (!task) return null;
+
+	// ExportedTask extends TaskDetail, so we can return it directly
+	return task;
+}
+
+/**
+ * Fetch items from static snapshot
+ * AC: @gh-pages-export ac-11
+ */
+export function fetchItemsStatic(params?: {
+	type?: string | string[];
+	tag?: string;
+	limit?: number;
+	offset?: number;
+}): PaginatedResponse<ItemSummary> {
+	const snapshot = getSnapshot();
+	if (!snapshot) {
+		return { items: [], total: 0, offset: 0, limit: 50 };
+	}
+
+	const filtered = filterItems(snapshot.items, params);
+	const paginated = paginate(filtered, params);
+
+	return {
+		...paginated,
+		items: paginated.items.map(toItemSummary)
+	};
+}
+
+/**
+ * Fetch single item from static snapshot
+ * AC: @gh-pages-export ac-13
+ */
+export function fetchItemStatic(ref: string): ItemDetail | null {
+	const snapshot = getSnapshot();
+	if (!snapshot) return null;
+
+	const item = findItemByRef(snapshot.items, ref);
+	if (!item) return null;
+
+	return item;
+}
+
+/**
+ * Fetch tasks linked to an item from static snapshot
+ */
+export function fetchItemTasksStatic(ref: string): PaginatedResponse<TaskSummary> {
+	const snapshot = getSnapshot();
+	if (!snapshot) {
+		return { items: [], total: 0, offset: 0, limit: 50 };
+	}
+
+	const item = findItemByRef(snapshot.items, ref);
+	if (!item) {
+		return { items: [], total: 0, offset: 0, limit: 50 };
+	}
+
+	// Find tasks that reference this item
+	const linkedTasks = snapshot.tasks.filter((t) => {
+		if (!t.spec_ref) return false;
+		const specRef = t.spec_ref.startsWith('@') ? t.spec_ref.slice(1) : t.spec_ref;
+		return item.slugs.includes(specRef) || item._ulid.startsWith(specRef.toUpperCase());
+	});
+
+	return {
+		items: linkedTasks.map(toTaskSummary),
+		total: linkedTasks.length,
+		offset: 0,
+		limit: linkedTasks.length
+	};
+}
+
+/**
+ * Fetch inbox from static snapshot
+ * AC: @gh-pages-export ac-11
+ */
+export function fetchInboxStatic(params?: {
+	limit?: number;
+	offset?: number;
+}): PaginatedResponse<InboxItem> {
+	const snapshot = getSnapshot();
+	if (!snapshot) {
+		return { items: [], total: 0, offset: 0, limit: 50 };
+	}
+
+	return paginate(snapshot.inbox, params);
+}
+
+/**
+ * Fetch session context from static snapshot
+ */
+export function fetchSessionContextStatic(): SessionContext | null {
+	const snapshot = getSnapshot();
+	return snapshot?.session ?? null;
+}
+
+/**
+ * Fetch observations from static snapshot
+ */
+export function fetchObservationsStatic(params?: {
+	type?: 'friction' | 'success' | 'question' | 'idea';
+	resolved?: boolean;
+}): PaginatedResponse<Observation> {
+	const snapshot = getSnapshot();
+	if (!snapshot) {
+		return { items: [], total: 0, offset: 0, limit: 50 };
+	}
+
+	let filtered = snapshot.observations;
+
+	if (params?.type) {
+		filtered = filtered.filter((o) => o.type === params.type);
+	}
+	if (params?.resolved !== undefined) {
+		filtered = filtered.filter((o) => o.resolved === params.resolved);
+	}
+
+	return {
+		items: filtered,
+		total: filtered.length,
+		offset: 0,
+		limit: filtered.length
+	};
+}
+
+/**
+ * Search across static snapshot
+ * AC: @gh-pages-export ac-11
+ */
+export function searchStatic(query: string): SearchResponse {
+	const snapshot = getSnapshot();
+	if (!snapshot) {
+		return { results: [], total: 0, showing: 0 };
+	}
+
+	const lowerQuery = query.toLowerCase();
+	const results: SearchResult[] = [];
+
+	// Search tasks
+	for (const task of snapshot.tasks) {
+		if (
+			task.title.toLowerCase().includes(lowerQuery) ||
+			task.slugs.some((s) => s.includes(lowerQuery))
+		) {
+			results.push({
+				type: 'task',
+				ulid: task._ulid,
+				title: task.title,
+				matchedFields: ['title']
+			});
+		}
+	}
+
+	// Search items
+	for (const item of snapshot.items) {
+		if (
+			item.title.toLowerCase().includes(lowerQuery) ||
+			item.slugs.some((s) => s.includes(lowerQuery))
+		) {
+			results.push({
+				type: 'item',
+				ulid: item._ulid,
+				title: item.title,
+				matchedFields: ['title']
+			});
+		}
+	}
+
+	// Search inbox
+	for (const inbox of snapshot.inbox) {
+		if (inbox.text.toLowerCase().includes(lowerQuery)) {
+			results.push({
+				type: 'inbox',
+				ulid: inbox._ulid,
+				title: inbox.text.slice(0, 50),
+				matchedFields: ['text']
+			});
+		}
+	}
+
+	return {
+		results: results.slice(0, 20),
+		total: results.length,
+		showing: Math.min(results.length, 20)
+	};
+}
+
+// ============================================================
+// Write Operations (throw ReadOnlyModeError)
+// ============================================================
+
+/**
+ * Start task - not available in static mode
+ * AC: @gh-pages-export ac-16, ac-18
+ */
+export function startTaskStatic(_ref: string): never {
+	throw new ReadOnlyModeError('start task');
+}
+
+/**
+ * Add task note - not available in static mode
+ * AC: @gh-pages-export ac-18
+ */
+export function addTaskNoteStatic(_ref: string, _content: string): never {
+	throw new ReadOnlyModeError('add note');
+}
+
+/**
+ * Add inbox item - not available in static mode
+ * AC: @gh-pages-export ac-17, ac-18
+ */
+export function addInboxItemStatic(_text: string, _tags?: string[]): never {
+	throw new ReadOnlyModeError('add inbox item');
+}
+
+/**
+ * Delete inbox item - not available in static mode
+ * AC: @gh-pages-export ac-18
+ */
+export function deleteInboxItemStatic(_ref: string): never {
+	throw new ReadOnlyModeError('delete inbox item');
+}

--- a/packages/web-ui/src/lib/api.ts
+++ b/packages/web-ui/src/lib/api.ts
@@ -2,11 +2,13 @@
  * API Client
  *
  * Helper functions for making requests to the kspec daemon API.
- * All functions use fetch with localhost:3456 as the base URL.
+ * Supports both daemon mode (live) and static mode (read-only JSON).
  *
  * AC Coverage:
  * - ac-26 (@multi-directory-daemon): X-Kspec-Dir header injection
  * - ac-36 (@multi-directory-daemon): Invalid project error detection
+ * - ac-11 (@gh-pages-export): Mode-aware API dispatch
+ * - ac-18 (@gh-pages-export): Graceful no-op for write operations
  */
 
 import type {
@@ -27,6 +29,18 @@ import {
 	isInvalidProjectError,
 	type Project
 } from './stores/project.svelte';
+import { isStaticMode, assertWritable } from './stores/mode.svelte';
+import {
+	fetchTasksStatic,
+	fetchTaskStatic,
+	fetchItemsStatic,
+	fetchItemStatic,
+	fetchItemTasksStatic,
+	fetchInboxStatic,
+	fetchSessionContextStatic,
+	fetchObservationsStatic,
+	searchStatic
+} from './api-static';
 import { DAEMON_API_BASE } from './constants';
 
 const API_BASE = DAEMON_API_BASE;
@@ -72,6 +86,7 @@ export async function fetchProjects(): Promise<{ projects: Project[] }> {
  * Fetch tasks with optional filters
  * AC: @web-dashboard ac-9, ac-10
  * AC: @multi-directory-daemon ac-26 - Includes X-Kspec-Dir header
+ * AC: @gh-pages-export ac-11 - Static mode support
  */
 export async function fetchTasks(params?: {
 	status?: string;
@@ -82,6 +97,11 @@ export async function fetchTasks(params?: {
 	limit?: number;
 	offset?: number;
 }): Promise<PaginatedResponse<TaskSummary>> {
+	// AC: @gh-pages-export ac-11 - Use static data in static mode
+	if (isStaticMode()) {
+		return fetchTasksStatic(params);
+	}
+
 	const url = new URL(`${API_BASE}/api/tasks`);
 
 	if (params) {
@@ -106,8 +126,18 @@ export async function fetchTasks(params?: {
  * Fetch single task by reference
  * AC: @web-dashboard ac-5
  * AC: @multi-directory-daemon ac-26 - Includes X-Kspec-Dir header
+ * AC: @gh-pages-export ac-12 - Static mode deep linking
  */
 export async function fetchTask(ref: string): Promise<TaskDetail> {
+	// AC: @gh-pages-export ac-12 - Use static data in static mode
+	if (isStaticMode()) {
+		const task = fetchTaskStatic(ref);
+		if (!task) {
+			throw new Error(`Task not found: ${ref}`);
+		}
+		return task;
+	}
+
 	const response = await fetch(`${API_BASE}/api/tasks/${ref}`, {
 		headers: getProjectHeaders()
 	});
@@ -122,8 +152,12 @@ export async function fetchTask(ref: string): Promise<TaskDetail> {
  * Start a task (change status to in_progress)
  * AC: @web-dashboard ac-7
  * AC: @multi-directory-daemon ac-26 - Includes X-Kspec-Dir header
+ * AC: @gh-pages-export ac-16, ac-18 - Disabled in static mode
  */
 export async function startTask(ref: string): Promise<void> {
+	// AC: @gh-pages-export ac-16, ac-18 - Write operations throw in static mode
+	assertWritable('start task');
+
 	const response = await fetch(`${API_BASE}/api/tasks/${ref}/start`, {
 		method: 'POST',
 		headers: getProjectHeaders()
@@ -137,8 +171,12 @@ export async function startTask(ref: string): Promise<void> {
  * Add a note to a task
  * AC: @web-dashboard ac-8
  * AC: @multi-directory-daemon ac-26 - Includes X-Kspec-Dir header
+ * AC: @gh-pages-export ac-18 - Disabled in static mode
  */
 export async function addTaskNote(ref: string, content: string): Promise<void> {
+	// AC: @gh-pages-export ac-18 - Write operations throw in static mode
+	assertWritable('add note');
+
 	const response = await fetch(`${API_BASE}/api/tasks/${ref}/note`, {
 		method: 'POST',
 		headers: {
@@ -156,6 +194,7 @@ export async function addTaskNote(ref: string, content: string): Promise<void> {
  * Fetch spec items with optional filters
  * AC: @web-dashboard ac-11
  * AC: @multi-directory-daemon ac-26 - Includes X-Kspec-Dir header
+ * AC: @gh-pages-export ac-11 - Static mode support
  */
 export async function fetchItems(params?: {
 	type?: string | string[];
@@ -163,6 +202,11 @@ export async function fetchItems(params?: {
 	limit?: number;
 	offset?: number;
 }): Promise<PaginatedResponse<ItemSummary>> {
+	// AC: @gh-pages-export ac-11 - Use static data in static mode
+	if (isStaticMode()) {
+		return fetchItemsStatic(params);
+	}
+
 	const url = new URL(`${API_BASE}/api/items`);
 
 	if (params) {
@@ -191,8 +235,18 @@ export async function fetchItems(params?: {
  * Fetch single spec item by reference
  * AC: @web-dashboard ac-12
  * AC: @multi-directory-daemon ac-26 - Includes X-Kspec-Dir header
+ * AC: @gh-pages-export ac-13 - Static mode deep linking
  */
 export async function fetchItem(ref: string): Promise<ItemDetail> {
+	// AC: @gh-pages-export ac-13 - Use static data in static mode
+	if (isStaticMode()) {
+		const item = fetchItemStatic(ref);
+		if (!item) {
+			throw new Error(`Item not found: ${ref}`);
+		}
+		return item;
+	}
+
 	const response = await fetch(`${API_BASE}/api/items/${ref}`, {
 		headers: getProjectHeaders()
 	});
@@ -207,8 +261,14 @@ export async function fetchItem(ref: string): Promise<ItemDetail> {
  * Fetch tasks linked to a spec item
  * AC: @web-dashboard ac-13
  * AC: @multi-directory-daemon ac-26 - Includes X-Kspec-Dir header
+ * AC: @gh-pages-export ac-11 - Static mode support
  */
 export async function fetchItemTasks(ref: string): Promise<PaginatedResponse<TaskSummary>> {
+	// AC: @gh-pages-export ac-11 - Use static data in static mode
+	if (isStaticMode()) {
+		return fetchItemTasksStatic(ref);
+	}
+
 	const response = await fetch(`${API_BASE}/api/items/${ref}/tasks`, {
 		headers: getProjectHeaders()
 	});
@@ -223,11 +283,17 @@ export async function fetchItemTasks(ref: string): Promise<PaginatedResponse<Tas
  * Fetch inbox items
  * AC: @web-dashboard ac-16
  * AC: @multi-directory-daemon ac-26 - Includes X-Kspec-Dir header
+ * AC: @gh-pages-export ac-11 - Static mode support
  */
 export async function fetchInbox(params?: {
 	limit?: number;
 	offset?: number;
 }): Promise<PaginatedResponse<InboxItem>> {
+	// AC: @gh-pages-export ac-11 - Use static data in static mode
+	if (isStaticMode()) {
+		return fetchInboxStatic(params);
+	}
+
 	const url = new URL(`${API_BASE}/api/inbox`);
 
 	if (params) {
@@ -252,8 +318,12 @@ export async function fetchInbox(params?: {
  * Add a new inbox item
  * AC: @web-dashboard ac-18
  * AC: @multi-directory-daemon ac-26 - Includes X-Kspec-Dir header
+ * AC: @gh-pages-export ac-17, ac-18 - Disabled in static mode
  */
 export async function addInboxItem(text: string, tags?: string[]): Promise<InboxItem> {
+	// AC: @gh-pages-export ac-17, ac-18 - Write operations throw in static mode
+	assertWritable('add inbox item');
+
 	const response = await fetch(`${API_BASE}/api/inbox`, {
 		method: 'POST',
 		headers: {
@@ -274,8 +344,12 @@ export async function addInboxItem(text: string, tags?: string[]): Promise<Inbox
  * Delete an inbox item
  * AC: @web-dashboard ac-19
  * AC: @multi-directory-daemon ac-26 - Includes X-Kspec-Dir header
+ * AC: @gh-pages-export ac-18 - Disabled in static mode
  */
 export async function deleteInboxItem(ref: string): Promise<void> {
+	// AC: @gh-pages-export ac-18 - Write operations throw in static mode
+	assertWritable('delete inbox item');
+
 	const response = await fetch(`${API_BASE}/api/inbox/${ref}`, {
 		method: 'DELETE',
 		headers: getProjectHeaders()
@@ -289,8 +363,18 @@ export async function deleteInboxItem(ref: string): Promise<void> {
  * Fetch session context
  * AC: @web-dashboard ac-20
  * AC: @multi-directory-daemon ac-26 - Includes X-Kspec-Dir header
+ * AC: @gh-pages-export ac-11 - Static mode support
  */
 export async function fetchSessionContext(): Promise<SessionContext> {
+	// AC: @gh-pages-export ac-11 - Use static data in static mode
+	if (isStaticMode()) {
+		const session = fetchSessionContextStatic();
+		if (!session) {
+			return { focus: null, threads: [], open_questions: [], updated_at: new Date().toISOString() };
+		}
+		return session;
+	}
+
 	const response = await fetch(`${API_BASE}/api/meta/session`, {
 		headers: getProjectHeaders()
 	});
@@ -305,11 +389,17 @@ export async function fetchSessionContext(): Promise<SessionContext> {
  * Fetch observations
  * AC: @web-dashboard ac-21, ac-22
  * AC: @multi-directory-daemon ac-26 - Includes X-Kspec-Dir header
+ * AC: @gh-pages-export ac-11 - Static mode support
  */
 export async function fetchObservations(params?: {
 	type?: 'friction' | 'success' | 'question' | 'idea';
 	resolved?: boolean;
 }): Promise<PaginatedResponse<Observation>> {
+	// AC: @gh-pages-export ac-11 - Use static data in static mode
+	if (isStaticMode()) {
+		return fetchObservationsStatic(params);
+	}
+
 	const url = new URL(`${API_BASE}/api/meta/observations`);
 
 	if (params) {
@@ -334,8 +424,14 @@ export async function fetchObservations(params?: {
  * Search across all entities
  * AC: @web-dashboard ac-24
  * AC: @multi-directory-daemon ac-26 - Includes X-Kspec-Dir header
+ * AC: @gh-pages-export ac-11 - Static mode support
  */
 export async function search(query: string): Promise<SearchResponse> {
+	// AC: @gh-pages-export ac-11 - Use static data in static mode
+	if (isStaticMode()) {
+		return searchStatic(query);
+	}
+
 	const url = new URL(`${API_BASE}/api/search`);
 	url.searchParams.set('q', query);
 

--- a/packages/web-ui/src/lib/components/ReadOnlyBanner.svelte
+++ b/packages/web-ui/src/lib/components/ReadOnlyBanner.svelte
@@ -1,0 +1,96 @@
+<script lang="ts">
+	/**
+	 * Read-Only Banner Component
+	 *
+	 * Displays a banner indicating the app is in read-only mode
+	 * when running from a static export.
+	 *
+	 * AC: @gh-pages-export ac-15 - Data freshness indicator
+	 * AC: @gh-pages-export ac-14 - Validation badge
+	 */
+
+	import { isStaticMode, getExportedAt, getSnapshotValidation } from '$lib/stores/mode.svelte';
+	import { Badge } from '$lib/components/ui/badge';
+	import { Button } from '$lib/components/ui/button';
+	import { RefreshCw, CheckCircle, XCircle, BookOpen } from 'lucide-svelte';
+
+	// Format the exported timestamp for display
+	function formatExportedAt(isoString: string | null): string {
+		if (!isoString) return 'Unknown';
+
+		const date = new Date(isoString);
+		const now = new Date();
+		const diffMs = now.getTime() - date.getTime();
+		const diffMins = Math.floor(diffMs / 60000);
+		const diffHours = Math.floor(diffMins / 60);
+		const diffDays = Math.floor(diffHours / 24);
+
+		// Show relative time for recent exports
+		if (diffMins < 1) return 'Just now';
+		if (diffMins < 60) return `${diffMins} minute${diffMins === 1 ? '' : 's'} ago`;
+		if (diffHours < 24) return `${diffHours} hour${diffHours === 1 ? '' : 's'} ago`;
+		if (diffDays < 7) return `${diffDays} day${diffDays === 1 ? '' : 's'} ago`;
+
+		// Show absolute date for older exports
+		return date.toLocaleDateString(undefined, {
+			year: 'numeric',
+			month: 'short',
+			day: 'numeric',
+			hour: '2-digit',
+			minute: '2-digit'
+		});
+	}
+
+	// Refresh the page to check for updates
+	function handleRefresh() {
+		window.location.reload();
+	}
+
+	// Get validation info
+	const validation = $derived(getSnapshotValidation());
+	const exportedAt = $derived(getExportedAt());
+	const formattedTime = $derived(formatExportedAt(exportedAt));
+</script>
+
+<!-- AC: @gh-pages-export ac-15 - Only show in static mode -->
+{#if isStaticMode()}
+	<div
+		role="alert"
+		class="flex items-center justify-between gap-4 border-b border-amber-200 bg-amber-50 px-4 py-2 text-sm text-amber-800 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-200"
+	>
+		<div class="flex items-center gap-3">
+			<BookOpen class="h-4 w-4 flex-shrink-0" />
+			<span>
+				<strong>Read-only mode</strong>
+				<span class="hidden sm:inline"> &mdash; Data as of: {formattedTime}</span>
+				<span class="sm:hidden"> &mdash; {formattedTime}</span>
+			</span>
+		</div>
+
+		<div class="flex items-center gap-2">
+			<!-- AC: @gh-pages-export ac-14 - Validation badge -->
+			{#if validation}
+				{#if validation.valid}
+					<Badge variant="outline" class="gap-1 border-green-500 text-green-600 dark:text-green-400">
+						<CheckCircle class="h-3 w-3" />
+						Valid
+					</Badge>
+				{:else}
+					<Badge
+						variant="outline"
+						class="gap-1 border-red-500 text-red-600 dark:text-red-400"
+						title="{validation.errorCount} errors, {validation.warningCount} warnings"
+					>
+						<XCircle class="h-3 w-3" />
+						{validation.errorCount} errors
+					</Badge>
+				{/if}
+			{/if}
+
+			<Button variant="ghost" size="sm" onclick={handleRefresh} title="Refresh page">
+				<RefreshCw class="h-4 w-4" />
+				<span class="sr-only">Refresh</span>
+			</Button>
+		</div>
+	</div>
+{/if}

--- a/packages/web-ui/src/lib/stores/mode.svelte.ts
+++ b/packages/web-ui/src/lib/stores/mode.svelte.ts
@@ -1,0 +1,155 @@
+/**
+ * Mode Store
+ *
+ * Manages the application mode: 'daemon' (live) or 'static' (read-only).
+ * Detects whether the daemon is reachable and falls back to static JSON if not.
+ *
+ * AC Coverage:
+ * - ac-11 (@gh-pages-export): Fetch JSON snapshot and render
+ * - ac-12, ac-13 (@gh-pages-export): Deep linking support
+ * - ac-15 (@gh-pages-export): Data freshness indicator
+ */
+
+import type { KspecSnapshot } from '$lib/types/snapshot';
+import { DAEMON_API_BASE } from '$lib/constants';
+
+// Application modes
+export type AppMode = 'loading' | 'daemon' | 'static';
+
+// Reactive state
+let mode = $state<AppMode>('loading');
+let snapshotData = $state<KspecSnapshot | null>(null);
+let initError = $state<string | null>(null);
+
+/**
+ * Initialize mode detection
+ *
+ * 1. Try daemon health check (2s timeout)
+ * 2. Fall back to static JSON
+ * 3. Show error state if neither available
+ *
+ * AC: @gh-pages-export ac-11
+ */
+export async function initMode(): Promise<void> {
+	// 1. Try daemon health check
+	try {
+		const response = await fetch(`${DAEMON_API_BASE}/health`, {
+			signal: AbortSignal.timeout(2000)
+		});
+		if (response.ok) {
+			mode = 'daemon';
+			return;
+		}
+	} catch {
+		// Daemon not available, try static fallback
+	}
+
+	// 2. Fall back to static JSON
+	// AC: @gh-pages-export ac-11 - Fetch kspec-snapshot.json from same origin
+	try {
+		const response = await fetch('/kspec-snapshot.json', {
+			signal: AbortSignal.timeout(5000)
+		});
+		if (response.ok) {
+			snapshotData = await response.json();
+			mode = 'static';
+			return;
+		}
+	} catch {
+		// Static JSON not available either
+	}
+
+	// 3. Neither available - default to daemon mode and let connection error handling show message
+	mode = 'daemon';
+	initError = 'Unable to connect to daemon and no static snapshot available';
+}
+
+/**
+ * Check if running in static mode
+ * AC: @gh-pages-export ac-11
+ */
+export function isStaticMode(): boolean {
+	return mode === 'static';
+}
+
+/**
+ * Check if running in daemon mode
+ */
+export function isDaemonMode(): boolean {
+	return mode === 'daemon';
+}
+
+/**
+ * Check if mode is still loading
+ */
+export function isLoading(): boolean {
+	return mode === 'loading';
+}
+
+/**
+ * Get the current mode
+ */
+export function getMode(): AppMode {
+	return mode;
+}
+
+/**
+ * Get the loaded snapshot data
+ * AC: @gh-pages-export ac-11
+ */
+export function getSnapshot(): KspecSnapshot | null {
+	return snapshotData;
+}
+
+/**
+ * Get the export timestamp for freshness display
+ * AC: @gh-pages-export ac-15
+ */
+export function getExportedAt(): string | null {
+	return snapshotData?.exported_at ?? null;
+}
+
+/**
+ * Get project info from snapshot
+ */
+export function getSnapshotProject(): { name: string; version?: string } | null {
+	return snapshotData?.project ?? null;
+}
+
+/**
+ * Get validation info from snapshot
+ * AC: @gh-pages-export ac-14
+ */
+export function getSnapshotValidation(): KspecSnapshot['validation'] | null {
+	return snapshotData?.validation ?? null;
+}
+
+/**
+ * Get initialization error if any
+ */
+export function getInitError(): string | null {
+	return initError;
+}
+
+/**
+ * Read-Only Mode Error
+ *
+ * Error thrown when a write operation is attempted in static mode.
+ * AC: @gh-pages-export ac-18
+ */
+export class ReadOnlyModeError extends Error {
+	constructor(operation: string) {
+		super(`Cannot ${operation} in read-only mode. Use the kspec CLI to make changes.`);
+		this.name = 'ReadOnlyModeError';
+	}
+}
+
+/**
+ * Guard for write operations
+ * AC: @gh-pages-export ac-18
+ */
+export function assertWritable(operation: string): void {
+	if (isStaticMode()) {
+		throw new ReadOnlyModeError(operation);
+	}
+}

--- a/packages/web-ui/src/lib/types/snapshot.ts
+++ b/packages/web-ui/src/lib/types/snapshot.ts
@@ -1,0 +1,91 @@
+/**
+ * Snapshot Types
+ *
+ * Types for the static JSON snapshot used in read-only mode.
+ * These mirror the export types from the CLI.
+ */
+
+import type {
+	TaskDetail,
+	ItemDetail,
+	InboxItem,
+	SessionContext,
+	Observation,
+	Agent,
+	Workflow
+} from '@kynetic-ai/shared';
+
+/**
+ * Convention from meta manifest
+ */
+export interface Convention {
+	_ulid: string;
+	domain: string;
+	rules: string[];
+}
+
+/**
+ * Acceptance criterion with inheritance tracking
+ */
+export interface InheritedAC {
+	id: string;
+	given: string;
+	when: string;
+	then: string;
+	_inherited_from: string;
+}
+
+/**
+ * Exported task with resolved spec reference title
+ */
+export interface ExportedTask extends TaskDetail {
+	spec_ref_title?: string;
+}
+
+/**
+ * Exported spec item with inherited ACs
+ */
+export interface ExportedItem extends ItemDetail {
+	children?: ExportedItem[];
+	inherited_acs?: InheritedAC[];
+}
+
+/**
+ * Validation result in snapshot
+ */
+export interface ExportedValidation {
+	valid: boolean;
+	errorCount: number;
+	warningCount: number;
+	errors: Array<{
+		file: string;
+		message: string;
+		path?: string;
+	}>;
+	warnings: Array<{
+		file: string;
+		message: string;
+	}>;
+}
+
+/**
+ * Full kspec snapshot structure
+ */
+export interface KspecSnapshot {
+	version: string;
+	exported_at: string;
+	project: {
+		name: string;
+		version?: string;
+		description?: string;
+	};
+	tasks: ExportedTask[];
+	items: ExportedItem[];
+	inbox: InboxItem[];
+	session: SessionContext | null;
+	observations: Observation[];
+	agents: Agent[];
+	workflows: Workflow[];
+	conventions: Convention[];
+	validation?: ExportedValidation;
+}

--- a/src/cli/commands/export.ts
+++ b/src/cli/commands/export.ts
@@ -1,0 +1,159 @@
+/**
+ * Export Command
+ *
+ * Exports kspec data to JSON or HTML format for static site hosting.
+ * AC: @gh-pages-export ac-1, ac-2, ac-3, ac-4, ac-5, ac-6, ac-7
+ */
+
+import * as fs from "node:fs/promises";
+import chalk from "chalk";
+import type { Command } from "commander";
+import {
+  calculateExportStats,
+  formatBytes,
+  generateHtmlExport,
+  generateJsonSnapshot,
+} from "../../export/index.js";
+import { EXIT_CODES } from "../exit-codes.js";
+import { error, info, isJsonMode, output, success, warn } from "../output.js";
+
+/**
+ * Register the export command.
+ */
+export function registerExportCommand(program: Command): void {
+  program
+    .command("export")
+    .description("Export kspec data to JSON or HTML format")
+    .requiredOption(
+      "--format <format>",
+      "Output format (json or html)",
+      "json"
+    )
+    .option("-o, --output <path>", "Output file path (defaults to stdout for JSON)")
+    .option(
+      "--include-validation",
+      "Include validation results in the export",
+      false
+    )
+    .option(
+      "--dry-run",
+      "Show what would be exported without writing files",
+      false
+    )
+    .action(async (options) => {
+      try {
+        // Validate format
+        // AC: @gh-pages-export ac-1, ac-6
+        if (options.format !== "json" && options.format !== "html") {
+          error(`Invalid format: ${options.format}. Must be 'json' or 'html'.`);
+          process.exit(EXIT_CODES.USAGE_ERROR);
+        }
+
+        // HTML format requires output file
+        // AC: @gh-pages-export ac-6
+        if (options.format === "html" && !options.output) {
+          error("HTML format requires --output <path>");
+          process.exit(EXIT_CODES.USAGE_ERROR);
+        }
+
+        info("Generating snapshot...");
+
+        // Generate the snapshot
+        // AC: @gh-pages-export ac-1, ac-2, ac-3, ac-4, ac-5
+        const snapshot = await generateJsonSnapshot(options.includeValidation);
+
+        // AC: @trait-dry-run ac-1, ac-2, ac-3 - Show preview without writing
+        if (options.dryRun) {
+          const stats = calculateExportStats(snapshot);
+
+          // AC: @trait-dry-run ac-3 - Clear indication this is a preview
+          // AC: @gh-pages-export ac-7
+          const dryRunOutput = {
+            dry_run: true,
+            format: options.format,
+            output: options.output || "(stdout)",
+            stats: {
+              tasks: stats.taskCount,
+              items: stats.itemCount,
+              inbox: stats.inboxCount,
+              observations: stats.observationCount,
+              agents: stats.agentCount,
+              workflows: stats.workflowCount,
+              conventions: stats.conventionCount,
+              estimated_size: formatBytes(stats.estimatedSizeBytes),
+            },
+            validation_included: options.includeValidation,
+            ...(options.includeValidation && snapshot.validation
+              ? {
+                  validation_summary: {
+                    valid: snapshot.validation.valid,
+                    errors: snapshot.validation.errorCount,
+                    warnings: snapshot.validation.warningCount,
+                  },
+                }
+              : {}),
+          };
+
+          output(dryRunOutput, () => {
+            console.log(chalk.cyan("\n=== Dry Run - No files will be written ===\n"));
+            console.log(chalk.gray("Format:"), options.format);
+            console.log(chalk.gray("Output:"), options.output || "(stdout)");
+            console.log();
+            console.log(chalk.gray("─".repeat(40)));
+            console.log(chalk.bold("Export Statistics:"));
+            console.log(chalk.gray("─".repeat(40)));
+            console.log(`  Tasks:        ${stats.taskCount}`);
+            console.log(`  Items:        ${stats.itemCount}`);
+            console.log(`  Inbox:        ${stats.inboxCount}`);
+            console.log(`  Observations: ${stats.observationCount}`);
+            console.log(`  Agents:       ${stats.agentCount}`);
+            console.log(`  Workflows:    ${stats.workflowCount}`);
+            console.log(`  Conventions:  ${stats.conventionCount}`);
+            console.log();
+            console.log(
+              `  Estimated size: ${chalk.cyan(formatBytes(stats.estimatedSizeBytes))}`
+            );
+
+            if (options.includeValidation && snapshot.validation) {
+              console.log();
+              console.log(chalk.gray("─".repeat(40)));
+              console.log(chalk.bold("Validation:"));
+              console.log(chalk.gray("─".repeat(40)));
+              const validIcon = snapshot.validation.valid
+                ? chalk.green("✓")
+                : chalk.red("✗");
+              console.log(`  Status: ${validIcon} ${snapshot.validation.valid ? "Valid" : "Invalid"}`);
+              console.log(`  Errors: ${snapshot.validation.errorCount}`);
+              console.log(`  Warnings: ${snapshot.validation.warningCount}`);
+            }
+            console.log();
+          });
+
+          return;
+        }
+
+        // Generate output based on format
+        let content: string;
+
+        if (options.format === "json") {
+          // AC: @gh-pages-export ac-1
+          content = JSON.stringify(snapshot, null, 2);
+        } else {
+          // AC: @gh-pages-export ac-6
+          content = generateHtmlExport(snapshot);
+        }
+
+        // Write or output
+        if (options.output) {
+          await fs.writeFile(options.output, content, "utf-8");
+          success(`Exported to ${options.output}`);
+        } else {
+          // JSON to stdout (no success message to keep output clean)
+          console.log(content);
+        }
+      } catch (err) {
+        error("Export failed", err);
+        process.exit(EXIT_CODES.ERROR);
+      }
+    });
+}

--- a/src/cli/commands/index.ts
+++ b/src/cli/commands/index.ts
@@ -2,6 +2,7 @@
 
 export { registerCloneForTestingCommand } from "./clone-for-testing.js";
 export { registerDeriveCommand } from "./derive.js";
+export { registerExportCommand } from "./export.js";
 export { registerHelpCommand } from "./help.js";
 export { registerInboxCommands } from "./inbox.js";
 export { registerInitCommand } from "./init.js";

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -15,6 +15,7 @@ import { initContext } from "../parser/yaml.js";
 import {
   registerCloneForTestingCommand,
   registerDeriveCommand,
+  registerExportCommand,
   registerHelpCommand,
   registerInboxCommands,
   registerInitCommand,
@@ -162,6 +163,7 @@ registerModuleCommands(program);
 registerCloneForTestingCommand(program);
 registerWorkflowCommand(program);
 registerMergeDriverCommand(program);
+registerExportCommand(program);
 
 // Handle unknown commands with suggestions
 program.on("command:*", (operands) => {

--- a/src/export/html.ts
+++ b/src/export/html.ts
@@ -1,0 +1,242 @@
+/**
+ * HTML Export Module
+ *
+ * Generates self-contained HTML files with embedded JSON and SPA loader.
+ * AC: @gh-pages-export ac-6
+ */
+
+import type { KspecSnapshot } from "./types.js";
+
+/**
+ * Generate a self-contained HTML file with embedded JSON snapshot.
+ *
+ * The HTML includes:
+ * - Embedded JSON data in a script tag
+ * - Redirect to hosted SPA (or minimal inline viewer)
+ * - Fallback for viewing raw data
+ *
+ * AC: @gh-pages-export ac-6
+ */
+export function generateHtmlExport(snapshot: KspecSnapshot): string {
+  const jsonData = JSON.stringify(snapshot, null, 2);
+  const escapedJson = jsonData
+    .replace(/</g, "\\u003c")
+    .replace(/>/g, "\\u003e")
+    .replace(/&/g, "\\u0026");
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>${escapeHtml(snapshot.project.name)} - kspec Export</title>
+  <style>
+    :root {
+      --bg: #1a1a2e;
+      --fg: #eee;
+      --accent: #4ade80;
+      --muted: #666;
+      --border: #333;
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: var(--bg);
+      color: var(--fg);
+      line-height: 1.6;
+      padding: 2rem;
+    }
+    .container { max-width: 1200px; margin: 0 auto; }
+    header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: 2rem;
+      padding-bottom: 1rem;
+      border-bottom: 1px solid var(--border);
+    }
+    h1 { font-size: 1.5rem; font-weight: 600; }
+    .meta { color: var(--muted); font-size: 0.875rem; }
+    .badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.25rem 0.75rem;
+      border-radius: 9999px;
+      font-size: 0.75rem;
+      font-weight: 500;
+    }
+    .badge.valid { background: rgba(74, 222, 128, 0.2); color: var(--accent); }
+    .badge.invalid { background: rgba(239, 68, 68, 0.2); color: #ef4444; }
+    .stats {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+      gap: 1rem;
+      margin-bottom: 2rem;
+    }
+    .stat {
+      background: rgba(255, 255, 255, 0.05);
+      padding: 1rem;
+      border-radius: 0.5rem;
+      border: 1px solid var(--border);
+    }
+    .stat-value { font-size: 2rem; font-weight: 700; color: var(--accent); }
+    .stat-label { color: var(--muted); font-size: 0.875rem; }
+    .section { margin-bottom: 2rem; }
+    .section-title {
+      font-size: 1rem;
+      font-weight: 600;
+      margin-bottom: 1rem;
+      color: var(--muted);
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+    .list { display: flex; flex-direction: column; gap: 0.5rem; }
+    .item {
+      background: rgba(255, 255, 255, 0.05);
+      padding: 1rem;
+      border-radius: 0.5rem;
+      border: 1px solid var(--border);
+    }
+    .item-title { font-weight: 500; }
+    .item-meta { color: var(--muted); font-size: 0.875rem; }
+    .status {
+      display: inline-block;
+      padding: 0.125rem 0.5rem;
+      border-radius: 0.25rem;
+      font-size: 0.75rem;
+      font-weight: 500;
+    }
+    .status-pending { background: rgba(251, 191, 36, 0.2); color: #fbbf24; }
+    .status-in_progress { background: rgba(59, 130, 246, 0.2); color: #3b82f6; }
+    .status-pending_review { background: rgba(168, 85, 247, 0.2); color: #a855f7; }
+    .status-completed { background: rgba(74, 222, 128, 0.2); color: #4ade80; }
+    .status-cancelled { background: rgba(239, 68, 68, 0.2); color: #ef4444; }
+    .status-blocked { background: rgba(239, 68, 68, 0.2); color: #ef4444; }
+    .read-only-banner {
+      background: rgba(251, 191, 36, 0.2);
+      color: #fbbf24;
+      padding: 0.75rem 1rem;
+      border-radius: 0.5rem;
+      margin-bottom: 1rem;
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+    }
+    footer {
+      margin-top: 2rem;
+      padding-top: 1rem;
+      border-top: 1px solid var(--border);
+      color: var(--muted);
+      font-size: 0.875rem;
+      text-align: center;
+    }
+    a { color: var(--accent); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <header>
+      <div>
+        <h1>${escapeHtml(snapshot.project.name)}</h1>
+        <div class="meta">
+          Exported: ${new Date(snapshot.exported_at).toLocaleString()}
+          ${snapshot.project.version ? ` • v${escapeHtml(snapshot.project.version)}` : ""}
+        </div>
+      </div>
+      ${snapshot.validation ? `
+        <span class="badge ${snapshot.validation.valid ? "valid" : "invalid"}">
+          ${snapshot.validation.valid ? "✓ Valid" : `✗ ${snapshot.validation.errorCount} errors`}
+        </span>
+      ` : ""}
+    </header>
+
+    <div class="read-only-banner">
+      <span>📖</span>
+      <span>Read-only view. Use the kspec CLI to make changes.</span>
+    </div>
+
+    <div class="stats">
+      <div class="stat">
+        <div class="stat-value">${snapshot.tasks.length}</div>
+        <div class="stat-label">Tasks</div>
+      </div>
+      <div class="stat">
+        <div class="stat-value">${snapshot.items.length}</div>
+        <div class="stat-label">Spec Items</div>
+      </div>
+      <div class="stat">
+        <div class="stat-value">${snapshot.inbox.length}</div>
+        <div class="stat-label">Inbox Items</div>
+      </div>
+      <div class="stat">
+        <div class="stat-value">${snapshot.observations.length}</div>
+        <div class="stat-label">Observations</div>
+      </div>
+    </div>
+
+    <div class="section">
+      <div class="section-title">Recent Tasks</div>
+      <div class="list">
+        ${snapshot.tasks.slice(0, 10).map(task => `
+          <div class="item">
+            <div class="item-title">
+              <span class="status status-${task.status}">${task.status}</span>
+              ${escapeHtml(task.title)}
+            </div>
+            <div class="item-meta">
+              @${task.slugs[0] || task._ulid.slice(0, 8)}
+              ${task.spec_ref_title ? ` • ${escapeHtml(task.spec_ref_title)}` : ""}
+            </div>
+          </div>
+        `).join("")}
+        ${snapshot.tasks.length > 10 ? `<div class="item-meta">... and ${snapshot.tasks.length - 10} more tasks</div>` : ""}
+      </div>
+    </div>
+
+    <div class="section">
+      <div class="section-title">Spec Items</div>
+      <div class="list">
+        ${snapshot.items.slice(0, 10).map(item => `
+          <div class="item">
+            <div class="item-title">${escapeHtml(item.title)}</div>
+            <div class="item-meta">
+              ${item.type || "item"} • @${item.slugs[0] || item._ulid.slice(0, 8)}
+              ${item.acceptance_criteria?.length ? ` • ${item.acceptance_criteria.length} ACs` : ""}
+            </div>
+          </div>
+        `).join("")}
+        ${snapshot.items.length > 10 ? `<div class="item-meta">... and ${snapshot.items.length - 10} more items</div>` : ""}
+      </div>
+    </div>
+
+    <footer>
+      Generated by <a href="https://github.com/chapel/kynetic-spec">kspec</a> v${escapeHtml(snapshot.version)}
+    </footer>
+  </div>
+
+  <!-- Embedded snapshot data -->
+  <script id="kspec-data" type="application/json">
+${escapedJson}
+  </script>
+
+  <script>
+    // Make snapshot available globally
+    window.KSPEC_STATIC_DATA = JSON.parse(document.getElementById('kspec-data').textContent);
+  </script>
+</body>
+</html>`;
+}
+
+/**
+ * Escape HTML special characters.
+ */
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+}

--- a/src/export/index.ts
+++ b/src/export/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Export Module
+ *
+ * Provides functionality for exporting kspec data to various formats.
+ */
+
+export * from "./types.js";
+export * from "./json.js";
+export * from "./html.js";

--- a/src/export/json.ts
+++ b/src/export/json.ts
@@ -1,0 +1,252 @@
+/**
+ * JSON Export Module
+ *
+ * Generates JSON snapshots of kspec data for static site hosting.
+ * Handles reference resolution, trait expansion, and validation inclusion.
+ *
+ * AC: @gh-pages-export ac-1, ac-2, ac-3, ac-4, ac-5
+ */
+
+import { readFileSync } from "node:fs";
+import * as path from "node:path";
+import type { AcceptanceCriterion, InboxItem } from "../schema/index.js";
+import {
+  buildIndexes,
+  initContext,
+  loadAllItems,
+  loadAllTasks,
+  loadInboxItems,
+  loadMetaContext,
+  type LoadedSpecItem,
+  type LoadedTask,
+  ReferenceIndex,
+  validate,
+} from "../parser/index.js";
+import { loadSessionContext } from "../parser/meta.js";
+import { TraitIndex } from "../parser/traits.js";
+import type {
+  ExportedItem,
+  ExportedTask,
+  ExportedValidation,
+  ExportStats,
+  InheritedAC,
+  KspecSnapshot,
+} from "./types.js";
+
+/**
+ * Get the kspec version from package.json
+ */
+function getKspecVersion(): string {
+  try {
+    // Try to find package.json relative to this module
+    const packagePath = path.resolve(
+      import.meta.dirname || __dirname,
+      "../../package.json"
+    );
+    const packageJson = JSON.parse(readFileSync(packagePath, "utf-8"));
+    return packageJson.version || "unknown";
+  } catch {
+    return "unknown";
+  }
+}
+
+/**
+ * Resolve spec_ref to its title for display.
+ * AC: @gh-pages-export ac-3
+ */
+function resolveSpecRefTitle(
+  specRef: string | null | undefined,
+  items: LoadedSpecItem[],
+  refIndex: ReferenceIndex
+): string | undefined {
+  if (!specRef) return undefined;
+
+  const result = refIndex.resolve(specRef);
+  if (!result.ok) return undefined;
+
+  const item = items.find((i) => i._ulid === result.ulid);
+  return item?.title;
+}
+
+/**
+ * Expand tasks with resolved spec reference titles.
+ * AC: @gh-pages-export ac-3
+ */
+function expandTasks(
+  tasks: LoadedTask[],
+  items: LoadedSpecItem[],
+  refIndex: ReferenceIndex
+): ExportedTask[] {
+  return tasks.map((task) => {
+    const exportedTask: ExportedTask = { ...task };
+
+    if (task.spec_ref) {
+      const title = resolveSpecRefTitle(task.spec_ref, items, refIndex);
+      if (title) {
+        exportedTask.spec_ref_title = title;
+      }
+    }
+
+    return exportedTask;
+  });
+}
+
+/**
+ * Get inherited ACs from traits for a spec item.
+ * AC: @gh-pages-export ac-4
+ */
+function getInheritedACs(
+  item: LoadedSpecItem,
+  traitIndex: TraitIndex
+): InheritedAC[] {
+  const inheritedAC = traitIndex.getInheritedAC(item._ulid);
+
+  return inheritedAC.map(({ trait, ac }) => ({
+    ...ac,
+    _inherited_from: `@${trait.slug}`,
+  }));
+}
+
+/**
+ * Expand items with inherited ACs from traits.
+ * AC: @gh-pages-export ac-4
+ */
+function expandItems(
+  items: LoadedSpecItem[],
+  traitIndex: TraitIndex
+): ExportedItem[] {
+  return items.map((item) => {
+    const exportedItem: ExportedItem = {
+      ...item,
+      acceptance_criteria: item.acceptance_criteria,
+    };
+
+    // Get inherited ACs from traits
+    const inheritedACs = getInheritedACs(item, traitIndex);
+    if (inheritedACs.length > 0) {
+      exportedItem.inherited_acs = inheritedACs;
+    }
+
+    return exportedItem;
+  });
+}
+
+/**
+ * Convert validation result to exported format.
+ * AC: @gh-pages-export ac-5
+ */
+function convertValidationResult(
+  result: Awaited<ReturnType<typeof validate>>
+): ExportedValidation {
+  return {
+    valid: result.valid,
+    errorCount: result.schemaErrors.length + result.refErrors.length,
+    warningCount: result.orphans.length + result.completenessWarnings.length,
+    errors: [
+      ...result.schemaErrors.map((e) => ({
+        file: e.file,
+        message: e.message,
+        path: e.path,
+      })),
+      ...result.refErrors.map((e) => ({
+        file: e.sourceFile || "unknown",
+        message: e.message,
+      })),
+    ],
+    warnings: [
+      ...result.orphans.map((o) => ({
+        file: "orphan",
+        message: `Orphaned ${o.type}: ${o.title}`,
+      })),
+      ...result.completenessWarnings.map((w) => ({
+        file: w.itemRef,
+        message: w.message,
+      })),
+    ],
+  };
+}
+
+/**
+ * Generate a JSON snapshot of all kspec data.
+ * AC: @gh-pages-export ac-1, ac-2, ac-3, ac-4, ac-5
+ */
+export async function generateJsonSnapshot(
+  includeValidation = false
+): Promise<KspecSnapshot> {
+  const ctx = await initContext();
+
+  // Load all data
+  const tasks = await loadAllTasks(ctx);
+  const items = await loadAllItems(ctx);
+  const inboxItems = await loadInboxItems(ctx);
+  const metaContext = await loadMetaContext(ctx);
+  const sessionContext = await loadSessionContext(ctx);
+
+  // Build indexes
+  const { refIndex, traitIndex } = await buildIndexes(ctx);
+
+  // Expand tasks with resolved spec references
+  const exportedTasks = expandTasks(tasks, items, refIndex);
+
+  // Expand items with inherited ACs
+  const exportedItems = expandItems(items, traitIndex);
+
+  // Build the snapshot
+  const snapshot: KspecSnapshot = {
+    version: getKspecVersion(),
+    exported_at: new Date().toISOString(),
+    project: {
+      name: ctx.manifest?.project?.name || "Unknown Project",
+      version: ctx.manifest?.project?.version,
+    },
+    tasks: exportedTasks,
+    items: exportedItems,
+    inbox: inboxItems,
+    session: sessionContext,
+    observations: metaContext.observations,
+    agents: metaContext.agents,
+    workflows: metaContext.workflows,
+    conventions: metaContext.conventions,
+  };
+
+  // Include validation if requested
+  if (includeValidation) {
+    const validationResult = await validate(ctx, {
+      schema: true,
+      refs: true,
+      orphans: true,
+      completeness: true,
+    });
+    snapshot.validation = convertValidationResult(validationResult);
+  }
+
+  return snapshot;
+}
+
+/**
+ * Calculate export statistics for dry-run.
+ * AC: @gh-pages-export ac-7
+ */
+export function calculateExportStats(snapshot: KspecSnapshot): ExportStats {
+  const jsonString = JSON.stringify(snapshot);
+
+  return {
+    taskCount: snapshot.tasks.length,
+    itemCount: snapshot.items.length,
+    inboxCount: snapshot.inbox.length,
+    observationCount: snapshot.observations.length,
+    agentCount: snapshot.agents.length,
+    workflowCount: snapshot.workflows.length,
+    conventionCount: snapshot.conventions.length,
+    estimatedSizeBytes: Buffer.byteLength(jsonString, "utf-8"),
+  };
+}
+
+/**
+ * Format bytes to human-readable size.
+ */
+export function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}

--- a/src/export/types.ts
+++ b/src/export/types.ts
@@ -1,0 +1,138 @@
+/**
+ * Export Types
+ *
+ * Types for the kspec export functionality.
+ * These define the structure of exported JSON snapshots and related types.
+ * AC: @gh-pages-export ac-2, ac-3, ac-4
+ */
+
+import type {
+  AcceptanceCriterion,
+  Agent,
+  Convention,
+  InboxItem,
+  Observation,
+  SessionContext,
+  Workflow,
+} from "../schema/index.js";
+import type { LoadedSpecItem, LoadedTask } from "../parser/yaml.js";
+
+/**
+ * Exported task with resolved spec reference title.
+ * AC: @gh-pages-export ac-3
+ */
+export interface ExportedTask extends LoadedTask {
+  /** Resolved title of the linked spec item (for display) */
+  spec_ref_title?: string;
+}
+
+/**
+ * Acceptance criterion with inheritance tracking.
+ * AC: @gh-pages-export ac-4
+ */
+export interface InheritedAC extends AcceptanceCriterion {
+  /** Reference to the trait this AC was inherited from */
+  _inherited_from: string;
+}
+
+/**
+ * Exported spec item with nested hierarchy and inherited ACs.
+ * AC: @gh-pages-export ac-4
+ */
+export interface ExportedItem extends Omit<LoadedSpecItem, 'acceptance_criteria'> {
+  /** Own acceptance criteria */
+  acceptance_criteria?: AcceptanceCriterion[];
+  /** Nested child items */
+  children?: ExportedItem[];
+  /** Acceptance criteria inherited from traits */
+  inherited_acs?: InheritedAC[];
+}
+
+/**
+ * Project metadata in the snapshot.
+ * AC: @gh-pages-export ac-2
+ */
+export interface ExportedProject {
+  name: string;
+  version?: string;
+  description?: string;
+}
+
+/**
+ * Validation result included in the snapshot.
+ * AC: @gh-pages-export ac-5
+ */
+export interface ExportedValidation {
+  valid: boolean;
+  errorCount: number;
+  warningCount: number;
+  errors: Array<{
+    file: string;
+    message: string;
+    path?: string;
+  }>;
+  warnings: Array<{
+    file: string;
+    message: string;
+  }>;
+}
+
+/**
+ * Full kspec snapshot structure.
+ * AC: @gh-pages-export ac-2
+ */
+export interface KspecSnapshot {
+  /** kspec version that generated this snapshot */
+  version: string;
+  /** ISO timestamp when the snapshot was exported */
+  exported_at: string;
+  /** Project metadata */
+  project: ExportedProject;
+  /** All tasks with resolved spec references */
+  tasks: ExportedTask[];
+  /** All spec items with hierarchy and inherited ACs */
+  items: ExportedItem[];
+  /** Inbox items */
+  inbox: InboxItem[];
+  /** Session context */
+  session: SessionContext | null;
+  /** Observations */
+  observations: Observation[];
+  /** Agents */
+  agents: Agent[];
+  /** Workflows */
+  workflows: Workflow[];
+  /** Conventions */
+  conventions: Convention[];
+  /** Validation results (optional) */
+  validation?: ExportedValidation;
+}
+
+/**
+ * Options for the export command.
+ */
+export interface ExportOptions {
+  /** Output format */
+  format: 'json' | 'html';
+  /** Output path (optional, defaults to stdout for json) */
+  output?: string;
+  /** Include validation results */
+  includeValidation?: boolean;
+  /** Dry run - show stats without writing */
+  dryRun?: boolean;
+}
+
+/**
+ * Statistics shown during dry-run.
+ * AC: @gh-pages-export ac-7
+ */
+export interface ExportStats {
+  taskCount: number;
+  itemCount: number;
+  inboxCount: number;
+  observationCount: number;
+  agentCount: number;
+  workflowCount: number;
+  conventionCount: number;
+  estimatedSizeBytes: number;
+}

--- a/tests/export/cli.test.ts
+++ b/tests/export/cli.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Export CLI Integration Tests
+ *
+ * AC: @gh-pages-export ac-1, ac-6, ac-7
+ * AC: @trait-dry-run ac-1, ac-2, ac-3
+ */
+
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { cleanupTempDir, kspec, setupTempFixtures } from "../helpers/cli.js";
+
+describe("Export CLI", () => {
+  let tempDir: string;
+
+  beforeAll(async () => {
+    tempDir = await setupTempFixtures();
+  });
+
+  afterAll(async () => {
+    await cleanupTempDir(tempDir);
+  });
+
+  // AC: @gh-pages-export ac-7
+  // AC: @trait-dry-run ac-1, ac-2, ac-3
+  describe("kspec export --dry-run", () => {
+    it("shows statistics without writing files", () => {
+      const result = kspec("export --format json --dry-run", tempDir);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain("Dry Run");
+      expect(result.stdout).toContain("Tasks:");
+      expect(result.stdout).toContain("Items:");
+      expect(result.stdout).toContain("Estimated size:");
+    });
+
+    it("shows validation info when --include-validation used", () => {
+      const result = kspec(
+        "export --format json --dry-run --include-validation",
+        tempDir
+      );
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain("Validation:");
+      expect(result.stdout).toContain("Status:");
+      expect(result.stdout).toContain("Errors:");
+    });
+  });
+
+  // AC: @gh-pages-export ac-1
+  describe("kspec export --format json", () => {
+    it("outputs valid JSON to stdout", () => {
+      const result = kspec("export --format json", tempDir);
+
+      expect(result.exitCode).toBe(0);
+
+      // Should contain JSON structure
+      expect(result.stdout).toContain('"version"');
+      expect(result.stdout).toContain('"exported_at"');
+      expect(result.stdout).toContain('"tasks"');
+      expect(result.stdout).toContain('"items"');
+    });
+
+    it("writes to file when --output specified", async () => {
+      const outputPath = path.join(tempDir, "export-test.json");
+
+      const result = kspec(
+        `export --format json -o "${outputPath}"`,
+        tempDir
+      );
+
+      expect(result.exitCode).toBe(0);
+
+      // Verify file was created
+      const content = await fs.readFile(outputPath, "utf-8");
+      const parsed = JSON.parse(content);
+
+      expect(parsed).toHaveProperty("version");
+      expect(parsed).toHaveProperty("exported_at");
+      expect(parsed).toHaveProperty("tasks");
+    });
+  });
+
+  // AC: @gh-pages-export ac-6
+  describe("kspec export --format html", () => {
+    it("requires --output for html format", () => {
+      const result = kspec("export --format html", tempDir, { expectFail: true });
+
+      expect(result.exitCode).toBe(2); // USAGE_ERROR
+      expect(result.stderr).toContain("requires --output");
+    });
+
+    it("generates HTML file", async () => {
+      const outputPath = path.join(tempDir, "export-test.html");
+
+      const result = kspec(
+        `export --format html -o "${outputPath}"`,
+        tempDir
+      );
+
+      expect(result.exitCode).toBe(0);
+
+      // Verify file was created
+      const content = await fs.readFile(outputPath, "utf-8");
+
+      expect(content).toContain("<!DOCTYPE html>");
+      expect(content).toContain("kspec-data");
+      expect(content).toContain("window.KSPEC_STATIC_DATA");
+    });
+  });
+
+  describe("error handling", () => {
+    it("rejects invalid format", () => {
+      const result = kspec("export --format xml", tempDir, { expectFail: true });
+
+      expect(result.exitCode).toBe(2); // USAGE_ERROR
+      expect(result.stderr).toContain("Invalid format");
+    });
+  });
+});

--- a/tests/export/html.test.ts
+++ b/tests/export/html.test.ts
@@ -1,0 +1,171 @@
+/**
+ * HTML Export Tests
+ *
+ * AC: @gh-pages-export ac-6
+ */
+
+import { describe, expect, it } from "vitest";
+import { generateHtmlExport, type KspecSnapshot } from "../../src/export/index.js";
+
+describe("HTML Export", () => {
+  const mockSnapshot: KspecSnapshot = {
+    version: "0.1.0",
+    exported_at: "2026-01-28T00:00:00.000Z",
+    project: {
+      name: "Test Project",
+      version: "1.0.0",
+    },
+    tasks: [
+      {
+        _ulid: "01TEST000000000000000000",
+        slugs: ["test-task"],
+        title: "Test Task",
+        type: "task",
+        status: "pending",
+        blocked_by: [],
+        depends_on: [],
+        context: [],
+        priority: 3,
+        tags: [],
+        vcs_refs: [],
+        created_at: "2026-01-01T00:00:00.000Z",
+        notes: [],
+        todos: [],
+      },
+    ],
+    items: [
+      {
+        _ulid: "01SPEC000000000000000000",
+        slugs: ["test-spec"],
+        title: "Test Spec",
+        type: "feature",
+        tags: [],
+        depends_on: [],
+        implements: [],
+        relates_to: [],
+        tests: [],
+        traits: [],
+        notes: [],
+        acceptance_criteria: [
+          {
+            id: "ac-1",
+            given: "test",
+            when: "test",
+            then: "test",
+          },
+        ],
+      },
+    ],
+    inbox: [],
+    session: null,
+    observations: [],
+    agents: [],
+    workflows: [],
+    conventions: [],
+  };
+
+  // AC: @gh-pages-export ac-6
+  describe("generateHtmlExport", () => {
+    it("generates valid HTML document", () => {
+      const html = generateHtmlExport(mockSnapshot);
+
+      expect(html).toContain("<!DOCTYPE html>");
+      expect(html).toContain("<html lang=\"en\">");
+      expect(html).toContain("</html>");
+    });
+
+    it("includes project name in title", () => {
+      const html = generateHtmlExport(mockSnapshot);
+
+      expect(html).toContain("<title>Test Project - kspec Export</title>");
+    });
+
+    it("includes embedded JSON data", () => {
+      const html = generateHtmlExport(mockSnapshot);
+
+      expect(html).toContain('<script id="kspec-data" type="application/json">');
+      expect(html).toContain("window.KSPEC_STATIC_DATA");
+    });
+
+    it("includes export timestamp", () => {
+      const html = generateHtmlExport(mockSnapshot);
+
+      expect(html).toContain("Exported:");
+    });
+
+    it("shows task count", () => {
+      const html = generateHtmlExport(mockSnapshot);
+
+      expect(html).toContain(">1</div>");
+      expect(html).toContain("Tasks");
+    });
+
+    it("shows read-only banner", () => {
+      const html = generateHtmlExport(mockSnapshot);
+
+      expect(html).toContain("Read-only view");
+    });
+
+    it("escapes HTML in project name", () => {
+      const snapshotWithHtml: KspecSnapshot = {
+        ...mockSnapshot,
+        project: {
+          name: "<script>alert('xss')</script>",
+        },
+      };
+
+      const html = generateHtmlExport(snapshotWithHtml);
+
+      expect(html).not.toContain("<script>alert('xss')</script>");
+      expect(html).toContain("&lt;script&gt;");
+    });
+
+    it("escapes JSON for HTML embedding", () => {
+      const snapshotWithSpecialChars: KspecSnapshot = {
+        ...mockSnapshot,
+        project: {
+          name: "Test </script> Project",
+        },
+      };
+
+      const html = generateHtmlExport(snapshotWithSpecialChars);
+
+      // JSON should be escaped to prevent script injection
+      expect(html).toContain("\\u003c/script\\u003e");
+    });
+
+    it("includes validation badge when validation present", () => {
+      const snapshotWithValidation: KspecSnapshot = {
+        ...mockSnapshot,
+        validation: {
+          valid: true,
+          errorCount: 0,
+          warningCount: 5,
+          errors: [],
+          warnings: [],
+        },
+      };
+
+      const html = generateHtmlExport(snapshotWithValidation);
+
+      expect(html).toContain("Valid");
+    });
+
+    it("shows error count when validation fails", () => {
+      const snapshotWithErrors: KspecSnapshot = {
+        ...mockSnapshot,
+        validation: {
+          valid: false,
+          errorCount: 3,
+          warningCount: 5,
+          errors: [],
+          warnings: [],
+        },
+      };
+
+      const html = generateHtmlExport(snapshotWithErrors);
+
+      expect(html).toContain("3 errors");
+    });
+  });
+});

--- a/tests/export/json.test.ts
+++ b/tests/export/json.test.ts
@@ -1,0 +1,158 @@
+/**
+ * JSON Export Tests
+ *
+ * AC: @gh-pages-export ac-1, ac-2, ac-3, ac-4, ac-5, ac-7
+ */
+
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { beforeAll, afterAll, describe, expect, it } from "vitest";
+import {
+  calculateExportStats,
+  formatBytes,
+  generateJsonSnapshot,
+  type KspecSnapshot,
+} from "../../src/export/index.js";
+import { setupTempFixtures, cleanupTempDir } from "../helpers/cli.js";
+
+describe("JSON Export", () => {
+  let tempDir: string;
+  let originalCwd: string;
+
+  beforeAll(async () => {
+    originalCwd = process.cwd();
+    tempDir = await setupTempFixtures();
+    process.chdir(tempDir);
+  });
+
+  afterAll(async () => {
+    process.chdir(originalCwd);
+    await cleanupTempDir(tempDir);
+  });
+
+  // AC: @gh-pages-export ac-1
+  describe("generateJsonSnapshot", () => {
+    it("generates snapshot with all data types", async () => {
+      const snapshot = await generateJsonSnapshot();
+
+      // Verify structure
+      expect(snapshot).toHaveProperty("version");
+      expect(snapshot).toHaveProperty("exported_at");
+      expect(snapshot).toHaveProperty("project");
+      expect(snapshot).toHaveProperty("tasks");
+      expect(snapshot).toHaveProperty("items");
+      expect(snapshot).toHaveProperty("inbox");
+      expect(snapshot).toHaveProperty("observations");
+      expect(snapshot).toHaveProperty("agents");
+      expect(snapshot).toHaveProperty("workflows");
+      expect(snapshot).toHaveProperty("conventions");
+
+      // Verify arrays
+      expect(Array.isArray(snapshot.tasks)).toBe(true);
+      expect(Array.isArray(snapshot.items)).toBe(true);
+      expect(Array.isArray(snapshot.inbox)).toBe(true);
+    });
+
+    // AC: @gh-pages-export ac-2
+    it("includes metadata with timestamp and version", async () => {
+      const snapshot = await generateJsonSnapshot();
+
+      // Version should be a string
+      expect(typeof snapshot.version).toBe("string");
+
+      // Timestamp should be valid ISO 8601
+      expect(snapshot.exported_at).toMatch(
+        /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z$/
+      );
+
+      // Project metadata
+      expect(snapshot.project).toHaveProperty("name");
+      expect(typeof snapshot.project.name).toBe("string");
+    });
+
+    // AC: @gh-pages-export ac-3
+    it("resolves spec_ref titles in tasks", async () => {
+      const snapshot = await generateJsonSnapshot();
+
+      // Find tasks with spec_ref
+      const tasksWithSpecRef = snapshot.tasks.filter((t) => t.spec_ref);
+
+      // If there are tasks with spec refs, they should have resolved titles
+      for (const task of tasksWithSpecRef) {
+        // spec_ref_title should be present for resolved refs
+        // (might be undefined if the ref doesn't resolve)
+        if (task.spec_ref_title) {
+          expect(typeof task.spec_ref_title).toBe("string");
+        }
+      }
+    });
+
+    // AC: @gh-pages-export ac-4
+    it("expands items with inherited ACs from traits", async () => {
+      const snapshot = await generateJsonSnapshot();
+
+      // Check if any items have inherited_acs
+      const itemsWithInheritedACs = snapshot.items.filter(
+        (i) => i.inherited_acs && i.inherited_acs.length > 0
+      );
+
+      // If there are items with inherited ACs, verify structure
+      for (const item of itemsWithInheritedACs) {
+        for (const ac of item.inherited_acs!) {
+          expect(ac).toHaveProperty("id");
+          expect(ac).toHaveProperty("given");
+          expect(ac).toHaveProperty("when");
+          expect(ac).toHaveProperty("then");
+          expect(ac).toHaveProperty("_inherited_from");
+          expect(ac._inherited_from).toMatch(/^@/);
+        }
+      }
+    });
+
+    // AC: @gh-pages-export ac-5
+    it("includes validation when requested", async () => {
+      const snapshot = await generateJsonSnapshot(true);
+
+      expect(snapshot.validation).toBeDefined();
+      expect(snapshot.validation).toHaveProperty("valid");
+      expect(snapshot.validation).toHaveProperty("errorCount");
+      expect(snapshot.validation).toHaveProperty("warningCount");
+      expect(snapshot.validation).toHaveProperty("errors");
+      expect(snapshot.validation).toHaveProperty("warnings");
+      expect(Array.isArray(snapshot.validation!.errors)).toBe(true);
+      expect(Array.isArray(snapshot.validation!.warnings)).toBe(true);
+    });
+
+    it("excludes validation by default", async () => {
+      const snapshot = await generateJsonSnapshot(false);
+      expect(snapshot.validation).toBeUndefined();
+    });
+  });
+
+  // AC: @gh-pages-export ac-7
+  describe("calculateExportStats", () => {
+    it("calculates correct statistics", async () => {
+      const snapshot = await generateJsonSnapshot();
+      const stats = calculateExportStats(snapshot);
+
+      expect(stats.taskCount).toBe(snapshot.tasks.length);
+      expect(stats.itemCount).toBe(snapshot.items.length);
+      expect(stats.inboxCount).toBe(snapshot.inbox.length);
+      expect(stats.observationCount).toBe(snapshot.observations.length);
+      expect(stats.agentCount).toBe(snapshot.agents.length);
+      expect(stats.workflowCount).toBe(snapshot.workflows.length);
+      expect(stats.conventionCount).toBe(snapshot.conventions.length);
+      expect(stats.estimatedSizeBytes).toBeGreaterThan(0);
+    });
+  });
+
+  describe("formatBytes", () => {
+    it("formats bytes correctly", () => {
+      expect(formatBytes(500)).toBe("500 B");
+      expect(formatBytes(1024)).toBe("1.0 KB");
+      expect(formatBytes(1536)).toBe("1.5 KB");
+      expect(formatBytes(1048576)).toBe("1.0 MB");
+      expect(formatBytes(1572864)).toBe("1.5 MB");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add `kspec export` command with `--format json|html`, `--include-validation`, and `--dry-run` options
- Implement static mode detection with daemon health check and JSON fallback
- Create read-only UI mode with disabled write actions and informative messages
- Add GitHub Actions workflow for gh-pages deployment on kspec-meta push

## Changes

**Export Command (AC 1-7):**
- `src/export/` - JSON/HTML snapshot generation with reference resolution and trait expansion
- `src/cli/commands/export.ts` - CLI command handler
- `tests/export/` - Unit and integration tests

**Static Data Layer (AC 11-13):**
- `packages/web-ui/src/lib/stores/mode.svelte.ts` - Mode detection
- `packages/web-ui/src/lib/api-static.ts` - Static API provider
- `packages/web-ui/src/lib/api.ts` - Mode-aware dispatch

**Read-Only Mode UI (AC 14-18):**
- `packages/web-ui/src/lib/components/ReadOnlyBanner.svelte` - Data freshness indicator
- Updated tasks and inbox pages to disable write actions in static mode

**CI Workflow (AC 8-10):**
- `.github/workflows/gh-pages.yml` - Deploy on kspec-meta push with debouncing

## Test plan

- [x] `npm run build` succeeds
- [x] `npm test -- tests/export/` - 25 tests pass
- [x] `kspec export --format json --dry-run` shows stats
- [x] `kspec export --format json -o /tmp/test.json` creates valid JSON
- [x] `kspec export --format html -o /tmp/test.html` creates valid HTML
- [ ] Manual: Build web-ui, serve with static JSON, verify read-only mode

Task: @01KFMMXF, @01KFMMXK, @01KFMMXR, @01KFMMXW
Spec: @gh-pages-export

🤖 Generated with [Claude Code](https://claude.ai/code)