### PR TITLE
fix(web-ui): use build-time flag for GitHub Pages static mode

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -64,11 +64,12 @@ jobs:
             --include-validation \
             -o gh-pages-output/kspec-snapshot.json
 
-      # AC: @gh-pages-export ac-9 - Build and copy SPA assets
+      # AC: @gh-pages-export ac-9, ac-19 - Build and copy SPA assets
       - name: Build web UI
         run: npm run build -w packages/web-ui
         env:
           BASE_PATH: /${{ github.event.repository.name }}
+          VITE_STATIC_MODE: "true"
 
       - name: Copy SPA assets
         run: cp -r packages/web-ui/build/* gh-pages-output/

--- a/packages/web-ui/src/lib/components/Sidebar.svelte
+++ b/packages/web-ui/src/lib/components/Sidebar.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { page } from '$app/stores';
+	import { goto } from '$app/navigation';
 	import { onMount } from 'svelte';
 	import {
 		Sidebar,
@@ -67,7 +68,7 @@
 	// Open observations panel
 	function openObservations() {
 		// Navigate to observations view (will implement panel in next step)
-		window.location.href = '/observations';
+		goto('/observations');
 	}
 </script>
 

--- a/packages/web-ui/src/lib/stores/mode.svelte.ts
+++ b/packages/web-ui/src/lib/stores/mode.svelte.ts
@@ -8,10 +8,17 @@
  * - ac-11 (@gh-pages-export): Fetch JSON snapshot and render
  * - ac-12, ac-13 (@gh-pages-export): Deep linking support
  * - ac-15 (@gh-pages-export): Data freshness indicator
+ * - ac-19 (@gh-pages-export): Build flag bypasses daemon check
+ * - ac-20 (@gh-pages-export): Base path prefix for snapshot URL
  */
 
 import type { KspecSnapshot } from '$lib/types/snapshot';
 import { DAEMON_API_BASE } from '$lib/constants';
+import { base } from '$app/paths';
+
+// Build-time static mode flag (set via VITE_STATIC_MODE=true)
+// When true, skip daemon detection entirely and load static snapshot directly
+const BUILD_STATIC_MODE = import.meta.env.VITE_STATIC_MODE === 'true';
 
 // Application modes
 export type AppMode = 'loading' | 'daemon' | 'static';
@@ -24,13 +31,20 @@ let initError = $state<string | null>(null);
 /**
  * Initialize mode detection
  *
- * 1. Try daemon health check (2s timeout)
- * 2. Fall back to static JSON
- * 3. Show error state if neither available
+ * 1. If BUILD_STATIC_MODE, load static snapshot directly (no daemon check)
+ * 2. Otherwise try daemon health check (2s timeout)
+ * 3. Fall back to static JSON
+ * 4. Show error state if neither available
  *
- * AC: @gh-pages-export ac-11
+ * AC: @gh-pages-export ac-11, ac-19
  */
 export async function initMode(): Promise<void> {
+	// AC: @gh-pages-export ac-19 - Build flag bypasses daemon check
+	if (BUILD_STATIC_MODE) {
+		await loadStaticSnapshot();
+		return;
+	}
+
 	// 1. Try daemon health check
 	try {
 		const response = await fetch(`${DAEMON_API_BASE}/health`, {
@@ -45,9 +59,9 @@ export async function initMode(): Promise<void> {
 	}
 
 	// 2. Fall back to static JSON
-	// AC: @gh-pages-export ac-11 - Fetch kspec-snapshot.json from same origin
+	// AC: @gh-pages-export ac-11, ac-20 - Fetch kspec-snapshot.json with base path
 	try {
-		const response = await fetch('/kspec-snapshot.json', {
+		const response = await fetch(`${base}/kspec-snapshot.json`, {
 			signal: AbortSignal.timeout(5000)
 		});
 		if (response.ok) {
@@ -62,6 +76,30 @@ export async function initMode(): Promise<void> {
 	// 3. Neither available - default to daemon mode and let connection error handling show message
 	mode = 'daemon';
 	initError = 'Unable to connect to daemon and no static snapshot available';
+}
+
+/**
+ * Load static snapshot with proper base path handling
+ * AC: @gh-pages-export ac-19, ac-20
+ */
+async function loadStaticSnapshot(): Promise<void> {
+	try {
+		const response = await fetch(`${base}/kspec-snapshot.json`, {
+			signal: AbortSignal.timeout(5000)
+		});
+		if (response.ok) {
+			snapshotData = await response.json();
+			mode = 'static';
+			return;
+		}
+		console.error('[Mode] Static snapshot fetch failed:', response.status);
+	} catch (err) {
+		console.error('[Mode] Static snapshot fetch error:', err);
+	}
+	// If static mode forced but load fails, stay in static mode with error
+	// (Don't fall back to daemon - that would cause WebSocket attempts)
+	mode = 'static';
+	initError = 'Failed to load static snapshot';
 }
 
 /**


### PR DESCRIPTION
## Summary

- Add `VITE_STATIC_MODE` build-time flag to skip daemon health check on GitHub Pages
- Use SvelteKit `base` path from `$app/paths` for snapshot URL (fixes 404)
- If static snapshot fails, stay in static mode with error instead of falling back to daemon (which causes WebSocket connection attempts)
- Replace `window.location.href` with `goto()` in Sidebar for proper SPA navigation

## Test plan

- [x] Build succeeds with `VITE_STATIC_MODE=true`
- [x] Unit tests pass (1457 passed)
- [x] Hardcoded `/kspec-snapshot.json` path no longer in built bundle
- [ ] Deploy to GitHub Pages and verify:
  - No WebSocket connection attempted (check Network tab)
  - Fetches `/kynetic-spec/kspec-snapshot.json` correctly
  - Read-only dashboard loads with data

Task: @01KG2HYF
Spec: @gh-pages-export ac-19, ac-20

Generated with [Claude Code](https://claude.ai/code)