### PR TITLE
fix(session): handle checkpoint from .kspec/ directory gracefully

### DIFF
--- a/src/cli/commands/session.ts
+++ b/src/cli/commands/session.ts
@@ -17,7 +17,11 @@ import {
   loadSessionContext,
   ReferenceIndex,
 } from "../../parser/index.js";
-import { type ShadowSyncResult, shadowPull } from "../../parser/shadow.js";
+import {
+  ShadowError,
+  type ShadowSyncResult,
+  shadowPull,
+} from "../../parser/shadow.js";
 import type { SessionContext as StoredSessionContext } from "../../schema/index.js";
 import {
   errors,
@@ -1170,6 +1174,19 @@ async function sessionCheckpointAction(
       }
     }
   } catch (err) {
+    // Handle RUNNING_FROM_SHADOW gracefully - skip with warning instead of erroring
+    // This happens when the stop hook runs while cwd is inside .kspec/ directory
+    if (err instanceof ShadowError && err.code === "RUNNING_FROM_SHADOW") {
+      if (!isJsonMode()) {
+        console.log(
+          chalk.yellow(
+            "[kspec] Session checkpoint skipped - running from inside .kspec/ directory",
+          ),
+        );
+      }
+      // Allow stop to proceed (exit successfully, no JSON output blocks the stop)
+      return;
+    }
     error(errors.failures.runCheckpoint, err);
     process.exit(EXIT_CODES.ERROR);
   }


### PR DESCRIPTION
## Summary
- Handle `RUNNING_FROM_SHADOW` error gracefully in session checkpoint command
- Human mode: Show warning message and exit successfully
- JSON mode: Exit silently (allows stop to proceed)

This prevents session end disruption when the stop hook runs while cwd is inside the `.kspec/` directory.

## Test plan
- [x] Tested checkpoint from project root (human mode) - detects issues correctly
- [x] Tested checkpoint from project root (JSON mode) - outputs block decision when issues exist
- [x] Tested checkpoint from .kspec/ directory (human mode) - shows skip warning and exits 0
- [x] Tested checkpoint from .kspec/ directory (JSON mode) - exits silently (no output, exit 0)
- [x] All 48 session tests pass

Task: @01KG715E

🤖 Generated with [Claude Code](https://claude.ai/code)