### PR TITLE
feat(cli): add --force flag to task complete command

### DIFF
--- a/src/cli/batch.ts
+++ b/src/cli/batch.ts
@@ -17,6 +17,7 @@ export interface BatchOperationResult {
   status: "success" | "error";
   error?: string;
   message?: string;
+  warning?: string;
   data?: unknown;
 }
 
@@ -66,6 +67,7 @@ export interface BatchOperationOptions<TItem, TContext> {
     success: boolean;
     message?: string;
     error?: string;
+    warning?: string;
     data?: unknown;
   }>;
   /** Function to extract ULID from an item */
@@ -141,6 +143,7 @@ export async function executeBatchOperation<TItem, TContext>(
         status: opResult.success ? "success" : "error",
         message: opResult.message,
         error: opResult.error,
+        warning: opResult.warning,
         data: opResult.data,
       });
     } catch (err) {

--- a/src/cli/commands/task.ts
+++ b/src/cli/commands/task.ts
@@ -1050,6 +1050,10 @@ export function registerTaskCommands(program: Command): void {
     .option("--refs <refs...>", "Complete multiple tasks by ref")
     .option("--reason <reason>", "Completion reason/notes")
     .option("--skip-review", "Skip review requirement (requires --reason)")
+    .option(
+      "--force",
+      "Force completion even if blocked (AC: @task-commands ac-1)",
+    )
     .option("--no-sync", "Skip syncing spec implementation status")
     .action(async (ref: string | undefined, options) => {
       try {
@@ -1088,8 +1092,13 @@ export function registerTaskCommands(program: Command): void {
                 };
               }
 
+              // AC: @task-commands ac-1 - Allow --force to bypass blocked state
+              // Handle blocked task with --force before other checks
+              const forcingBlockedTask =
+                foundTask.status === "blocked" && options.force;
+
               // AC: @spec-completion-enforcement ac-7 - Allow skip-review bypass
-              if (!options.skipReview) {
+              if (!options.skipReview && !forcingBlockedTask) {
                 // AC: @spec-completion-enforcement ac-2
                 if (foundTask.status === "in_progress") {
                   return {
@@ -1142,6 +1151,16 @@ export function registerTaskCommands(program: Command): void {
                   getAuthor(),
                 );
                 taskNotes = [...taskNotes, skipNote];
+              }
+
+              // AC: @task-commands ac-1 - Document force completion of blocked task
+              if (forcingBlockedTask) {
+                const blockedBy = foundTask.blocked_by.join("; ");
+                const forceNote = createNote(
+                  `Completed with --force despite blocked state. Was blocked by: ${blockedBy || "(dependency-blocked)"}${options.reason ? `. Reason: ${options.reason}` : ""}`,
+                  getAuthor(),
+                );
+                taskNotes = [...taskNotes, forceNote];
               }
 
               // Update status
@@ -1206,10 +1225,21 @@ export function registerTaskCommands(program: Command): void {
                 }
               }
 
+              // AC: @task-commands ac-1 - Show warning when force-completing blocked task
+              let warningMsg: string | undefined;
+              if (forcingBlockedTask) {
+                const blockedBy = foundTask.blocked_by.join("; ");
+                warningMsg = `Task was blocked by: ${blockedBy || "(dependency-blocked)"}`;
+                if (!isJsonMode()) {
+                  warn(warningMsg);
+                }
+              }
+
               return {
                 success: true,
                 message: `Completed task: ${index.shortUlid(updatedTask._ulid)}`,
                 data: updatedTask,
+                ...(forcingBlockedTask && { warning: warningMsg }),
               };
             } catch (err) {
               return {

--- a/tests/task-completion-enforcement.test.ts
+++ b/tests/task-completion-enforcement.test.ts
@@ -104,6 +104,69 @@ describe('Integration: task completion enforcement', () => {
     expect(stdout + stderr).toContain('Cannot complete blocked task');
   });
 
+  // AC: @task-commands ac-1
+  it('should complete blocked task with --force flag and show warning', () => {
+    // Block a task
+    kspec('task block @test-task-pending --reason "Waiting for API"', tempDir);
+
+    // Verify it's blocked
+    const taskData = kspecJson<{ status: string }>(
+      'task get @test-task-pending',
+      tempDir
+    );
+    expect(taskData.status).toBe('blocked');
+
+    // Complete with --force should succeed with warning
+    const { stdout, stderr, exitCode } = kspecWithStatus(
+      'task complete @test-task-pending --force --reason "Work done by other task"',
+      tempDir
+    );
+    expect(exitCode).toBe(0);
+    const output = stdout + stderr;
+    expect(output).toContain('Completed task');
+    expect(output).toContain('Waiting for API'); // Warning shows what it was blocked by
+
+    // Verify it's completed
+    const afterComplete = kspecJson<{
+      status: string;
+      closed_reason: string | null;
+      notes: Array<{ content: string; author: string }>;
+    }>('task get @test-task-pending', tempDir);
+    expect(afterComplete.status).toBe('completed');
+    expect(afterComplete.closed_reason).toBe('Work done by other task');
+
+    // Check that a note was added documenting the forced completion
+    const forceNote = afterComplete.notes.find((n) =>
+      n.content.includes('--force')
+    );
+    expect(forceNote).toBeTruthy();
+    expect(forceNote?.content).toContain('blocked');
+    expect(forceNote?.content).toContain('Waiting for API');
+  });
+
+  // AC: @task-commands ac-1 - JSON output includes warning
+  it('should include warning in JSON output when force-completing blocked task', () => {
+    // Block a task
+    kspec('task block @test-task-pending --reason "Dependency missing"', tempDir);
+
+    // Complete with --force and --json
+    const result = kspecJson<{
+      success: boolean;
+      summary: { total: number; succeeded: number };
+      results: Array<{
+        status: string;
+        warning?: string;
+      }>;
+    }>(
+      'task complete @test-task-pending --force --reason "Covered elsewhere"',
+      tempDir
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.results[0].status).toBe('success');
+    expect(result.results[0].warning).toContain('Dependency missing');
+  });
+
   // AC: @spec-completion-enforcement ac-5
   it('should error when trying to complete cancelled task', () => {
     // Cancel a task


### PR DESCRIPTION
## Summary

- Add `--force` flag to `kspec task complete` to bypass blocked state
- Use case: task is effectively done (covered by other work) but technically blocked
- Shows warning when force-completing blocked task
- Adds note documenting the forced completion

## Test plan

- [x] Tests pass in task-completion-enforcement.test.ts
- [x] Human output shows warning when --force used on blocked task
- [x] JSON output includes warning field
- [x] Note added to task documents the forced completion


🤖 Generated with [Claude Code](https://claude.com/claude-code)

Task: @01KG70TT
Spec: @task-commands