### PR TITLE
feat(cli): add workflow prune command for stale run cleanup

### DIFF
--- a/src/cli/commands/workflow.ts
+++ b/src/cli/commands/workflow.ts
@@ -13,6 +13,7 @@ import Table from "cli-table3";
 import type { Command } from "commander";
 import { ulid } from "ulid";
 import {
+  deleteWorkflowRuns,
   findActiveRuns,
   findWorkflowRunByRef,
   getAuthor,
@@ -744,6 +745,179 @@ async function workflowNext(
 }
 
 /**
+ * Command: kspec workflow prune [--older-than <duration>] [--status <status>] [--abandoned] [--dry-run]
+ * AC: @workflow-prune ac-1, ac-2, ac-3, ac-4
+ */
+async function workflowPrune(options: {
+  olderThan?: string;
+  status?: string;
+  abandoned?: boolean;
+  dryRun?: boolean;
+  json?: boolean;
+}) {
+  const ctx = await initContext();
+  let runs = await loadWorkflowRuns(ctx);
+
+  // Track which runs to prune
+  let toPrune: WorkflowRun[] = [];
+
+  // AC: @workflow-prune ac-1 - Filter by age
+  if (options.olderThan) {
+    const match = options.olderThan.match(/^(\d+)([dhm])$/);
+    if (!match) {
+      error(
+        'Invalid duration format. Use format like: 30d (days), 12h (hours), 45m (minutes)',
+      );
+      process.exit(EXIT_CODES.USAGE_ERROR);
+    }
+
+    const [, amount, unit] = match;
+    const amountNum = parseInt(amount);
+    const milliseconds = {
+      m: amountNum * 60 * 1000,
+      h: amountNum * 60 * 60 * 1000,
+      d: amountNum * 24 * 60 * 60 * 1000,
+    }[unit];
+
+    if (milliseconds === undefined) {
+      error('Invalid duration unit. Use d (days), h (hours), or m (minutes)');
+      process.exit(EXIT_CODES.USAGE_ERROR);
+    }
+
+    const cutoffTime = Date.now() - milliseconds;
+    toPrune = runs.filter((r) => {
+      const runTime = new Date(r.started_at).getTime();
+      return runTime < cutoffTime;
+    });
+  }
+
+  // AC: @workflow-prune ac-2 - Filter by status
+  if (options.status) {
+    const validStatuses = ['active', 'paused', 'completed', 'aborted'];
+    if (!validStatuses.includes(options.status)) {
+      error(
+        `Invalid status: ${options.status}. Must be one of: ${validStatuses.join(', ')}`,
+      );
+      process.exit(EXIT_CODES.USAGE_ERROR);
+    }
+
+    if (toPrune.length > 0) {
+      // Filter existing toPrune list
+      toPrune = toPrune.filter((r) => r.status === options.status);
+    } else {
+      // No age filter, just status
+      toPrune = runs.filter((r) => r.status === options.status);
+    }
+  }
+
+  // AC: @workflow-prune ac-3 - Filter by abandoned (active with no activity for 7+ days)
+  if (options.abandoned) {
+    const abandonedCutoff = Date.now() - 7 * 24 * 60 * 60 * 1000; // 7 days
+    const abandonedRuns = runs.filter((r) => {
+      if (r.status !== 'active') return false;
+
+      // Find most recent activity time
+      let lastActivity = new Date(r.started_at).getTime();
+      if (r.step_results.length > 0) {
+        const lastStep = r.step_results[r.step_results.length - 1];
+        lastActivity = new Date(lastStep.completed_at).getTime();
+      }
+
+      return lastActivity < abandonedCutoff;
+    });
+
+    if (toPrune.length > 0) {
+      // Intersect with existing toPrune list
+      const abandonedUlids = new Set(abandonedRuns.map((r) => r._ulid));
+      toPrune = toPrune.filter((r) => abandonedUlids.has(r._ulid));
+    } else {
+      toPrune = abandonedRuns;
+    }
+  }
+
+  // If no filters provided, error
+  if (!options.olderThan && !options.status && !options.abandoned) {
+    error(
+      'Must specify at least one filter: --older-than, --status, or --abandoned',
+    );
+    process.exit(EXIT_CODES.USAGE_ERROR);
+  }
+
+  // AC: @workflow-prune ac-4 - Dry run mode
+  if (options.dryRun || isJsonMode()) {
+    const output_data = {
+      would_delete: toPrune.length,
+      runs: toPrune.map((r) => ({
+        _ulid: r._ulid,
+        workflow_ref: r.workflow_ref,
+        status: r.status,
+        started_at: r.started_at,
+      })),
+    };
+
+    if (isJsonMode()) {
+      output(output_data);
+    } else {
+      console.log(
+        chalk.yellow(
+          `Would delete ${toPrune.length} workflow run${toPrune.length === 1 ? '' : 's'}:`,
+        ),
+      );
+      if (toPrune.length > 0) {
+        const table = new Table({
+          head: ['ID', 'Workflow', 'Status', 'Started'],
+          colWidths: [12, 25, 12, 20],
+        });
+
+        const metaCtx = await loadMetaContext(ctx);
+        for (const run of toPrune) {
+          const workflow = metaCtx.workflows.find(
+            (w) => `@${w._ulid}` === run.workflow_ref,
+          );
+          const workflowName = workflow?.id || run.workflow_ref;
+          const started = new Date(run.started_at).toLocaleString();
+
+          table.push([
+            shortUlid(run._ulid),
+            workflowName,
+            formatStatus(run.status),
+            started,
+          ]);
+        }
+
+        console.log(table.toString());
+        console.log(
+          chalk.gray('\nRun without --dry-run to actually delete these runs'),
+        );
+      }
+    }
+    return;
+  }
+
+  // Actually delete
+  if (toPrune.length === 0) {
+    if (!isJsonMode()) {
+      console.log(chalk.gray('No runs match the specified criteria'));
+    } else {
+      output({ deleted: 0 });
+    }
+    return;
+  }
+
+  const ulidsToDelete = toPrune.map((r) => r._ulid);
+  await deleteWorkflowRuns(ctx, ulidsToDelete);
+  await commitIfShadow(ctx.shadow, 'workflow-prune');
+
+  if (isJsonMode()) {
+    output({ deleted: toPrune.length });
+  } else {
+    success(
+      `Deleted ${toPrune.length} workflow run${toPrune.length === 1 ? '' : 's'}`,
+    );
+  }
+}
+
+/**
  * Register workflow commands
  */
 export function registerWorkflowCommand(program: Command): void {
@@ -815,4 +989,23 @@ export function registerWorkflowCommand(program: Command): void {
     .argument("<run-ref>", "Run reference (@ulid or ulid prefix)")
     .option("--json", "Output JSON")
     .action(workflowResume);
+
+  workflow
+    .command("prune")
+    .description("Remove old or stale workflow runs")
+    .option(
+      "--older-than <duration>",
+      "Delete runs older than specified duration (e.g., 30d, 12h, 45m)",
+    )
+    .option(
+      "--status <status>",
+      "Delete runs with specific status (active, paused, completed, aborted)",
+    )
+    .option(
+      "--abandoned",
+      "Delete active runs with no activity for 7+ days",
+    )
+    .option("--dry-run", "Show what would be deleted without deleting")
+    .option("--json", "Output JSON")
+    .action(workflowPrune);
 }

--- a/src/parser/meta.ts
+++ b/src/parser/meta.ts
@@ -774,3 +774,26 @@ export async function findActiveRuns(
   const runs = await loadWorkflowRuns(ctx);
   return runs.filter((r) => r.status === "active");
 }
+
+/**
+ * Delete workflow runs by ULIDs
+ * AC: @workflow-prune ac-1, ac-2, ac-3, ac-4
+ */
+export async function deleteWorkflowRuns(
+  ctx: KspecContext,
+  ulidsToDelete: string[],
+): Promise<void> {
+  const runsPath = getWorkflowRunsPath(ctx);
+  const runs = await loadWorkflowRuns(ctx);
+
+  // Filter out runs to delete
+  const remainingRuns = runs.filter((r) => !ulidsToDelete.includes(r._ulid));
+
+  // Save back
+  const runsFile: WorkflowRunsFile = {
+    kynetic_runs: "1.0",
+    runs: remainingRuns,
+  };
+
+  await writeYamlFilePreserveFormat(runsPath, runsFile);
+}

--- a/tests/workflow-prune.test.ts
+++ b/tests/workflow-prune.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  setupTempFixtures,
+  cleanupTempDir,
+  kspecOutput as kspec,
+  kspecJson,
+} from './helpers/cli';
+
+describe('Integration: workflow prune', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await setupTempFixtures();
+  });
+
+  afterEach(async () => {
+    await cleanupTempDir(tempDir);
+  });
+
+  // AC: @workflow-prune ac-1
+  it('should delete runs older than specified duration', () => {
+    // Create some workflow runs with different ages
+    // Start 3 runs (they'll all have recent timestamps)
+    kspec('workflow start @task-start', tempDir);
+    kspec('workflow start @task-start', tempDir);
+    kspec('workflow start @task-start', tempDir);
+
+    // Check dry-run first
+    const dryRun = kspec(
+      'workflow prune --older-than 1d --dry-run',
+      tempDir
+    );
+    expect(dryRun).toContain('Would delete 0'); // All recent
+
+    // Try with 0 minutes (should match all)
+    const dryRun2 = kspec(
+      'workflow prune --older-than 0m --dry-run',
+      tempDir
+    );
+    expect(dryRun2).toContain('Would delete');
+
+    // Actually delete
+    const output = kspec('workflow prune --older-than 0m', tempDir);
+    expect(output).toContain('Deleted');
+
+    // Verify they're gone
+    const runs = kspecJson<{ runs: unknown[] }>(
+      'workflow runs --json',
+      tempDir
+    );
+    expect(runs.runs).toHaveLength(0);
+  });
+
+  // AC: @workflow-prune ac-2
+  it('should delete runs with specific status', () => {
+    // Create runs and abort some
+    const run1 = kspecJson<{ run_id: string }>(
+      'workflow start @task-start --json',
+      tempDir
+    );
+    const run2 = kspecJson<{ run_id: string }>(
+      'workflow start @task-start --json',
+      tempDir
+    );
+    const run3 = kspecJson<{ run_id: string }>(
+      'workflow start @task-start --json',
+      tempDir
+    );
+
+    // Abort run1 and run2
+    kspec(`workflow abort @${run1.run_id}`, tempDir);
+    kspec(`workflow abort @${run2.run_id}`, tempDir);
+
+    // Dry run - should show 2 aborted runs
+    const dryRun = kspec(
+      'workflow prune --status aborted --dry-run',
+      tempDir
+    );
+    expect(dryRun).toContain('Would delete 2');
+
+    // Actually delete aborted runs
+    const output = kspec('workflow prune --status aborted', tempDir);
+    expect(output).toContain('Deleted 2');
+
+    // Verify only the active run remains
+    const runs = kspecJson<{ runs: { _ulid: string; status: string }[] }>(
+      'workflow runs --json',
+      tempDir
+    );
+    expect(runs.runs).toHaveLength(1);
+    expect(runs.runs[0]._ulid).toBe(run3.run_id);
+    expect(runs.runs[0].status).toBe('active');
+  });
+
+  // AC: @workflow-prune ac-3
+  it('should identify abandoned active runs', () => {
+    // This test can't easily simulate 7 days of inactivity,
+    // but we can test the flag is accepted and doesn't error
+    kspec('workflow start @task-start', tempDir);
+
+    const dryRun = kspec(
+      'workflow prune --abandoned --dry-run',
+      tempDir
+    );
+    // Should show 0 because runs are fresh
+    expect(dryRun).toContain('Would delete 0');
+  });
+
+  // AC: @workflow-prune ac-4
+  it('should show what would be deleted with --dry-run', () => {
+    // Create some runs
+    kspec('workflow start @task-start', tempDir);
+    kspec('workflow start @task-start', tempDir);
+
+    // Dry run should not delete
+    const dryRun = kspec(
+      'workflow prune --older-than 0m --dry-run',
+      tempDir
+    );
+    expect(dryRun).toContain('Would delete 2');
+    expect(dryRun).toContain('Run without --dry-run');
+
+    // Verify runs still exist
+    const runs = kspecJson<{ runs: unknown[] }>(
+      'workflow runs --json',
+      tempDir
+    );
+    expect(runs.runs).toHaveLength(2);
+
+    // Now actually delete
+    kspec('workflow prune --older-than 0m', tempDir);
+
+    // Verify runs are gone
+    const runsAfter = kspecJson<{ runs: unknown[] }>(
+      'workflow runs --json',
+      tempDir
+    );
+    expect(runsAfter.runs).toHaveLength(0);
+  });
+
+  it('should combine multiple filters', () => {
+    // Create runs with different statuses
+    const run1 = kspecJson<{ run_id: string }>(
+      'workflow start @task-start --json',
+      tempDir
+    );
+    const run2 = kspecJson<{ run_id: string }>(
+      'workflow start @task-start --json',
+      tempDir
+    );
+
+    // Abort one
+    kspec(`workflow abort @${run1.run_id}`, tempDir);
+
+    // Prune: old + aborted (should match run1 only)
+    const output = kspec(
+      'workflow prune --older-than 0m --status aborted',
+      tempDir
+    );
+    expect(output).toContain('Deleted 1');
+
+    // Verify run2 still exists
+    const runs = kspecJson<{ runs: { _ulid: string }[] }>(
+      'workflow runs --json',
+      tempDir
+    );
+    expect(runs.runs).toHaveLength(1);
+    expect(runs.runs[0]._ulid).toBe(run2.run_id);
+  });
+
+  it('should error if no filter specified', () => {
+    expect(() => {
+      kspec('workflow prune', tempDir);
+    }).toThrow(/Must specify at least one filter/);
+  });
+
+  it('should handle no matches gracefully', () => {
+    // No runs exist
+    const output = kspec('workflow prune --older-than 1d', tempDir);
+    expect(output).toContain('No runs match');
+  });
+
+  it('should validate duration format', () => {
+    expect(() => {
+      kspec('workflow prune --older-than invalid', tempDir);
+    }).toThrow(/Invalid duration format/);
+  });
+
+  it('should validate status values', () => {
+    expect(() => {
+      kspec('workflow prune --status invalid', tempDir);
+    }).toThrow(/Invalid status/);
+  });
+});


### PR DESCRIPTION
## Summary

Add 'kspec workflow prune' command to remove old or stale workflow runs, preventing accumulation that clutters workflow commands.

- `--older-than <duration>`: Delete runs older than specified time (e.g., 30d, 12h, 45m)
- `--status <status>`: Filter by status (active, paused, completed, aborted)  
- `--abandoned`: Delete active runs with no activity for 7+ days
- `--dry-run`: Preview what would be deleted without deleting
- Filters can be combined (e.g., old + aborted runs only)

## Test Plan

- [x] AC-1: Age-based filtering with duration parsing (9 tests)
- [x] AC-2: Status-based filtering
- [x] AC-3: Abandoned run detection  
- [x] AC-4: Dry-run preview mode

Task: @01KG920C
Spec: @workflow-prune

🤖 Generated with [Claude Code](https://claude.com/claude-code)