### PR TITLE
feat(cli): add Resolved column to observation list with --all flag

### DIFF
--- a/src/cli/commands/meta.ts
+++ b/src/cli/commands/meta.ts
@@ -291,6 +291,7 @@ function formatConventionDetail(convention: Convention): void {
 /**
  * Format observations table output
  * AC-obs-2: outputs table with columns: ID, Type, Workflow, Created, Content (truncated)
+ * AC: @obs-list-display ac-1 - When --all flag used, show Resolved column with ✓/✗
  */
 function formatObservations(
   observations: Observation[],
@@ -309,19 +310,35 @@ function formatObservations(
     return;
   }
 
+  // AC: @obs-list-display ac-1 - Include Resolved column when showing all observations
+  const headers = showResolved
+    ? [
+        chalk.bold("ID"),
+        chalk.bold("Type"),
+        chalk.bold("Resolved"),
+        chalk.bold("Workflow"),
+        chalk.bold("Created"),
+        chalk.bold("Content"),
+      ]
+    : [
+        chalk.bold("ID"),
+        chalk.bold("Type"),
+        chalk.bold("Workflow"),
+        chalk.bold("Created"),
+        chalk.bold("Content"),
+      ];
+
+  const colWidths = showResolved
+    ? [10, 10, 10, 20, 12, 40]
+    : [10, 10, 20, 12, 50];
+
   const table = new Table({
-    head: [
-      chalk.bold("ID"),
-      chalk.bold("Type"),
-      chalk.bold("Workflow"),
-      chalk.bold("Created"),
-      chalk.bold("Content"),
-    ],
+    head: headers,
     style: {
       head: [],
       border: [],
     },
-    colWidths: [10, 10, 20, 12, 50],
+    colWidths,
     wordWrap: true,
   });
 
@@ -329,12 +346,22 @@ function formatObservations(
     const id = obs._ulid.substring(0, 8);
     const workflow = obs.workflow_ref || "-";
     const created = new Date(obs.created_at).toISOString().split("T")[0];
+    // Adjust content truncation based on available column width
+    const maxContentLen = showResolved ? 37 : 47;
     const content =
-      obs.content.length > 47
-        ? `${obs.content.substring(0, 47)}...`
+      obs.content.length > maxContentLen
+        ? `${obs.content.substring(0, maxContentLen)}...`
         : obs.content;
 
-    table.push([id, obs.type, workflow, created, content]);
+    // AC: @obs-list-display ac-1 - Show ✓ for resolved, ✗ for unresolved
+    if (showResolved) {
+      const resolvedIndicator = obs.resolved
+        ? chalk.green("✓")
+        : chalk.red("✗");
+      table.push([id, obs.type, resolvedIndicator, workflow, created, content]);
+    } else {
+      table.push([id, obs.type, workflow, created, content]);
+    }
   }
 
   console.log(table.toString());

--- a/tests/meta.test.ts
+++ b/tests/meta.test.ts
@@ -668,6 +668,41 @@ describe('Integration: meta observations', () => {
     expect(outputAll).toContain('This will be resolved');
   });
 
+  // AC: @obs-list-display ac-1
+  it('should show Resolved column with checkmarks when using --all flag', async () => {
+    // Create two observations: one resolved, one unresolved
+    const createOutput = kspec('meta observe friction "Will be resolved"', tempDir);
+    const match = createOutput.match(/Created observation: ([A-Z0-9]{8})/);
+    expect(match).not.toBeNull();
+    const obsRef = match![1];
+
+    kspec('meta observe success "Will stay unresolved"', tempDir);
+
+    // Resolve one observation
+    kspec(`meta resolve @${obsRef} "Fixed it"`, tempDir);
+
+    // List with --all should show Resolved column
+    const outputAll = kspec('meta observations --all', tempDir);
+
+    // Should contain Resolved header
+    expect(outputAll).toContain('Resolved');
+
+    // Should show both observations with resolved indicators
+    // ✓ for resolved, ✗ for unresolved
+    expect(outputAll).toContain('✓');
+    expect(outputAll).toContain('✗');
+    expect(outputAll).toContain('Will be resolved');
+    expect(outputAll).toContain('Will stay unresolved');
+
+    // List without --all should NOT show Resolved column
+    const outputDefault = kspec('meta observations', tempDir);
+    expect(outputDefault).not.toContain('Resolved');
+    // Should not show resolved observation
+    expect(outputDefault).not.toContain('Will be resolved');
+    // Should show unresolved observation
+    expect(outputDefault).toContain('Will stay unresolved');
+  });
+
   // AC: @observations ac-obs-5
   it('should output JSON with full observation objects', () => {
     kspec('meta observe friction "Test observation"', tempDir);


### PR DESCRIPTION
## Summary
- Adds a Resolved column to observation list output when using `--all` flag
- Shows ✓ (green) for resolved observations, ✗ (red) for unresolved
- Column only appears when `--all` is used since unresolved-only list doesn't need it

## Test plan
- [x] Verify `kspec meta observations --all` shows Resolved column with checkmarks
- [x] Verify `kspec meta observations` (without --all) does not show Resolved column
- [x] Run observation-related tests: `npm test -- --run tests/meta.test.ts --testNamePattern="observations"`

Task: @01KG70WJ
Spec: @obs-list-display

🤖 Generated with [Claude Code](https://claude.com/claude-code)