### PR TITLE
fix(web-ui): use $state() runes for Svelte 5 reactivity in inbox and observations

### DIFF
--- a/packages/web-ui/src/routes/inbox/+page.svelte
+++ b/packages/web-ui/src/routes/inbox/+page.svelte
@@ -20,19 +20,19 @@
 	import { getProjectVersion } from '$lib/stores/project.svelte';
 
 	// AC: @web-dashboard ac-16
-	let items: InboxItem[] = [];
-	let loading = true;
-	let error = '';
+	let items = $state<InboxItem[]>([]);
+	let loading = $state(true);
+	let error = $state('');
 
 	// AC: @web-dashboard ac-17
-	let showAddInput = false;
-	let newItemText = '';
-	let addingItem = false;
+	let showAddInput = $state(false);
+	let newItemText = $state('');
+	let addingItem = $state(false);
 
 	// AC: @web-dashboard ac-19
-	let deleteConfirmOpen = false;
-	let itemToDelete: InboxItem | null = null;
-	let deletingItem = false;
+	let deleteConfirmOpen = $state(false);
+	let itemToDelete = $state<InboxItem | null>(null);
+	let deletingItem = $state(false);
 
 	onMount(async () => {
 		await loadInbox();

--- a/packages/web-ui/src/routes/observations/+page.svelte
+++ b/packages/web-ui/src/routes/observations/+page.svelte
@@ -14,9 +14,9 @@
 	import { getProjectVersion } from '$lib/stores/project.svelte';
 
 	// AC: @web-dashboard ac-22
-	let observations: Observation[] = [];
-	let loading = true;
-	let error = '';
+	let observations = $state<Observation[]>([]);
+	let loading = $state(true);
+	let error = $state('');
 
 	// Type icons mapping
 	const typeIcons = {


### PR DESCRIPTION
## Summary
- Fix inbox and observations pages stuck on "Loading..." in static mode
- Convert plain `let` declarations to `$state()` runes for Svelte 5 reactivity
- Inbox: 9 variables converted
- Observations: 3 variables converted

## Problem
In Svelte 5, plain `let` is not automatically reactive. When data loaded, the `loading = false` assignment had no effect, so the UI stayed stuck on "Loading..." forever.

Dashboard, Tasks, and Items pages already used `$state()` correctly.

## Test plan
- [x] Build succeeds
- [ ] Inbox page shows data in static mode (GitHub Pages)
- [ ] Observations page shows data in static mode

Task: @01KG3RS9

Generated with [Claude Code](https://claude.ai/code)