### PR TITLE
fix(export): suppress info message when JSON output goes to stdout

### DIFF
--- a/src/cli/commands/export.ts
+++ b/src/cli/commands/export.ts
@@ -56,7 +56,11 @@ export function registerExportCommand(program: Command): void {
           process.exit(EXIT_CODES.USAGE_ERROR);
         }
 
-        info("Generating snapshot...");
+        // Only show progress when not outputting JSON to stdout (keep stdout clean for piping)
+        const jsonToStdout = options.format === "json" && !options.output && !options.dryRun;
+        if (!jsonToStdout) {
+          info("Generating snapshot...");
+        }
 
         // Generate the snapshot
         // AC: @gh-pages-export ac-1, ac-2, ac-3, ac-4, ac-5


### PR DESCRIPTION
## Summary
- Suppress info message when exporting JSON to stdout (no `-o` flag)
- Fixes corrupted JSON output at https://kynetic-ai.github.io/kspec-snapshot.json
- Info message still shows when writing to file or in dry-run mode

## Problem
The `info("Generating snapshot...")` call was outputting to stdout before the JSON content, making the output start with `ℹ Generating snapshot...` instead of valid JSON. This broke parsers and caused the GitHub Pages snapshot to only parse tasks (first valid JSON array found).

## Test plan
- [x] `export --format json` to stdout produces valid JSON (starts with `{`)
- [x] `export --format json -o file.json` still shows info message
- [x] All 25 export tests pass

Task: @01KG3P07

Generated with [Claude Code](https://claude.ai/code)