### PR TITLE
fix: use Node.js 22 for gh-pages workflow

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary

- Update Node.js version from 18 to 22 for gh-pages workflow

Vite requires Node.js 20.19+ or 22.12+. The previous version (18) caused build failures for the web UI.

## Test plan

- [ ] After merge, re-run the workflow

🤖 Generated with [Claude Code](https://claude.ai/code)