### PR TITLE
fix(web-ui): fix Svelte 5 snippet compatibility in Tooltip for pending tasks

### DIFF
--- a/.claude/skills/svelte-5/SKILL.md
+++ b/.claude/skills/svelte-5/SKILL.md
@@ -211,6 +211,57 @@ Usage:
 </script>
 ```
 
+## bits-ui Component Patterns
+
+### Migrating `let:builder` to Child Snippets
+
+In Svelte 4, bits-ui components used `let:builder` to expose builder props for composition:
+
+```svelte
+<!-- Svelte 4 - BROKEN in Svelte 5 -->
+<Tooltip.Trigger asChild let:builder>
+  <Button builders={[builder]} disabled={true}>
+    Hover me
+  </Button>
+</Tooltip.Trigger>
+```
+
+In Svelte 5, this pattern causes `invalid_default_snippet` errors because `let:` directives conflict with default snippet rendering.
+
+**Fix: Use the `child` snippet pattern:**
+
+```svelte
+<!-- Svelte 5 - Correct -->
+<Tooltip.Trigger>
+  {#snippet child({ props })}
+    <Button {...props} disabled={true}>
+      Hover me
+    </Button>
+  {/snippet}
+</Tooltip.Trigger>
+```
+
+**Key differences:**
+- Remove `asChild` attribute
+- Remove `let:builder` directive
+- Use `{#snippet child({ props })}` instead
+- Spread `{...props}` onto the child element instead of `builders={[builder]}`
+
+This applies to all bits-ui trigger components:
+- `Tooltip.Trigger`
+- `Dialog.Trigger`
+- `Popover.Trigger`
+- `DropdownMenu.Trigger`
+- etc.
+
+### Why This Breaks
+
+The bits-ui trigger components support two rendering modes:
+1. **Default children**: `{@render children?.()}` - renders child content directly
+2. **Child snippet**: `{@render child({ props })}` - passes builder props to child
+
+Using `let:builder` expects mode 2 but the component tries to render mode 1, causing Svelte 5 to throw `invalid_default_snippet`.
+
 ## Common Mistakes
 
 ### 1. Mixing Stores and Runes

--- a/packages/web-ui/src/routes/tasks/+page.svelte
+++ b/packages/web-ui/src/routes/tasks/+page.svelte
@@ -414,15 +414,17 @@
 					<div>
 						{#if isStaticMode()}
 							<Tooltip.Root>
-								<Tooltip.Trigger asChild let:builder>
-									<Button
-										builders={[builder]}
-										data-testid="start-task-button"
-										disabled={true}
-										class="w-full"
-									>
-										Start Task
-									</Button>
+								<Tooltip.Trigger>
+									{#snippet child({ props })}
+										<Button
+											{...props}
+											data-testid="start-task-button"
+											disabled={true}
+											class="w-full"
+										>
+											Start Task
+										</Button>
+									{/snippet}
 								</Tooltip.Trigger>
 								<Tooltip.Content>
 									<p>Read-only mode - use CLI to start task</p>


### PR DESCRIPTION
## Summary

- Fix `invalid_default_snippet` error that occurred when viewing pending tasks on GitHub Pages
- Replace Svelte 4 `let:builder` pattern with Svelte 5 child snippet pattern in `Tooltip.Trigger`
- Document the bits-ui migration pattern in the `/svelte-5` skill for future reference

## Root Cause

The `Tooltip.Trigger` component used the Svelte 4 pattern:
```svelte
<Tooltip.Trigger asChild let:builder>
  <Button builders={[builder]} ... />
</Tooltip.Trigger>
```

In Svelte 5, `let:` directives conflict with default snippet rendering, causing `invalid_default_snippet` errors.

## Fix

Use the Svelte 5 child snippet pattern:
```svelte
<Tooltip.Trigger>
  {#snippet child({ props })}
    <Button {...props} ... />
  {/snippet}
</Tooltip.Trigger>
```

## Test plan

- [ ] Visit https://kynetic-ai.github.io/kynetic-spec/tasks?status=pending
- [ ] Click on a pending task to open the detail panel
- [ ] Verify no console errors about `invalid_default_snippet`
- [ ] Verify the "Start Task" button renders correctly with tooltip

Task: @01KG2Z08

🤖 Generated with [Claude Code](https://claude.ai/code)