### PR TITLE
fix(help): rename 'workflow' help key to avoid command collision

### DIFF
--- a/src/cli/help/content.ts
+++ b/src/cli/help/content.ts
@@ -163,7 +163,7 @@ Run this after 'kspec init' to set up agent integration.
       "kspec setup --agent claude-code",
       "kspec setup --dry-run",
     ],
-    seeAlso: ["init", "workflow"],
+    seeAlso: ["init", "task-workflow"],
   },
 
   item: {
@@ -249,7 +249,7 @@ and no incomplete dependencies.
     seeAlso: ["task", "tasks"],
   },
 
-  workflow: {
+  "task-workflow": {
     title: "Typical Workflow",
     concept: `
 Common workflow for working on tasks.


### PR DESCRIPTION
## Summary
- Renamed `helpContent['workflow']` to `task-workflow` to fix collision with `workflow` CLI command
- `kspec help workflow` now correctly shows the workflow command help
- The "Typical Workflow" guide is still accessible via `kspec help task-workflow`

## Test plan
- [x] Verified `kspec help workflow` shows workflow command help
- [x] Verified `kspec help task-workflow` shows the typical workflow guide
- [x] Help tests pass (17 tests)

Task: @01KG6ZDE

🤖 Generated with [Claude Code](https://claude.com/claude-code)