### PR TITLE
chore: gitignore ralph end-iteration marker file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ coverage/
 .kspec-session
 bun.lock
 .claude/ralph-task-limit.json
+.claude/ralph-end-iteration.json


### PR DESCRIPTION
## Summary

- Add `.claude/ralph-end-iteration.json` to `.gitignore`
- This marker file was added in #292 but the gitignore entry was missed
- Matches the existing pattern for `.claude/ralph-task-limit.json`

## Context

These are temporary files used for ralph loop control signals. They should not be committed to the repository.

Also deleted inbox item `@01KG762F` about marker cleanup - that's already implemented in the finally hook for both markers.

🤖 Generated with [Claude Code](https://claude.ai/code)