### PR TITLE
fix(web-ui): use absolute path for filter URL updates

### DIFF
--- a/packages/web-ui/src/lib/components/TaskFilters.svelte
+++ b/packages/web-ui/src/lib/components/TaskFilters.svelte
@@ -70,7 +70,7 @@
 		// Reset offset when filter changes
 		params.delete('offset');
 
-		const newUrl = `?${params.toString()}`;
+		const newUrl = `${base}/tasks?${params.toString()}`;
 		goto(newUrl, { replaceState: false, keepFocus: true });
 	}
 


### PR DESCRIPTION
## Summary

Fix relative URL `?${params}` in TaskFilters.svelte which doesn't work with base path - navigates to root instead of `/kynetic-spec/tasks`.

Follow-up to PR #264 per Greptile review comment.

## Verification

Explored entire codebase with subagent - this was the only remaining issue. All other navigation patterns now correctly use `${base}` prefix.

Generated with [Claude Code](https://claude.ai/code)