### PR TITLE
fix(e2e): improve daemon fixture reliability

### DIFF
--- a/packages/web-ui/tests/fixtures/test-base.ts
+++ b/packages/web-ui/tests/fixtures/test-base.ts
@@ -141,8 +141,21 @@ export const test = base.extend<{ daemon: DaemonFixture }>({
       throw new Error('Failed to start daemon: ' + startResult.stderr);
     }
 
-    // Wait for daemon to be ready
-    await new Promise((r) => setTimeout(r, 2000));
+    // Wait for daemon to be ready by polling health endpoint
+    const maxAttempts = 30;
+    const pollInterval = 100;
+    for (let i = 0; i < maxAttempts; i++) {
+      try {
+        const response = await fetch(`http://localhost:${DAEMON_PORT}/api/health`);
+        if (response.ok) break;
+      } catch {
+        // Daemon not ready yet
+      }
+      if (i === maxAttempts - 1) {
+        throw new Error(`Daemon failed to become ready after ${maxAttempts * pollInterval}ms`);
+      }
+      await new Promise((r) => setTimeout(r, pollInterval));
+    }
 
     // Helper to create a valid second project for multi-project tests
     // AC: @multi-directory-daemon ac-25 - Tests need multiple valid projects

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -5,7 +5,7 @@
 
 import type { Command } from 'commander';
 import { spawn, execSync } from 'child_process';
-import { existsSync } from 'fs';
+import { existsSync, readdirSync, statSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { error, info, output, success, warn, isJsonMode } from '../output.js';
@@ -27,6 +27,42 @@ function isBunAvailable(): boolean {
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
+
+/**
+ * Check if daemon dist files are stale (source newer than dist)
+ * Returns true if rebuild is recommended
+ */
+function checkDaemonStaleness(): boolean {
+  // __dirname is dist/cli/commands, go up 3 levels to package root, then into packages/daemon/src
+  const sourceDir = join(__dirname, '../../../packages/daemon/src');
+  // dist/daemon is 2 levels up from __dirname
+  const distDir = join(__dirname, '../../daemon');
+
+  if (!existsSync(sourceDir) || !existsSync(distDir)) return false;
+
+  try {
+    const getNewestMtime = (dir: string): number => {
+      const files = readdirSync(dir, { withFileTypes: true });
+      let newest = 0;
+      for (const f of files) {
+        const fullPath = join(dir, f.name);
+        if (f.isDirectory()) {
+          newest = Math.max(newest, getNewestMtime(fullPath));
+        } else if (f.name.endsWith('.ts')) {
+          newest = Math.max(newest, statSync(fullPath).mtimeMs);
+        }
+      }
+      return newest;
+    };
+
+    const newestSource = getNewestMtime(sourceDir);
+    const newestDist = getNewestMtime(distDir);
+
+    return newestSource > newestDist;
+  } catch {
+    return false; // Don't warn if check fails
+  }
+}
 
 
 /**
@@ -181,6 +217,12 @@ async function startServer(opts: {
       error('Install Bun: https://bun.sh/docs/installation');
     }
     process.exit(EXIT_CODES.ERROR);
+  }
+
+  // Check for stale daemon build (dev experience improvement)
+  if (checkDaemonStaleness() && !jsonMode) {
+    warn('Warning: dist/daemon/ may be stale (source files are newer).');
+    warn('  Run "npm run build:daemon" to update.');
   }
 
   // AC: @cli-serve-commands ac-2 - background mode

--- a/src/cli/pid-utils.ts
+++ b/src/cli/pid-utils.ts
@@ -11,7 +11,7 @@
  * AC: @multi-directory-daemon ac-9, ac-9b, ac-9c, ac-10, ac-11, ac-13
  */
 
-import { readFileSync, writeFileSync, unlinkSync, existsSync, mkdirSync } from 'fs';
+import { readFileSync, writeFileSync, unlinkSync, existsSync, mkdirSync, openSync, closeSync, constants } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
 
@@ -37,13 +37,42 @@ export class PidFileManager {
   }
 
   /**
-   * AC: @multi-directory-daemon ac-9
+   * AC: @multi-directory-daemon ac-9, ac-10b
    * Writes current process PID to ~/.config/kspec/daemon.pid
    * Creates parent directory if it doesn't exist.
+   * Uses exclusive file creation flag to prevent concurrent daemon starts.
    */
   writePid(): void {
     this.ensureConfigDir();
-    writeFileSync(this.pidFilePath, process.pid.toString(), 'utf-8');
+
+    // AC: @multi-directory-daemon ac-10b
+    // Use O_CREAT | O_EXCL flags for atomic file creation
+    // This prevents race conditions between concurrent daemon starts
+    try {
+      const fd = openSync(this.pidFilePath, constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY, 0o644);
+      try {
+        writeFileSync(fd, process.pid.toString(), 'utf-8');
+      } finally {
+        closeSync(fd);
+      }
+    } catch (err: any) {
+      if (err.code === 'EEXIST') {
+        // File already exists - check if daemon is actually running
+        if (this.isDaemonRunning()) {
+          throw new Error('Daemon already running');
+        }
+        // Stale PID file - remove it and retry inline (not recursive)
+        this.remove();
+        const fd = openSync(this.pidFilePath, constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY, 0o644);
+        try {
+          writeFileSync(fd, process.pid.toString(), 'utf-8');
+        } finally {
+          closeSync(fd);
+        }
+      } else {
+        throw err;
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary

- Replace fixed 2s daemon wait with `/api/health` polling (30 attempts × 100ms = 3s max)
- Add staleness detection warning when `dist/daemon/` is older than `packages/daemon/src/`
- Sync `PidFileManager` with daemon version for atomic file locking (ac-10b)

## Changes

| File | Change |
|------|--------|
| `packages/web-ui/tests/fixtures/test-base.ts` | Health check polling replaces fixed wait |
| `src/cli/commands/serve.ts` | `checkDaemonStaleness()` function + warning |
| `src/cli/pid-utils.ts` | Atomic file locking with `O_CREAT \| O_EXCL` |

## Test plan

- [x] E2E smoke tests pass (5/5)
- [x] daemon-pid.test.ts passes (11/11)
- [x] Staleness warning verified manually
- [x] Warning clears after `npm run build:daemon`

Task: @01KG5VSF
Spec: @multi-directory-daemon

🤖 Generated with [Claude Code](https://claude.com/claude-code)