### PR TITLE
fix(web-ui): generate index.html and copy to 404.html for GitHub Pages

### DIFF
--- a/.github/workflows/gh-pages-ui.yml
+++ b/.github/workflows/gh-pages-ui.yml
@@ -64,6 +64,10 @@ jobs:
       - name: Copy SPA assets
         run: cp -r packages/web-ui/build/* gh-pages-output/
 
+      # GitHub Pages serves 404.html for unknown routes, enabling SPA client-side routing
+      - name: Create 404.html for SPA routing
+        run: cp gh-pages-output/index.html gh-pages-output/404.html
+
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4
         with:

--- a/packages/web-ui/svelte.config.js
+++ b/packages/web-ui/svelte.config.js
@@ -10,9 +10,8 @@ const config = {
 			// Output directory for static build (to be embedded in daemon)
 			pages: 'build',
 			assets: 'build',
-			// Use 404.html for GitHub Pages SPA routing (GH Pages serves this for missing routes)
-			// For local daemon, index.html would work but 404.html is compatible with both
-			fallback: '404.html',
+			// Generate index.html as SPA entry point
+			fallback: 'index.html',
 			precompress: false,
 			strict: true
 		}),


### PR DESCRIPTION
## Summary
- Change SvelteKit fallback from `404.html` to `index.html`
- Copy `index.html` to `404.html` in workflow for GH Pages SPA routing

## Rationale
The logical approach:
- `index.html` is the main SPA entry point (what users visit)
- `404.html` is a copy that GitHub Pages serves for unknown routes (enabling client-side routing)

Previously it was backwards: generating `404.html` and copying to `index.html`.

## Test plan
- [ ] Build produces `index.html`
- [ ] GitHub Pages serves root correctly
- [ ] SPA routing works (direct links to /inbox, /observations, etc.)

Generated with [Claude Code](https://claude.ai/code)