### PR TITLE
fix(workflow): use 1-indexed step numbering in display

### DIFF
--- a/src/cli/commands/workflow.ts
+++ b/src/cli/commands/workflow.ts
@@ -194,7 +194,7 @@ async function workflowRuns(options: {
         (w) => `@${w._ulid}` === run.workflow_ref,
       );
       const workflowName = workflow?.id || run.workflow_ref;
-      const stepProgress = `${run.current_step}/${run.total_steps}`;
+      const stepProgress = `${run.current_step + 1}/${run.total_steps}`;
       const started = new Date(run.started_at).toLocaleString();
 
       table.push([
@@ -237,7 +237,7 @@ async function workflowShow(runRef: string, _options: { json?: boolean }) {
     console.log(`ID:           ${shortUlid(run._ulid)}`);
     console.log(`Workflow:     ${workflowName} (${run.workflow_ref})`);
     console.log(`Status:       ${formatStatus(run.status)}`);
-    console.log(`Progress:     ${run.current_step}/${run.total_steps}`);
+    console.log(`Progress:     ${run.current_step + 1}/${run.total_steps}`);
     console.log(`Started:      ${new Date(run.started_at).toLocaleString()}`);
 
     if (run.initiated_by) {
@@ -267,7 +267,7 @@ async function workflowShow(runRef: string, _options: { json?: boolean }) {
 
       for (const result of run.step_results) {
         table.push([
-          result.step_index.toString(),
+          (result.step_index + 1).toString(),
           formatStatus(result.status),
           new Date(result.started_at).toLocaleString(),
           new Date(result.completed_at).toLocaleString(),

--- a/tests/workflow-runs.test.ts
+++ b/tests/workflow-runs.test.ts
@@ -280,7 +280,7 @@ describe('workflow show', () => {
     expect(result.stdout).toContain('Workflow Run Details');
     expect(result.stdout).toContain('test-workflow');
     expect(result.stdout).toContain('active');
-    expect(result.stdout).toContain('0/3');
+    expect(result.stdout).toContain('1/3');
     expect(result.stdout).toContain('Initiated by: @test');
     expect(result.stdout).toContain(`@${testTaskUlid}`);
   });


### PR DESCRIPTION
## Summary
- Fixed off-by-one bug in workflow step numbering display
- Progress and step columns were showing 0-indexed values (0/3 instead of 1/3)
- Fixed in three locations:
  - `workflow runs`: step progress column
  - `workflow show`: progress line
  - `workflow show`: step results table step column

## Test plan
- [x] All workflow tests pass
- [x] `workflow show` displays 1/3 for first step (not 0/3)
- [x] `workflow runs` table shows correct progress

Task: @01KG6ZE0

Generated with [Claude Code](https://claude.ai/code)