### PR TITLE
fix: enforce CI re-verification in PR review workflows

### DIFF
--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -104,6 +104,15 @@ The workflow handles:
 5. Wait for CI to pass
 6. Merge with quality gates
 
+### CRITICAL: CI Re-verification
+
+**After ANY push, you MUST re-verify CI from the beginning.** Prior CI checks are invalidated by new commits. Never merge without fresh CI verification on the current HEAD.
+
+If you push fixes during review:
+1. Wait for CI to complete on the new commits
+2. Verify CI status shows current HEAD (not stale)
+3. Only then proceed to merge
+
 ## Subagent Context
 
 This skill runs in **ACP subagent context**:

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -129,7 +129,10 @@ This enforces quality gates:
 2. All review comments addressed (automated AND human)
 3. All @claude requests completed
 4. All review threads resolved
-5. Explicit merge decision
+5. **Final CI re-verification** before merge decision
+6. Explicit merge decision
+
+**CRITICAL: After ANY push, re-verify CI from the beginning.** Prior CI checks are invalidated by new commits. Never merge without fresh CI verification on current HEAD.
 
 **Do not merge while CI is running or blocking.** Wait for all checks to complete. Only skip gates if user explicitly says to merge anyway.
 


### PR DESCRIPTION
## Summary

- Add CRITICAL notes to `@pr-review-merge` and `@pr-review-loop` workflows requiring CI re-verification after any push
- Add explicit "RETURN TO STEP 1" instruction after pushing fixes in review feedback step
- Add new "FINAL CI VERIFICATION" step before merge decision in `@pr-review-merge`
- Update `/pr` and `/pr-review` skills to document CI re-verification requirements

## Problem

An agent was observed barreling through the PR merge workflow without re-checking CI after pushing fixes. The agent had checked CI initially (it passed), then addressed review comments and pushed changes, but continued to merge without verifying the new commits passed CI.

## Solution

Multiple layers of protection:
1. **Workflow descriptions**: Added CRITICAL note that prior CI checks are invalidated by new commits
2. **Step-level guidance**: on_fail handlers now explicitly say "RETURN TO STEP 1" after pushing
3. **Final gate**: New pre-merge CI verification step requires fresh check on current HEAD
4. **Skill documentation**: Both `/pr` and `/pr-review` skills updated with same guidance

## Test plan

- [ ] Verify workflow YAML is valid (kspec validate)
- [ ] Review workflow steps read clearly
- [ ] Skill documentation is consistent with workflow changes

Task: @01KFP5YG

🤖 Generated with [Claude Code](https://claude.ai/code)