### PR TITLE
docs: clarify loop mode blocking pattern to prevent premature end-iteration

### DIFF
--- a/.claude/skills/kspec/SKILL.md
+++ b/.claude/skills/kspec/SKILL.md
@@ -109,6 +109,8 @@ kspec task block @task-slug --reason "Waiting on API spec"
 kspec task unblock @task-slug
 ```
 
+**In loop mode:** Block only for genuine external blockers (human decision needed, spec gap, external dependency). Complexity and difficulty are NOT blockers - push through. Always check `kspec tasks ready --eligible` for other work before ending the loop. See `/task-work` for detailed loop mode guidance.
+
 ### Cancellation
 
 When a task is no longer needed:

--- a/.claude/skills/task-work/SKILL.md
+++ b/.claude/skills/task-work/SKILL.md
@@ -318,25 +318,68 @@ After 3 genuine attempts with different fixes, add a note documenting what you t
 Exit when:
 - **Task work complete** - PR created (normal exit)
 - **No eligible tasks** - `kspec tasks ready --eligible` returns empty
+- **All remaining eligible tasks blocked** - every eligible task has a genuine external blocker
+
+**Important:** "No eligible tasks" means ALL eligible tasks are done or blocked, not just the one you're working on. If one task is blocked, check for others before ending.
+
+### Blocking vs End-Iteration
+
+When you hit a genuine blocker on a task, the correct pattern is:
+
+1. **Attempt the work first** - actually try to solve the problem
+2. **Block the specific task** - not the whole loop
+3. **Check for other work** - there may be more eligible tasks
+4. **Continue or end** - only end when nothing remains
+
+| Situation | Action | Correct Response |
+|-----------|--------|------------------|
+| Task needs external input | `kspec task block` | Block task, continue to next |
+| Task has spec gap | `kspec task block` | Block task, continue to next |
+| Task requires architectural decision | `kspec task block` | Block task, mark needs_review, continue |
+| Task is complex/difficult | **DO THE WORK** | Complexity is not a blocker |
+| Tests are failing | **FIX THEM** | Debug and resolve |
+| Service needs to be running | **START IT** | See "Tasks Requiring Services" |
+| No more eligible tasks exist | `end-iteration` | Only valid end condition |
+
+```bash
+# Pattern: When you hit a genuine blocker mid-task
+kspec task note @task "Attempted X, Y, Z. Blocked because: [external reason]"
+kspec task block @task --reason "Requires architectural decision on X"
+kspec task set @task --automation needs_review
+
+# Check for other work before ending
+kspec tasks ready --eligible
+# If tasks exist: pick one and continue
+# If empty: then end-iteration is appropriate
+```
 
 ### Explicit Loop End Signal
 
-If you determine the loop should end (e.g., no more eligible tasks, or you've completed your focused work), you can explicitly signal ralph:
+Use `end-iteration` **only** when no more work is possible:
 
 ```bash
 kspec ralph end-iteration --reason "No eligible tasks remaining"
 ```
 
-This writes a marker file that ralph detects and triggers graceful loop exit after the current iteration completes. Use this when you want to ensure the loop ends cleanly rather than just finishing your current turn.
+**Valid reasons to end:**
+- `kspec tasks ready --eligible` returns empty
+- All remaining eligible tasks are blocked (and you checked)
+
+**Invalid reasons to end:**
+- "This task is hard" → do it anyway
+- "This task needs external decision" → block it and check for other tasks
+- "I've done enough" → check for more eligible tasks first
 
 ### What Is NOT an Exit Condition
 
-These are NOT reasons to exit or mark needs_review:
+These are NOT reasons to exit, block, or mark needs_review:
 - "Task seems complex" - do it anyway
 - "Might take multiple iterations" - that's fine, iterate
 - "Requires daemon" - start the daemon
 - "E2E tests need running" - run them
 - "Estimated time exceeds iteration" - estimates are not work, do the work
+
+**What to do instead:** Push through. Complexity and difficulty are expected. Block tasks only for genuine external blockers (human decision needed, spec gap, external dependency). If you can theoretically solve it with more effort, it's not blocked - keep working.
 
 ### Key Behaviors
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -250,6 +250,39 @@ pending → in_progress → pending_review → completed
 
 `blocked` is auto-computed when `depends_on` tasks aren't completed.
 
+### Task Blocking in Loop Mode
+
+When running in automated loop mode (ralph), understanding when to block vs continue is critical.
+
+**The pattern:**
+1. **Attempt the work** - actually try to solve the problem first
+2. **Hit a genuine blocker** - external dependency, needs human decision, spec gap
+3. **Block the task** - with documented reason and what you tried
+4. **Check for other work** - `kspec tasks ready --eligible`
+5. **Continue or end** - only end when ALL eligible tasks are blocked/done
+
+**Valid blocking reasons** (external blockers):
+- Requires human architectural decision
+- Needs spec clarification
+- Depends on external API/service not available
+- Blocked by another task
+
+**Invalid blocking reasons** (do the work):
+- Task seems complex
+- Tests are failing (fix them)
+- Service needs running (start it)
+- Might take multiple iterations
+
+```bash
+# When you hit a genuine blocker after attempting work
+kspec task note @task "Attempted: X, Y, Z. Blocked because: [external reason]"
+kspec task block @task --reason "Requires architectural decision on X"
+kspec task set @task --automation needs_review
+kspec tasks ready --eligible  # Check for other work
+```
+
+**Key principle:** One blocked task is NOT "no more work." Check for other eligible tasks before ending the loop. See `/task-work` skill for detailed loop mode guidance.
+
 ### Notes (Work Log)
 
 Tasks have append-only notes that track progress:


### PR DESCRIPTION
## Summary

- Adds "Blocking vs End-Iteration" section to task-work skill with comparison table
- Clarifies that tasks must be **attempted** before blocking (complexity is not a blocker)
- Documents the correct pattern: attempt → block → check for other work → continue
- Adds "Task Blocking in Loop Mode" section to AGENTS.md
- Cross-references loop mode guidance from kspec skill

## Context

In a recent ralph session, an agent prematurely ended the loop after 2/10 iterations because one task "required architectural decisions." The correct behavior would have been to block that task and continue with other eligible work.

The documentation previously told agents what NOT to do but didn't explain what TO do instead.

## Test plan

- [x] Documentation-only change, no tests required
- [x] Verified markdown renders correctly

Task: @01KGJ5DM

🤖 Generated with [Claude Code](https://claude.ai/code)