### PR TITLE
feat(cli): add concrete examples to --help for variadic options

### DIFF
--- a/src/cli/commands/inbox.ts
+++ b/src/cli/commands/inbox.ts
@@ -74,6 +74,13 @@ export function registerInboxCommands(program: Command): void {
     .command("add <text>")
     .description("Capture an idea quickly")
     .option("--tag <tag...>", "Add tags for categorization")
+    .addHelpText(
+      "after",
+      `
+Examples:
+  $ kspec inbox add "Idea for new feature"
+  $ kspec inbox add "Consider refactoring X" --tag refactor tech-debt`,
+    )
     .action(async (text: string, options) => {
       try {
         const ctx = await initContext();
@@ -164,6 +171,13 @@ export function registerInboxCommands(program: Command): void {
     .option("--spec-ref <ref>", "Link to spec item")
     .option("--tag <tag...>", "Tags for the task")
     .option("--keep", "Keep inbox item after promoting")
+    .addHelpText(
+      "after",
+      `
+Examples:
+  $ kspec inbox promote @ref --title "New task from idea"
+  $ kspec inbox promote @ref --title "Tagged task" --tag cli urgent`,
+    )
     .action(async (ref: string, options) => {
       try {
         const ctx = await initContext();

--- a/src/cli/commands/item.ts
+++ b/src/cli/commands/item.ts
@@ -580,6 +580,13 @@ export function registerItemCommands(program: Command): void {
       "--as <field>",
       "Child field override (e.g., requirements, constraints)",
     )
+    .addHelpText(
+      "after",
+      `
+Examples:
+  $ kspec item add --under @parent --title "Feature name" --type feature
+  $ kspec item add --under @parent --title "Multi-tag" --tag api public`,
+    )
     .action(async (options) => {
       try {
         const ctx = await initContext();
@@ -691,6 +698,14 @@ export function registerItemCommands(program: Command): void {
       "Set verified_at (defaults to now if --verified-by provided)",
     )
     .option("--trait <trait...>", "Set traits (replaces existing)")
+    .addHelpText(
+      "after",
+      `
+Examples:
+  $ kspec item set @item-ref --title "New title"
+  $ kspec item set @item-ref --tag api internal security
+  $ kspec item set @item-ref --trait reusable testable`,
+    )
     .action(async (ref, options) => {
       try {
         const ctx = await initContext();

--- a/src/cli/commands/meta.ts
+++ b/src/cli/commands/meta.ts
@@ -1098,6 +1098,13 @@ export function registerMetaCommands(program: Command): void {
       "--resolution <text>",
       "Resolution text (required for batch mode unless observations have promoted tasks)",
     )
+    .addHelpText(
+      "after",
+      `
+Examples:
+  $ kspec meta resolve @obs-ref "Fixed in PR #123"
+  $ kspec meta resolve --refs @obs1 @obs2 --resolution "Resolved in batch"`,
+    )
     .action(
       async (
         ref: string | undefined,
@@ -1254,6 +1261,14 @@ export function registerMetaCommands(program: Command): void {
     )
     .option("--based-on <ref>", "Base workflow reference (for loop workflows)")
     .option("--tag <tag...>", "Tags for the workflow (for workflows)")
+    .addHelpText(
+      "after",
+      `
+Examples:
+  $ kspec meta add agent --id my-agent --name "My Agent" --capability search code
+  $ kspec meta add convention --domain testing --rule "Always test" --rule "Use mocks"
+  $ kspec meta add workflow --id my-flow --trigger manual --tag automation ci`,
+    )
     .action(async (type: string, options) => {
       try {
         const ctx = await initContext();

--- a/src/cli/commands/module.ts
+++ b/src/cli/commands/module.ts
@@ -30,6 +30,13 @@ export function registerModuleCommands(program: Command): void {
     .requiredOption("--slug <slug>", "Module slug (becomes filename)")
     .option("--description <desc>", "Module description")
     .option("--tag <tag...>", "Tags")
+    .addHelpText(
+      "after",
+      `
+Examples:
+  $ kspec module add --title "Auth Module" --slug auth
+  $ kspec module add --title "API Module" --slug api --tag core public`,
+    )
     .action(async (options) => {
       try {
         const ctx = await initContext();

--- a/src/cli/commands/task.ts
+++ b/src/cli/commands/task.ts
@@ -562,6 +562,14 @@ export function registerTaskCommands(program: Command): void {
       "--automation <status>",
       "Automation eligibility (eligible, needs_review, manual_only)",
     )
+    .addHelpText(
+      "after",
+      `
+Examples:
+  $ kspec task add --title "Implement feature" --spec-ref @feature-spec
+  $ kspec task add --title "Fix bug" --type bug --priority 1
+  $ kspec task add --title "Multi-tag task" --tag cli urgent`,
+    )
     .action(async (options) => {
       try {
         const ctx = await initContext();
@@ -704,6 +712,15 @@ export function registerTaskCommands(program: Command): void {
     .option(
       "--status <status>",
       "Reject with error - use state transition commands instead",
+    )
+    .addHelpText(
+      "after",
+      `
+Examples:
+  $ kspec task set @task-slug --priority 2
+  $ kspec task set @task-slug --depends-on @dep1 @dep2
+  $ kspec task set @task-slug --tag cli urgent
+  $ kspec task set --refs @task1 @task2 --priority 3`,
     )
     .action(async (ref: string | undefined, options) => {
       try {
@@ -1055,6 +1072,13 @@ export function registerTaskCommands(program: Command): void {
       "Force completion even if blocked (AC: @task-commands ac-1)",
     )
     .option("--no-sync", "Skip syncing spec implementation status")
+    .addHelpText(
+      "after",
+      `
+Examples:
+  $ kspec task complete @task-slug --reason "Merged in PR #123"
+  $ kspec task complete --refs @task1 @task2 --reason "Batch completion"`,
+    )
     .action(async (ref: string | undefined, options) => {
       try {
         const ctx = await initContext();
@@ -1401,6 +1425,13 @@ export function registerTaskCommands(program: Command): void {
     .description("Cancel a task")
     .option("--refs <refs...>", "Cancel multiple tasks by ref")
     .option("--reason <reason>", "Cancellation reason")
+    .addHelpText(
+      "after",
+      `
+Examples:
+  $ kspec task cancel @task-slug --reason "No longer needed"
+  $ kspec task cancel --refs @task1 @task2 --reason "Superseded by @new-task"`,
+    )
     .action(async (ref: string | undefined, options) => {
       try {
         const ctx = await initContext();
@@ -1572,6 +1603,14 @@ export function registerTaskCommands(program: Command): void {
     .option("--refs <refs...>", "Delete multiple tasks by ref")
     .option("--force", "Skip confirmation (required for --refs)")
     .option("--dry-run", "Show what would be deleted without deleting")
+    .addHelpText(
+      "after",
+      `
+Examples:
+  $ kspec task delete @task-slug
+  $ kspec task delete --refs @task1 @task2 --force
+  $ kspec task delete --refs @task1 @task2 --dry-run`,
+    )
     .action(async (ref: string | undefined, options) => {
       try {
         const ctx = await initContext();

--- a/tests/help-examples.test.ts
+++ b/tests/help-examples.test.ts
@@ -1,0 +1,130 @@
+// AC: @cli-help-examples ac-1 - Help output includes concrete examples for variadic options
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { kspecOutput as kspec, cleanupTempDir, setupTempFixtures } from './helpers/cli';
+
+describe('CLI help examples for variadic options', () => {
+  let tempDir: string;
+
+  beforeAll(async () => {
+    tempDir = await setupTempFixtures();
+  });
+
+  afterAll(async () => {
+    await cleanupTempDir(tempDir);
+  });
+
+  // AC: @cli-help-examples ac-1 - task set shows examples for --depends-on, --refs, --tag
+  it('task set --help shows examples for variadic options', () => {
+    const output = kspec('task set --help', tempDir);
+
+    // Verify Examples section exists
+    expect(output).toContain('Examples:');
+
+    // Verify --depends-on example
+    expect(output).toContain('--depends-on @dep1 @dep2');
+
+    // Verify --refs example
+    expect(output).toContain('--refs @task1 @task2');
+
+    // Verify --tag example
+    expect(output).toContain('--tag cli urgent');
+  });
+
+  // AC: @cli-help-examples ac-1 - task complete shows examples for --refs
+  it('task complete --help shows examples for --refs', () => {
+    const output = kspec('task complete --help', tempDir);
+
+    expect(output).toContain('Examples:');
+    expect(output).toContain('--refs @task1 @task2');
+    expect(output).toContain('--reason');
+  });
+
+  // AC: @cli-help-examples ac-1 - task cancel shows examples for --refs
+  it('task cancel --help shows examples for --refs', () => {
+    const output = kspec('task cancel --help', tempDir);
+
+    expect(output).toContain('Examples:');
+    expect(output).toContain('--refs @task1 @task2');
+  });
+
+  // AC: @cli-help-examples ac-1 - task delete shows examples for --refs
+  it('task delete --help shows examples for --refs', () => {
+    const output = kspec('task delete --help', tempDir);
+
+    expect(output).toContain('Examples:');
+    expect(output).toContain('--refs @task1 @task2');
+    expect(output).toContain('--force');
+    expect(output).toContain('--dry-run');
+  });
+
+  // AC: @cli-help-examples ac-1 - task add shows examples for --tag
+  it('task add --help shows examples for --tag', () => {
+    const output = kspec('task add --help', tempDir);
+
+    expect(output).toContain('Examples:');
+    expect(output).toContain('--tag cli urgent');
+  });
+
+  // AC: @cli-help-examples ac-1 - meta resolve shows examples for --refs
+  it('meta resolve --help shows examples for --refs', () => {
+    const output = kspec('meta resolve --help', tempDir);
+
+    expect(output).toContain('Examples:');
+    expect(output).toContain('--refs @obs1 @obs2');
+    expect(output).toContain('--resolution');
+  });
+
+  // AC: @cli-help-examples ac-1 - meta add shows examples for variadic options
+  it('meta add --help shows examples for variadic options', () => {
+    const output = kspec('meta add --help', tempDir);
+
+    expect(output).toContain('Examples:');
+    // Agent example with --capability
+    expect(output).toContain('--capability');
+    // Convention example with --rule
+    expect(output).toContain('--rule');
+    // Workflow example with --tag
+    expect(output).toContain('--tag');
+  });
+
+  // AC: @cli-help-examples ac-1 - item add shows examples for --tag
+  it('item add --help shows examples for --tag', () => {
+    const output = kspec('item add --help', tempDir);
+
+    expect(output).toContain('Examples:');
+    expect(output).toContain('--tag');
+  });
+
+  // AC: @cli-help-examples ac-1 - item set shows examples for --tag and --trait
+  it('item set --help shows examples for --tag and --trait', () => {
+    const output = kspec('item set --help', tempDir);
+
+    expect(output).toContain('Examples:');
+    expect(output).toContain('--tag');
+    expect(output).toContain('--trait');
+  });
+
+  // AC: @cli-help-examples ac-1 - inbox add shows examples for --tag
+  it('inbox add --help shows examples for --tag', () => {
+    const output = kspec('inbox add --help', tempDir);
+
+    expect(output).toContain('Examples:');
+    expect(output).toContain('--tag');
+  });
+
+  // AC: @cli-help-examples ac-1 - inbox promote shows examples for --tag
+  it('inbox promote --help shows examples for --tag', () => {
+    const output = kspec('inbox promote --help', tempDir);
+
+    expect(output).toContain('Examples:');
+    expect(output).toContain('--tag');
+  });
+
+  // AC: @cli-help-examples ac-1 - module add shows examples for --tag
+  it('module add --help shows examples for --tag', () => {
+    const output = kspec('module add --help', tempDir);
+
+    expect(output).toContain('Examples:');
+    expect(output).toContain('--tag');
+  });
+});


### PR DESCRIPTION
## Summary

- Added Examples section to CLI --help output for commands with variadic options
- Uses commander's `addHelpText('after', ...)` to display examples at end of help output
- Commands updated: task set/add/complete/cancel/delete, meta resolve/add, item add/set, inbox add/promote, module add

## Test plan

- [x] `npm test -- tests/help-examples.test.ts` - 12 tests verify Examples section and specific option examples
- [x] Manual verification: `kspec task set --help` shows Examples section with variadic option usage

Task: @01KG71BB
Spec: @cli-help-examples

🤖 Generated with [Claude Code](https://claude.ai/code)