### PR TITLE
feat(cli): add 'kspec util ulid' command for ULID generation

### DIFF
--- a/src/cli/commands/index.ts
+++ b/src/cli/commands/index.ts
@@ -21,5 +21,6 @@ export { registerShadowCommands } from "./shadow.js";
 export { registerTaskCommands } from "./task.js";
 export { registerTasksCommands } from "./tasks.js";
 export { registerItemTraitCommands, registerTraitCommands } from "./trait.js";
+export { registerUtilCommands } from "./util.js";
 export { registerValidateCommand } from "./validate.js";
 export { registerWorkflowCommand } from "./workflow.js";

--- a/src/cli/commands/util.ts
+++ b/src/cli/commands/util.ts
@@ -1,0 +1,34 @@
+import type { Command } from "commander";
+import { ulid } from "ulid";
+import { output } from "../output.js";
+
+/**
+ * Register utility commands
+ * AC: @cli-utilities
+ */
+export function registerUtilCommands(program: Command): void {
+  const util = program
+    .command("util")
+    .description("Utility commands for development tasks");
+
+  // kspec util ulid - generate valid ULIDs
+  // AC: @cli-utilities ac-1
+  util
+    .command("ulid")
+    .description("Generate valid ULIDs for YAML fixtures")
+    .option("-c, --count <n>", "Number of ULIDs to generate", "1")
+    .action((options) => {
+      const count = Math.max(1, parseInt(options.count, 10) || 1);
+      const ulids: string[] = [];
+
+      for (let i = 0; i < count; i++) {
+        ulids.push(ulid());
+      }
+
+      output({ ulids }, () => {
+        for (const id of ulids) {
+          console.log(id);
+        }
+      });
+    });
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -35,6 +35,7 @@ import {
   registerTaskCommands,
   registerTasksCommands,
   registerTraitCommands,
+  registerUtilCommands,
   registerValidateCommand,
   registerWorkflowCommand,
 } from "./commands/index.js";
@@ -166,6 +167,7 @@ registerCloneForTestingCommand(program);
 registerWorkflowCommand(program);
 registerMergeDriverCommand(program);
 registerExportCommand(program);
+registerUtilCommands(program);
 
 // Handle unknown commands with suggestions
 program.on("command:*", (operands) => {

--- a/tests/util.test.ts
+++ b/tests/util.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { kspec, kspecJson, setupTempFixtures, cleanupTempDir } from "./helpers/cli";
+
+describe("Integration: util commands", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await setupTempFixtures();
+  });
+
+  afterEach(async () => {
+    await cleanupTempDir(tempDir);
+  });
+
+  describe("util ulid", () => {
+    // AC: @cli-utilities ac-1
+    it("should generate a single valid ULID by default", async () => {
+      const result = await kspec("util ulid", tempDir);
+      expect(result.exitCode).toBe(0);
+
+      // ULID format: 26 chars, Crockford base32
+      const ulid = result.stdout.trim();
+      expect(ulid).toMatch(/^[0-9A-HJKMNP-TV-Z]{26}$/);
+    });
+
+    // AC: @cli-utilities ac-1
+    it("should generate multiple ULIDs with --count option", async () => {
+      const result = await kspec("util ulid --count 5", tempDir);
+      expect(result.exitCode).toBe(0);
+
+      const ulids = result.stdout.trim().split("\n");
+      expect(ulids).toHaveLength(5);
+
+      // Each should be valid ULID format
+      for (const ulid of ulids) {
+        expect(ulid).toMatch(/^[0-9A-HJKMNP-TV-Z]{26}$/);
+      }
+
+      // All should be unique
+      const uniqueUlids = new Set(ulids);
+      expect(uniqueUlids.size).toBe(5);
+    });
+
+    // AC: @cli-utilities ac-1
+    it("should generate multiple ULIDs with -c short option", async () => {
+      const result = await kspec("util ulid -c 3", tempDir);
+      expect(result.exitCode).toBe(0);
+
+      const ulids = result.stdout.trim().split("\n");
+      expect(ulids).toHaveLength(3);
+    });
+
+    // AC: @cli-utilities ac-1
+    it("should output JSON format with --json flag", async () => {
+      const result = await kspecJson<{ ulids: string[] }>("util ulid --count 2", tempDir);
+
+      expect(result.ulids).toHaveLength(2);
+      for (const ulid of result.ulids) {
+        expect(ulid).toMatch(/^[0-9A-HJKMNP-TV-Z]{26}$/);
+      }
+    });
+
+    // AC: @cli-utilities ac-1 (Crockford base32 format)
+    it("should generate ULIDs using valid Crockford base32 characters only", async () => {
+      // Generate many ULIDs to have a good sample
+      const result = await kspec("util ulid --count 10", tempDir);
+      expect(result.exitCode).toBe(0);
+
+      const ulids = result.stdout.trim().split("\n");
+
+      // Crockford base32 excludes: I, L, O, U (lowercase variants too)
+      const invalidChars = /[ILOUilou]/;
+
+      for (const ulid of ulids) {
+        expect(ulid).not.toMatch(invalidChars);
+        // Should be all uppercase or digits
+        expect(ulid).toMatch(/^[0-9A-HJKMNP-TV-Z]{26}$/);
+      }
+    });
+
+    it("should handle invalid count gracefully", async () => {
+      // Invalid count should default to 1
+      const result = await kspec("util ulid --count abc", tempDir);
+      expect(result.exitCode).toBe(0);
+
+      const ulids = result.stdout.trim().split("\n");
+      expect(ulids).toHaveLength(1);
+    });
+
+    it("should handle zero count as 1", async () => {
+      const result = await kspec("util ulid --count 0", tempDir);
+      expect(result.exitCode).toBe(0);
+
+      const ulids = result.stdout.trim().split("\n");
+      expect(ulids).toHaveLength(1);
+    });
+
+    it("should handle negative count as 1", async () => {
+      const result = await kspec("util ulid --count -5", tempDir);
+      expect(result.exitCode).toBe(0);
+
+      const ulids = result.stdout.trim().split("\n");
+      expect(ulids).toHaveLength(1);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `kspec util ulid` command for generating valid ULIDs
- Supports `--count N` / `-c N` option to generate multiple ULIDs
- JSON output supported via `--json` flag
- ULIDs use Crockford base32 format suitable for kspec schemas

## Test plan
- [x] Single ULID generation works
- [x] Multiple ULID generation with --count option
- [x] Short -c option works
- [x] JSON output format correct
- [x] Edge cases (invalid/zero/negative counts) handled gracefully
- [x] All generated ULIDs use valid Crockford base32 characters

Task: @01KG70XC
Spec: @cli-utilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)