### PR TITLE
fix(ralph): ensure PR review subagent completes task after merge

### DIFF
--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -145,12 +145,20 @@ PR #234 merged successfully.
 Task @task-reflect-loop-skill ready for completion.
 ```
 
-## Integration
+## Task Completion
 
-After PR merge, the calling context (ralph or user) should:
+**CRITICAL: You MUST complete the task after merging the PR.**
+
+The `@pr-review-loop` workflow includes task completion as the final step (ac-7). After the PR is merged:
 
 ```bash
-kspec task complete @task-ref --reason "PR #N merged"
+kspec task complete @task-ref --reason "Merged in PR #N. <summary>"
 ```
 
-This skill focuses solely on the PR review/merge cycle.
+Include in the reason:
+- PR number
+- Summary of what was implemented
+- Any notable changes or deviations
+- AC coverage confirmation
+
+Do NOT exit after merge without completing the task.

--- a/src/cli/commands/ralph.ts
+++ b/src/cli/commands/ralph.ts
@@ -479,6 +479,30 @@ async function buildSubagentContext(
 }
 
 /**
+ * Check if a task was completed by the subagent.
+ * AC: @ralph-subagent-spawning ac-12
+ */
+async function verifyTaskCompleted(taskRef: string): Promise<boolean> {
+  const result = spawnSync("kspec", ["task", "get", taskRef, "--json"], {
+    encoding: "utf-8",
+    stdio: "pipe",
+  });
+
+  if (result.status !== 0) {
+    warn(`Failed to check task status for ${taskRef}: ${result.stderr}`);
+    return false;
+  }
+
+  try {
+    const task = JSON.parse(result.stdout);
+    return task.status === "completed";
+  } catch {
+    warn(`Failed to parse task status for ${taskRef}`);
+    return false;
+  }
+}
+
+/**
  * Mark a task as needing review due to subagent timeout.
  * AC: @ralph-subagent-spawning ac-9
  */
@@ -680,8 +704,22 @@ async function processPendingReviewTasks(
         );
         consecutiveFailures.count++;
       } else {
-        success(`${DEFAULT_SUBAGENT_PREFIX} Completed: ${task.ref}`);
-        consecutiveFailures.count = 0;
+        // AC: @ralph-subagent-spawning ac-12 - Verify task was completed
+        const wasCompleted = await verifyTaskCompleted(task.ref);
+        if (wasCompleted) {
+          success(`${DEFAULT_SUBAGENT_PREFIX} Completed: ${task.ref}`);
+          consecutiveFailures.count = 0;
+        } else {
+          // Task wasn't completed - subagent likely exited early
+          warn(
+            `${DEFAULT_SUBAGENT_PREFIX} Subagent succeeded but task ${task.ref} is still pending_review`,
+          );
+          await markTaskNeedsReview(
+            task.ref,
+            "Subagent merged PR but did not complete the task. Review required to verify merge and complete task manually.",
+          );
+          consecutiveFailures.count++;
+        }
       }
 
       // Check if we've hit max failures

--- a/src/ralph/subagent.ts
+++ b/src/ralph/subagent.ts
@@ -85,7 +85,7 @@ export const DEFAULT_SUBAGENT_PREFIX = "[REVIEW SUBAGENT]";
 
 /**
  * Build the prompt for a PR review subagent.
- * AC: @ralph-subagent-spawning ac-2, ac-10
+ * AC: @ralph-subagent-spawning ac-2, ac-10, ac-12
  */
 export function buildSubagentPrompt(context: SubagentContext): string {
   const specSection = context.specWithACs
@@ -129,13 +129,17 @@ This will:
 2. Check spec alignment
 3. Wait for CI to pass
 4. Merge the PR if all gates pass
+5. Complete the task with PR reference
+
+**CRITICAL: You MUST complete the task after merging the PR.**
+Use: \`kspec task complete ${context.taskRef} --reason "Merged in PR #N. <summary>"\`
 
 **Exit when:**
-- PR is merged successfully
+- PR is merged AND task is completed successfully
 - PR cannot be merged (quality gates failed, needs human review)
 - No PR found for this task
 
-Do NOT start new work. Your only job is to get this specific PR merged.
+Do NOT start new work. Your only job is to get this specific PR merged and task completed.
 `;
 }
 


### PR DESCRIPTION
## Summary

- Fix PR review subagent exiting before completing the task after merge
- Add defensive verification in ralph to check task completion
- Update skill documentation to remove conflicting guidance

## Problem

The PR review subagent was merging PRs but exiting before completing the associated task. This left tasks in `pending_review` state for the next iteration, where the task limit would get triggered causing a cycle.

Root cause: The subagent prompt said "Exit when: PR is merged successfully" but task completion is a separate step after merge.

## Changes

- `src/ralph/subagent.ts`: Updated prompt to require task completion before exit
- `src/cli/commands/ralph.ts`: Added `verifyTaskCompleted()` + defensive check
- `.claude/skills/pr-review/SKILL.md`: Removed conflicting "caller completes task" guidance
- Added ac-12 to `@ralph-subagent-spawning` spec

## Test plan

- [x] Build succeeds
- [x] ralph tests pass (11 tests)
- [ ] CI passes

Task: @01KG762Y
Spec: @ralph-subagent-spawning

🤖 Generated with [Claude Code](https://claude.com/claude-code)