### PR TITLE
feat(derive): add --title flag to override default task title

### DIFF
--- a/src/cli/commands/derive.ts
+++ b/src/cli/commands/derive.ts
@@ -271,6 +271,7 @@ async function deriveTaskFromSpec(
     dryRun: boolean;
     dependsOn?: string[];
     priority?: number;
+    title?: string;
   },
 ): Promise<DeriveResult> {
   // Check if a task already exists for this spec
@@ -314,8 +315,9 @@ async function deriveTaskFromSpec(
     : [];
 
   // Build task input with depends_on and initial notes
+  // AC: @derive-title-override ac-1 - use provided title if specified
   const taskInput: TaskInput = {
-    title: `Implement: ${specItem.title}`,
+    title: options.title ?? `Implement: ${specItem.title}`,
     type: "task",
     spec_ref: `@${specItem.slugs[0] || specItem._ulid}`,
     derivation: "auto",
@@ -414,6 +416,7 @@ export function registerDeriveCommand(program: Command): void {
       "Set priority for created task(s) (1-5)",
       parseInt,
     )
+    .option("--title <title>", "Override task title (default: 'Implement: {spec title}')")
     .action(async (ref: string | undefined, options) => {
       try {
         // Validate arguments
@@ -521,6 +524,7 @@ export function registerDeriveCommand(program: Command): void {
               dryRun: options.dryRun || false,
               dependsOn,
               priority: options.priority,
+              title: options.title,
             },
           );
 

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -963,6 +963,17 @@ describe('Integration: derive', () => {
     const pendingForSpec = allTasks.filter((t: any) => t.slugs.some((s: string) => s.startsWith('task-test-feature')));
     expect(pendingForSpec.length).toBe(1); // One new pending task for the spec
   });
+
+  // AC: @derive-title-override ac-1
+  it('should use --title override instead of default title', () => {
+    const output = kspec('derive @test-feature --flat --title "Custom Task Title"', tempDir);
+    expect(output).toContain('Created');
+
+    // Verify task was created with custom title
+    const taskOutput = kspec('task get @task-test-feature --json', tempDir);
+    const task = JSON.parse(taskOutput);
+    expect(task.title).toBe('Custom Task Title');
+  });
 });
 
 describe('Integration: session', () => {


### PR DESCRIPTION
## Summary
- Added `--title` option to `kspec derive` command
- When specified, uses the provided title instead of the default "Implement: {spec title}"
- Enables more descriptive or custom task names when deriving from specs

## Test plan
- [x] Added integration test verifying AC-1: `should use --title override instead of default title`
- [x] All 21 existing derive tests pass
- [x] Verified `--title` appears in `kspec derive --help`

Task: @01KG920G
Spec: @derive-title-override

🤖 Generated with [Claude Code](https://claude.com/claude-code)