### PR TITLE
feat(merge): normalize refs in set array merges

### DIFF
--- a/src/cli/commands/merge-driver.ts
+++ b/src/cli/commands/merge-driver.ts
@@ -12,6 +12,7 @@ import {
   parseYamlVersions,
   mergeObjects,
   mergeUlidArrays,
+  mergeSetArray,
   resolveConflictsInteractive,
   formatConflictComment,
   detectFileType,
@@ -20,6 +21,13 @@ import {
   type ConflictInfo,
   type ObjectMergeResult,
 } from "../../merge/index.js";
+import {
+  initContext,
+  loadAllTasks,
+  loadAllItems,
+} from "../../parser/yaml.js";
+import { loadMetaContext } from "../../parser/meta.js";
+import { ReferenceIndex } from "../../parser/refs.js";
 
 /**
  * Result type for root-level merges that can be either object or array.
@@ -33,16 +41,72 @@ import { EXIT_CODES } from "../exit-codes.js";
 import { error } from "../output.js";
 
 /**
+ * Field names that contain kspec refs and should use normalized merging.
+ * AC: @merge-ref-normalization ac-1
+ */
+const REF_SET_FIELDS = [
+  "depends_on",
+  "blocked_by",
+  "implements",
+  "relates_to",
+  "tests",
+  "context",
+  "traits",
+];
+
+/**
+ * Check if a field name is a ref-containing set field.
+ */
+function isRefSetField(fieldName: string): boolean {
+  return REF_SET_FIELDS.includes(fieldName);
+}
+
+/**
+ * Lazily build a ReferenceIndex for ref normalization.
+ * Returns undefined if context can't be initialized (graceful degradation).
+ *
+ * AC: @merge-ref-normalization ac-2
+ * Graceful degradation when context unavailable.
+ */
+async function buildRefIndex(): Promise<ReferenceIndex | undefined> {
+  try {
+    // Initialize from current working directory
+    // The merge driver runs from the project root
+    const ctx = await initContext();
+
+    // Load all items needed for the index
+    const tasks = await loadAllTasks(ctx);
+    const items = await loadAllItems(ctx);
+    const metaContext = await loadMetaContext(ctx);
+    const metaItems = [
+      ...metaContext.agents,
+      ...metaContext.workflows,
+      ...metaContext.conventions,
+      ...metaContext.observations,
+    ];
+
+    return new ReferenceIndex(tasks, items, metaItems);
+  } catch {
+    // Failed to load context - return undefined for graceful degradation
+    return undefined;
+  }
+}
+
+/**
  * Enhanced object merge that handles arrays with ULID items specially.
  *
  * For array fields containing objects with _ulid, uses ULID-based merging
  * to first merge the array structure, then recursively merges each item.
+ *
+ * AC: @merge-ref-normalization ac-1
+ * For ref-containing set fields (depends_on, etc), uses normalized comparison.
  */
 function mergeObjectsWithArrays(
   base: Record<string, unknown> | undefined,
   ours: Record<string, unknown> | undefined,
   theirs: Record<string, unknown> | undefined,
   path = "",
+  refIndex?: ReferenceIndex,
 ): ObjectMergeResult {
   const baseObj = base ?? {};
   const oursObj = ours ?? {};
@@ -63,6 +127,23 @@ function mergeObjectsWithArrays(
     const baseVal = baseObj[key];
     const oursVal = oursObj[key];
     const theirsVal = theirsObj[key];
+
+    // Check if this is a ref-containing set field (string arrays like depends_on)
+    // AC: @merge-ref-normalization ac-1
+    if (
+      isRefSetField(key) &&
+      (Array.isArray(baseVal) || Array.isArray(oursVal) || Array.isArray(theirsVal))
+    ) {
+      // Use ref-normalized set merge
+      const mergedSet = mergeSetArray(
+        baseVal as string[] | undefined,
+        oursVal as string[] | undefined,
+        theirsVal as string[] | undefined,
+        refIndex,
+      );
+      merged[key] = mergedSet;
+      continue;
+    }
 
     // Check if this field is an array of ULID items
     if (
@@ -253,6 +334,10 @@ async function performSemanticMerge(
   // For now, use generic object merging for all types
   // Future: Specialized merging based on _fileType
 
+  // Build reference index for ref normalization (lazy, may fail gracefully)
+  // AC: @merge-ref-normalization ac-1, ac-2
+  const refIndex = await buildRefIndex();
+
   // Check if root is array vs object (check all three versions)
   // AC: @merge-file-detection ac-7
   const isRootLevelArray = isRootArray(versions.base) || isRootArray(versions.ours) || isRootArray(versions.theirs);
@@ -270,6 +355,7 @@ async function performSemanticMerge(
       versions.ours as Record<string, unknown>,
       versions.theirs as Record<string, unknown>,
       "",
+      refIndex,
     );
     finalMerged = objectResult.merged;
     conflicts = objectResult.conflicts;

--- a/src/merge/arrays.ts
+++ b/src/merge/arrays.ts
@@ -7,6 +7,8 @@
  * - Append-only arrays (notes, todos)
  */
 
+import type { ReferenceIndex } from "../parser/refs.js";
+
 /**
  * Merge arrays that contain entities with _ulid fields.
  *
@@ -78,38 +80,95 @@ export function mergeUlidArrays<T extends { _ulid: string }>(
 }
 
 /**
+ * Normalize a kspec reference to its canonical ULID form if possible.
+ * Returns the original value if not a ref or resolution fails.
+ *
+ * AC: @merge-ref-normalization ac-2
+ * Graceful degradation: unresolvable refs kept as-is.
+ *
+ * @param value The value to potentially normalize
+ * @param refIndex Optional reference index for resolution
+ * @returns Canonical form (@ULID) or original value
+ */
+export function normalizeRef<T extends string | number>(
+  value: T,
+  refIndex?: ReferenceIndex,
+): string | number {
+  // Only process strings that look like refs
+  if (typeof value !== "string" || !value.startsWith("@")) {
+    return value;
+  }
+
+  // No index available - keep as-is
+  if (!refIndex) {
+    return value;
+  }
+
+  // Try to resolve
+  const result = refIndex.resolve(value);
+  if (result.ok) {
+    // Return canonical ULID form with @ prefix
+    return `@${result.ulid}`;
+  }
+
+  // AC: @merge-ref-normalization ac-2 - Resolution failed, keep original
+  return value;
+}
+
+/**
  * Merge set-like arrays (tags, depends_on, etc).
  *
  * AC: @yaml-merge-driver ac-6
  * Set union: combine both arrays, remove duplicates.
  *
+ * AC: @merge-ref-normalization ac-1
+ * For arrays containing kspec refs (depends_on, blocked_by, etc),
+ * normalizes refs to canonical ULID form before comparison to
+ * prevent duplicates when same item is referenced differently.
+ *
  * Strategy:
  * 1. Start with items from ours
  * 2. Add items from theirs that aren't in ours
- * 3. Remove duplicates
+ * 3. Remove duplicates (using normalized form for refs)
+ * 4. Preserve original representation (ours takes precedence)
  *
  * @param base Array from common ancestor (not used for set merge)
  * @param ours Array from current branch
  * @param theirs Array from incoming branch
+ * @param refIndex Optional reference index for normalizing refs
  * @returns Merged array with unique items
  */
 export function mergeSetArray<T extends string | number>(
   base: T[] | undefined,
   ours: T[] | undefined,
   theirs: T[] | undefined,
+  refIndex?: ReferenceIndex,
 ): T[] {
   const oursArr = ours ?? [];
   const theirsArr = theirs ?? [];
 
-  // Use Set to eliminate duplicates
-  const result = new Set<T>(oursArr);
+  // Build a map from normalized form -> original value
+  // This preserves the original form while deduplicating by canonical meaning
+  // AC: @merge-ref-normalization ac-1
+  const normalizedToOriginal = new Map<string | number, T>();
 
-  // Add items from theirs
-  for (const item of theirsArr) {
-    result.add(item);
+  // Add ours first (ours takes precedence for representation)
+  for (const item of oursArr) {
+    const normalized = normalizeRef(item, refIndex);
+    if (!normalizedToOriginal.has(normalized)) {
+      normalizedToOriginal.set(normalized, item);
+    }
   }
 
-  return Array.from(result);
+  // Add theirs (only if not already present in normalized form)
+  for (const item of theirsArr) {
+    const normalized = normalizeRef(item, refIndex);
+    if (!normalizedToOriginal.has(normalized)) {
+      normalizedToOriginal.set(normalized, item);
+    }
+  }
+
+  return Array.from(normalizedToOriginal.values());
 }
 
 /**

--- a/src/merge/index.ts
+++ b/src/merge/index.ts
@@ -18,6 +18,7 @@ export { parseYamlVersions } from "./parse.js";
 export {
   mergeUlidArrays,
   mergeSetArray,
+  normalizeRef,
   detectDeletion,
 } from "./arrays.js";
 

--- a/tests/merge-arrays.test.ts
+++ b/tests/merge-arrays.test.ts
@@ -6,8 +6,11 @@ import { describe, expect, it } from "vitest";
 import {
   mergeUlidArrays,
   mergeSetArray,
+  normalizeRef,
   detectDeletion,
 } from "../src/merge/arrays.js";
+import { ReferenceIndex } from "../src/parser/refs.js";
+import type { LoadedTask, LoadedSpecItem } from "../src/parser/yaml.js";
 
 describe("mergeUlidArrays", () => {
   it("should merge arrays with items added in both branches", () => {
@@ -318,5 +321,240 @@ describe("detectDeletion", () => {
     expect(result.deletedInTheirs).toBe(false);
     expect(result.modifiedInOurs).toBe(false);
     expect(result.modifiedInTheirs).toBe(false);
+  });
+});
+
+// ============================================================
+// Reference Normalization Tests
+// AC: @merge-ref-normalization ac-1, ac-2
+// ============================================================
+
+/**
+ * Helper to create a minimal ReferenceIndex for testing.
+ */
+function createTestRefIndex(): ReferenceIndex {
+  const tasks: LoadedTask[] = [
+    {
+      _ulid: "01TASKAAAA000000000000000",
+      slugs: ["task-one"],
+      title: "Task One",
+      type: "task",
+      status: "pending",
+      priority: 2,
+      tags: [],
+      notes: [],
+      todos: [],
+      context: [],
+      vcs_refs: [],
+      blocked_by: [],
+      depends_on: [],
+      created_at: new Date().toISOString(),
+      _sourceFile: "test.yaml",
+    },
+    {
+      _ulid: "01TASKBBBB000000000000001",
+      slugs: ["task-two"],
+      title: "Task Two",
+      type: "task",
+      status: "pending",
+      priority: 2,
+      tags: [],
+      notes: [],
+      todos: [],
+      context: [],
+      vcs_refs: [],
+      blocked_by: [],
+      depends_on: [],
+      created_at: new Date().toISOString(),
+      _sourceFile: "test.yaml",
+    },
+  ];
+  const items: LoadedSpecItem[] = [];
+  return new ReferenceIndex(tasks, items, []);
+}
+
+describe("normalizeRef", () => {
+  it("should return non-ref strings unchanged", () => {
+    // AC: @merge-ref-normalization ac-2
+    const refIndex = createTestRefIndex();
+
+    expect(normalizeRef("plain-tag", refIndex)).toBe("plain-tag");
+    expect(normalizeRef("another-value", refIndex)).toBe("another-value");
+  });
+
+  it("should return numbers unchanged", () => {
+    // AC: @merge-ref-normalization ac-2
+    const refIndex = createTestRefIndex();
+
+    expect(normalizeRef(42, refIndex)).toBe(42);
+    expect(normalizeRef(0, refIndex)).toBe(0);
+  });
+
+  it("should normalize slug ref to canonical ULID", () => {
+    // AC: @merge-ref-normalization ac-1
+    const refIndex = createTestRefIndex();
+
+    const result = normalizeRef("@task-one", refIndex);
+
+    expect(result).toBe("@01TASKAAAA000000000000000");
+  });
+
+  it("should normalize full ULID ref to same form", () => {
+    // AC: @merge-ref-normalization ac-1
+    const refIndex = createTestRefIndex();
+
+    const result = normalizeRef("@01TASKAAAA000000000000000", refIndex);
+
+    expect(result).toBe("@01TASKAAAA000000000000000");
+  });
+
+  it("should normalize ULID prefix ref to full ULID", () => {
+    // AC: @merge-ref-normalization ac-1
+    const refIndex = createTestRefIndex();
+
+    const result = normalizeRef("@01TASKAAAA", refIndex);
+
+    expect(result).toBe("@01TASKAAAA000000000000000");
+  });
+
+  it("should keep unresolvable ref as-is", () => {
+    // AC: @merge-ref-normalization ac-2
+    const refIndex = createTestRefIndex();
+
+    const result = normalizeRef("@nonexistent-task", refIndex);
+
+    expect(result).toBe("@nonexistent-task");
+  });
+
+  it("should keep ref as-is when no refIndex provided", () => {
+    // AC: @merge-ref-normalization ac-2
+    const result = normalizeRef("@task-one", undefined);
+
+    expect(result).toBe("@task-one");
+  });
+});
+
+describe("mergeSetArray with ref normalization", () => {
+  it("should deduplicate refs when one uses @slug and other uses @ULID", () => {
+    // AC: @merge-ref-normalization ac-1
+    const refIndex = createTestRefIndex();
+
+    const base: string[] = [];
+    const ours = ["@task-one"]; // Uses slug
+    const theirs = ["@01TASKAAAA000000000000000"]; // Uses full ULID for same task
+
+    const result = mergeSetArray(base, ours, theirs, refIndex);
+
+    // Should have only one entry, not two
+    expect(result).toHaveLength(1);
+    // Ours takes precedence for representation
+    expect(result[0]).toBe("@task-one");
+  });
+
+  it("should keep unresolvable refs as-is without error", () => {
+    // AC: @merge-ref-normalization ac-2
+    const refIndex = createTestRefIndex();
+
+    const base: string[] = [];
+    const ours = ["@nonexistent-task"];
+    const theirs = ["@01NONEXJSTENT000000000000"];
+
+    // Should not throw
+    const result = mergeSetArray(base, ours, theirs, refIndex);
+
+    // Both should be present (couldn't resolve, so treated as distinct)
+    expect(result).toHaveLength(2);
+    expect(result).toContain("@nonexistent-task");
+    expect(result).toContain("@01NONEXJSTENT000000000000");
+  });
+
+  it("should work without refIndex (backward compatibility)", () => {
+    // Existing behavior when no refIndex provided
+    const base: string[] = [];
+    const ours = ["@task-one"];
+    const theirs = ["@01TASKAAAA000000000000000"];
+
+    // No refIndex - should treat as distinct strings
+    const result = mergeSetArray(base, ours, theirs);
+
+    expect(result).toHaveLength(2);
+  });
+
+  it("should handle mixed refs and non-refs in same array", () => {
+    // AC: @merge-ref-normalization ac-1
+    const refIndex = createTestRefIndex();
+
+    const base: string[] = [];
+    const ours = ["@task-one", "plain-tag"];
+    const theirs = ["@01TASKAAAA000000000000000", "another-tag"];
+
+    const result = mergeSetArray(base, ours, theirs, refIndex);
+
+    // Should have 3: one task ref (deduplicated) + two tags
+    expect(result).toHaveLength(3);
+    expect(result).toContain("@task-one");
+    expect(result).toContain("plain-tag");
+    expect(result).toContain("another-tag");
+  });
+
+  it("should handle ULID prefix refs", () => {
+    // AC: @merge-ref-normalization ac-1
+    const refIndex = createTestRefIndex();
+
+    const base: string[] = [];
+    const ours = ["@task-one"];
+    const theirs = ["@01TASKAAAA"]; // ULID prefix
+
+    const result = mergeSetArray(base, ours, theirs, refIndex);
+
+    // Should deduplicate - both resolve to same item
+    expect(result).toHaveLength(1);
+  });
+
+  it("should prefer ours representation when both resolve to same ref", () => {
+    // AC: @merge-ref-normalization ac-1 - verify ours precedence
+    const refIndex = createTestRefIndex();
+
+    const base: string[] = [];
+    const ours = ["@01TASKAAAA000000000000000"]; // Full ULID
+    const theirs = ["@task-one"]; // Slug
+
+    const result = mergeSetArray(base, ours, theirs, refIndex);
+
+    expect(result).toHaveLength(1);
+    // Ours form should be preserved
+    expect(result[0]).toBe("@01TASKAAAA000000000000000");
+  });
+
+  it("should deduplicate multiple refs pointing to different items", () => {
+    // AC: @merge-ref-normalization ac-1
+    const refIndex = createTestRefIndex();
+
+    const base: string[] = [];
+    const ours = ["@task-one", "@task-two"];
+    const theirs = ["@01TASKAAAA000000000000000", "@01TASKBBBB000000000000001"];
+
+    const result = mergeSetArray(base, ours, theirs, refIndex);
+
+    // Should have 2 items (each pair deduplicated)
+    expect(result).toHaveLength(2);
+    expect(result).toContain("@task-one");
+    expect(result).toContain("@task-two");
+  });
+
+  it("should handle all refs being the same item", () => {
+    // AC: @merge-ref-normalization ac-1
+    const refIndex = createTestRefIndex();
+
+    const base: string[] = [];
+    const ours = ["@task-one", "@01TASKAAAA000000000000000"];
+    const theirs = ["@01TASKAAAA", "@task-one"];
+
+    const result = mergeSetArray(base, ours, theirs, refIndex);
+
+    // All resolve to same item - should be just 1
+    expect(result).toHaveLength(1);
+    // First occurrence wins (ours: @task-one)
+    expect(result[0]).toBe("@task-one");
   });
 });


### PR DESCRIPTION
## Summary

- Implements reference normalization during YAML merge operations to prevent duplicate entries when the same item is referenced using different formats (@slug vs @ULID)
- Adds lazy loading of kspec context during merge to resolve refs to canonical form
- Graceful degradation when context unavailable or refs unresolvable

## Changes

- `src/merge/arrays.ts`: Added `normalizeRef()` helper and updated `mergeSetArray()` to accept optional `ReferenceIndex`
- `src/cli/commands/merge-driver.ts`: Added `buildRefIndex()` for lazy context loading, `REF_SET_FIELDS` constant, and ref-aware field detection
- `src/merge/index.ts`: Exported `normalizeRef` for testing
- `tests/merge-arrays.test.ts`: Added 14 new tests covering both acceptance criteria

## Test plan

- [x] All 32 merge-arrays tests pass
- [x] All 12 merge-driver-cli tests pass
- [x] AC-1 covered: @slug + @ULID for same item deduplicated
- [x] AC-2 covered: Unresolvable refs kept as-is, no errors

Task: @task-reference-normalization-in-merges
Spec: @merge-ref-normalization

🤖 Generated with [Claude Code](https://claude.com/claude-code)