### PR TITLE
fix: configure base path for GitHub Pages deployment

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -67,6 +67,8 @@ jobs:
       # AC: @gh-pages-export ac-9 - Build and copy SPA assets
       - name: Build web UI
         run: npm run build -w packages/web-ui
+        env:
+          BASE_PATH: /${{ github.event.repository.name }}
 
       - name: Copy SPA assets
         run: cp -r packages/web-ui/build/* gh-pages-output/

--- a/packages/web-ui/svelte.config.js
+++ b/packages/web-ui/svelte.config.js
@@ -1,5 +1,8 @@
 import adapter from '@sveltejs/adapter-static';
 
+// Base path for GitHub Pages deployment (set via BASE_PATH env var)
+const basePath = process.env.BASE_PATH || '';
+
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
 	kit: {
@@ -10,7 +13,11 @@ const config = {
 			fallback: 'index.html',
 			precompress: false,
 			strict: true
-		})
+		}),
+		paths: {
+			// Set base path for GitHub Pages (empty for daemon/local)
+			base: basePath
+		}
 	}
 };
 


### PR DESCRIPTION
## Summary

- Add BASE_PATH env var support in svelte.config.js
- CI workflow sets BASE_PATH to repo name for correct asset paths

SvelteKit needs a base path when hosted under a subdirectory like `/kynetic-spec/`. Without this, assets are loaded from `/_app/` instead of `/kynetic-spec/_app/`.

## Test plan

- [ ] After merge, re-run gh-pages workflow
- [ ] Verify site loads at https://kynetic-ai.github.io/kynetic-spec/

🤖 Generated with [Claude Code](https://claude.ai/code)