### PR TITLE
fix(web-ui): fix race condition and SPA routing for GitHub Pages

### DIFF
--- a/packages/web-ui/src/lib/stores/mode.svelte.ts
+++ b/packages/web-ui/src/lib/stores/mode.svelte.ts
@@ -104,10 +104,13 @@ async function loadStaticSnapshot(): Promise<void> {
 
 /**
  * Check if running in static mode
- * AC: @gh-pages-export ac-11
+ * AC: @gh-pages-export ac-11, ac-19
+ *
+ * Returns true immediately if BUILD_STATIC_MODE is set (synchronous check)
+ * to prevent race conditions where API calls run before initMode() completes.
  */
 export function isStaticMode(): boolean {
-	return mode === 'static';
+	return BUILD_STATIC_MODE || mode === 'static';
 }
 
 /**

--- a/packages/web-ui/svelte.config.js
+++ b/packages/web-ui/svelte.config.js
@@ -10,7 +10,9 @@ const config = {
 			// Output directory for static build (to be embedded in daemon)
 			pages: 'build',
 			assets: 'build',
-			fallback: 'index.html',
+			// Use 404.html for GitHub Pages SPA routing (GH Pages serves this for missing routes)
+			// For local daemon, index.html would work but 404.html is compatible with both
+			fallback: '404.html',
 			precompress: false,
 			strict: true
 		}),


### PR DESCRIPTION
## Summary

Fixes two remaining issues with GitHub Pages deployment:

1. **Race condition**: `isStaticMode()` now returns `true` synchronously when `BUILD_STATIC_MODE=true`, preventing daemon API calls (like `/api/meta/session`) before async `initMode()` completes

2. **SPA routing 404s**: Changed adapter-static fallback from `index.html` to `404.html` for GitHub Pages SPA routing (GH Pages serves `404.html` for missing routes like `/tasks`)

## Test plan

- [x] Build succeeds with `VITE_STATIC_MODE=true`
- [x] `404.html` created in build output
- [x] Unit tests pass (1457 passed)
- [ ] Deploy to GitHub Pages and verify:
  - No `localhost:3456/api/meta/session` requests
  - Routes like `/tasks` work without 404
  - Dashboard loads correctly

Task: @01KG2RGN
Spec: @gh-pages-export ac-19

Generated with [Claude Code](https://claude.ai/code)