### PR TITLE
feat(cli): add signal handlers for ralph marker cleanup on Ctrl+C

### DIFF
--- a/src/cli/commands/ralph.ts
+++ b/src/cli/commands/ralph.ts
@@ -1021,16 +1021,21 @@ export function registerRalphCommand(program: Command): void {
 
         // AC: @ralph-end-iteration ac-signal-cleanup, @ralph-task-limit ac-signal-cleanup
         // Signal handlers for cleanup on Ctrl+C or kill
-        const signalCleanup = async (signal: string) => {
+        // Note: Signal handlers must be synchronous, so we use Promise.finally()
+        // to ensure cleanup completes before exit
+        const signalCleanup = (signal: string) => {
           info(`Received ${signal}, cleaning up...`);
           // Kill agent if running
           if (agent) {
             agent.kill();
           }
-          // Clean up marker files
-          await clearTaskLimitMarker(ctx.rootDir);
-          await clearEndIterationMarker(ctx.rootDir);
-          process.exit(0);
+          // Clean up marker files, then exit after cleanup completes
+          Promise.all([
+            clearTaskLimitMarker(ctx.rootDir),
+            clearEndIterationMarker(ctx.rootDir),
+          ]).finally(() => {
+            process.exit(0);
+          });
         };
         const sigintHandler = () => { signalCleanup("SIGINT"); };
         const sigtermHandler = () => { signalCleanup("SIGTERM"); };

--- a/tests/ralph/end-iteration.test.ts
+++ b/tests/ralph/end-iteration.test.ts
@@ -139,21 +139,25 @@ describe('Marker file cleanup', () => {
 
 describe('Signal cleanup', () => {
   // AC: @ralph-end-iteration ac-signal-cleanup
-  // Note: Actual signal handling (SIGINT/SIGTERM) requires integration testing
-  // with a running ralph process. This test verifies the code structure.
+  // Static analysis to verify signal handlers are registered correctly.
+  // Full integration testing would require spawning ralph and sending signals.
 
-  it('should register SIGINT and SIGTERM handlers (verified via code inspection)', () => {
-    // The signal handlers are registered in ralph.ts:
-    // - process.on("SIGINT", sigintHandler)
-    // - process.on("SIGTERM", sigtermHandler)
-    // They call signalCleanup() which:
-    // 1. Kills the agent if running
-    // 2. Clears both marker files
-    // 3. Exits the process
-    //
-    // This is verified by code inspection. Full integration testing
-    // would require spawning ralph and sending signals, which is
-    // complex and platform-dependent.
-    expect(true).toBe(true);
+  it('should register SIGINT and SIGTERM handlers', async () => {
+    const ralphContent = await fs.readFile(
+      path.join(process.cwd(), 'src/cli/commands/ralph.ts'),
+      'utf-8'
+    );
+
+    // Verify signal handlers are registered
+    expect(ralphContent).toContain('process.on("SIGINT"');
+    expect(ralphContent).toContain('process.on("SIGTERM"');
+
+    // Verify cleanup functions are called in handlers
+    expect(ralphContent).toContain('clearTaskLimitMarker');
+    expect(ralphContent).toContain('clearEndIterationMarker');
+
+    // Verify cleanup awaits before exit (uses Promise.finally pattern)
+    expect(ralphContent).toContain('Promise.all');
+    expect(ralphContent).toContain('.finally(() =>');
   });
 });


### PR DESCRIPTION
## Summary

- Add SIGINT and SIGTERM handlers to ralph run command
- Handlers clean up marker files when process is terminated via Ctrl+C or kill
- Prevents orphaned marker files that would otherwise persist for 1 hour

## Implementation

The signal handlers:
1. Log the signal received
2. Kill the agent if running
3. Clear both task-limit and end-iteration marker files
4. Exit the process cleanly

Handlers are removed in the finally block to avoid double cleanup on normal exit.

## Cross-platform

Node.js handles Ctrl+C as SIGINT on both Unix and Windows. SIGTERM is Unix-only but harmless to register on Windows.

## Test plan

- [x] Build succeeds
- [x] All ralph tests pass (20 tests)
- [x] Code inspection verifies signal handler registration

Task: @01KG8Q5G
Spec: @ralph-end-iteration ac-signal-cleanup
Spec: @ralph-task-limit ac-signal-cleanup

🤖 Generated with [Claude Code](https://claude.ai/code)