### PR TITLE
fix: add workflow_dispatch trigger for gh-pages workflow

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -9,6 +9,7 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches: [kspec-meta]
+  workflow_dispatch:  # Allow manual trigger for testing
 
 # AC: @gh-pages-export ac-10 - Debounce rapid commits
 # Cancel in-progress deployments for same branch


### PR DESCRIPTION
## Summary

- Add `workflow_dispatch` trigger to allow manual testing of the gh-pages workflow

The push trigger for kspec-meta requires the workflow file to exist on that branch. This adds manual trigger support so we can test the workflow.

## Test plan

- [ ] After merge, manually trigger the workflow via GitHub UI or `gh workflow run`

🤖 Generated with [Claude Code](https://claude.ai/code)