### PR TITLE
fix(ralph): rename end-iteration to end-loop for clarity

### DIFF
--- a/.claude/skills/task-work/SKILL.md
+++ b/.claude/skills/task-work/SKILL.md
@@ -283,11 +283,17 @@ Loop mode is NOT a free pass to:
    kspec task submit @task
    ```
 
-6. **Create PR and exit**
-   ```bash
+6. **Create PR and stop responding**
+   ```
    /pr
    ```
-   After PR created, EXIT. Ralph handles PR review via separate subagent.
+   After PR created, **stop responding** (do NOT call any more commands).
+   Ralph automatically:
+   1. Sends the reflection prompt to you
+   2. Processes pending_review tasks via subagent
+   3. Continues to the next iteration with remaining tasks
+
+   **Do NOT call `end-loop`** - creating a PR completes ONE task, not the loop.
 
 ### Tasks Requiring Services
 
@@ -322,7 +328,24 @@ Exit when:
 
 **Important:** "No eligible tasks" means ALL eligible tasks are done or blocked, not just the one you're working on. If one task is blocked, check for others before ending.
 
-### Blocking vs End-Iteration
+### Turn Completion vs Loop End
+
+**Turn Completion (normal):** Stop responding. Ralph continues automatically.
+Your turn ends when you stop sending tool calls. Ralph then:
+- Sends the reflection prompt
+- Processes pending_review tasks via subagent
+- Continues to the next iteration
+
+**Loop End (explicit signal):** `kspec ralph end-loop` - ends ALL remaining iterations.
+Only use when `kspec tasks ready --eligible` returns empty AND you've verified
+no more work is possible.
+
+**Common Mistake:** Calling `end-loop` after creating a PR.
+- Creating a PR = one task's code done
+- Other ready tasks may still exist
+- Ralph continues automatically to work on them
+
+### Blocking vs Ending the Loop
 
 When you hit a genuine blocker on a task, the correct pattern is:
 
@@ -339,7 +362,7 @@ When you hit a genuine blocker on a task, the correct pattern is:
 | Task is complex/difficult | **DO THE WORK** | Complexity is not a blocker |
 | Tests are failing | **FIX THEM** | Debug and resolve |
 | Service needs to be running | **START IT** | See "Tasks Requiring Services" |
-| No more eligible tasks exist | `end-iteration` | Only valid end condition |
+| No more eligible tasks exist | `end-loop` | Only valid end condition |
 
 ```bash
 # Pattern: When you hit a genuine blocker mid-task
@@ -350,15 +373,15 @@ kspec task set @task --automation needs_review
 # Check for other work before ending
 kspec tasks ready --eligible
 # If tasks exist: pick one and continue
-# If empty: then end-iteration is appropriate
+# If empty: then end-loop is appropriate
 ```
 
 ### Explicit Loop End Signal
 
-Use `end-iteration` **only** when no more work is possible:
+Use `end-loop` **only** when no more work is possible:
 
 ```bash
-kspec ralph end-iteration --reason "No eligible tasks remaining"
+kspec ralph end-loop --reason "No eligible tasks remaining"
 ```
 
 **Valid reasons to end:**
@@ -369,6 +392,7 @@ kspec ralph end-iteration --reason "No eligible tasks remaining"
 - "This task is hard" → do it anyway
 - "This task needs external decision" → block it and check for other tasks
 - "I've done enough" → check for more eligible tasks first
+- "I just created a PR" → ralph continues automatically, don't call end-loop
 
 ### What Is NOT an Exit Condition
 

--- a/.gitignore
+++ b/.gitignore
@@ -31,4 +31,4 @@ coverage/
 .kspec-session
 bun.lock
 .claude/ralph-task-limit.json
-.claude/ralph-end-iteration.json
+.claude/ralph-end-loop.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -283,6 +283,30 @@ kspec tasks ready --eligible  # Check for other work
 
 **Key principle:** One blocked task is NOT "no more work." Check for other eligible tasks before ending the loop. See `/task-work` skill for detailed loop mode guidance.
 
+### Ralph Loop Model
+
+Ralph operates in a prompt-response loop:
+
+```
+for each iteration (1..maxLoops):
+  1. Ralph sends task-work prompt
+  2. Agent works on tasks, may create PR(s)
+  3. Agent stops responding (turn complete)
+  4. Ralph sends reflection prompt
+  5. Agent captures learnings, stops responding
+  6. Ralph processes pending_review tasks via subagent
+  7. If no end-loop signal: continue to next iteration
+```
+
+**Key insight:** When you stop responding, ralph continues automatically.
+The loop only ends when:
+- Max iterations reached
+- Agent explicitly calls `kspec ralph end-loop`
+- Max consecutive failures reached
+
+**Do NOT call `end-loop` after creating a PR.** Simply stop responding.
+Ralph will continue to the next phase/iteration.
+
 ### Notes (Work Log)
 
 Tasks have append-only notes that track progress:

--- a/src/cli/commands/ralph.ts
+++ b/src/cli/commands/ralph.ts
@@ -78,16 +78,16 @@ interface TaskLimitMarker {
 }
 
 const TASK_LIMIT_MARKER_PATH = ".claude/ralph-task-limit.json";
-const END_ITERATION_MARKER_PATH = ".claude/ralph-end-iteration.json";
+const END_LOOP_MARKER_PATH = ".claude/ralph-end-loop.json";
 const STALE_MARKER_THRESHOLD_MS = 60 * 60 * 1000; // 1 hour
 
-// ─── End Iteration Marker ───────────────────────────────────────────────────
+// ─── End Loop Marker ────────────────────────────────────────────────────────
 
 /**
- * Marker file schema for explicit end-iteration signaling.
- * AC: @ralph-end-iteration ac-cmd
+ * Marker file schema for explicit end-loop signaling.
+ * AC: @ralph-end-loop ac-cmd
  */
-interface EndIterationMarker {
+interface EndLoopMarker {
   requested: boolean;
   timestamp: string; // ISO8601
   reason?: string;
@@ -152,17 +152,17 @@ async function clearStaleMarker(rootDir: string): Promise<boolean> {
 }
 
 /**
- * Write end-iteration marker file.
- * AC: @ralph-end-iteration ac-cmd
+ * Write end-loop marker file.
+ * AC: @ralph-end-loop ac-cmd
  */
-async function writeEndIterationMarker(
+async function writeEndLoopMarker(
   rootDir: string,
   reason?: string,
 ): Promise<void> {
-  const markerPath = path.join(rootDir, END_ITERATION_MARKER_PATH);
+  const markerPath = path.join(rootDir, END_LOOP_MARKER_PATH);
   const dir = path.dirname(markerPath);
   await fs.mkdir(dir, { recursive: true });
-  const marker: EndIterationMarker = {
+  const marker: EndLoopMarker = {
     requested: true,
     timestamp: new Date().toISOString(),
     reason,
@@ -171,27 +171,27 @@ async function writeEndIterationMarker(
 }
 
 /**
- * Read end-iteration marker file if it exists.
- * AC: @ralph-end-iteration ac-detect
+ * Read end-loop marker file if it exists.
+ * AC: @ralph-end-loop ac-detect
  */
-async function readEndIterationMarker(
+async function readEndLoopMarker(
   rootDir: string,
-): Promise<EndIterationMarker | null> {
-  const markerPath = path.join(rootDir, END_ITERATION_MARKER_PATH);
+): Promise<EndLoopMarker | null> {
+  const markerPath = path.join(rootDir, END_LOOP_MARKER_PATH);
   try {
     const content = await fs.readFile(markerPath, "utf-8");
-    return JSON.parse(content) as EndIterationMarker;
+    return JSON.parse(content) as EndLoopMarker;
   } catch {
     return null;
   }
 }
 
 /**
- * Clear end-iteration marker file.
- * AC: @ralph-end-iteration ac-cleanup
+ * Clear end-loop marker file.
+ * AC: @ralph-end-loop ac-cleanup
  */
-async function clearEndIterationMarker(rootDir: string): Promise<void> {
-  const markerPath = path.join(rootDir, END_ITERATION_MARKER_PATH);
+async function clearEndLoopMarker(rootDir: string): Promise<void> {
+  const markerPath = path.join(rootDir, END_LOOP_MARKER_PATH);
   try {
     await fs.unlink(markerPath);
   } catch {
@@ -200,16 +200,16 @@ async function clearEndIterationMarker(rootDir: string): Promise<void> {
 }
 
 /**
- * Clear stale end-iteration markers (older than 1 hour).
- * AC: @ralph-end-iteration ac-cleanup
+ * Clear stale end-loop markers (older than 1 hour).
+ * AC: @ralph-end-loop ac-cleanup
  */
-async function clearStaleEndIterationMarker(rootDir: string): Promise<boolean> {
-  const marker = await readEndIterationMarker(rootDir);
+async function clearStaleEndLoopMarker(rootDir: string): Promise<boolean> {
+  const marker = await readEndLoopMarker(rootDir);
   if (!marker) return false;
 
   const markerAge = Date.now() - new Date(marker.timestamp).getTime();
   if (markerAge > STALE_MARKER_THRESHOLD_MS) {
-    await clearEndIterationMarker(rootDir);
+    await clearEndLoopMarker(rootDir);
     return true;
   }
   return false;
@@ -226,12 +226,12 @@ function detectTaskCompleteCommand(command: string): boolean {
 }
 
 /**
- * Detect if a Bash command is an end-iteration command.
- * AC: @ralph-end-iteration ac-detect
+ * Detect if a Bash command is an end-loop command.
+ * AC: @ralph-end-loop ac-detect
  */
-function detectEndIterationCommand(command: string): boolean {
-  // Match "kspec ralph end-iteration" with any arguments
-  return /\bkspec\s+ralph\s+end-iteration\b/.test(command);
+function detectEndLoopCommand(command: string): boolean {
+  // Match "kspec ralph end-loop" with any arguments
+  return /\bkspec\s+ralph\s+end-loop\b/.test(command);
 }
 
 /**
@@ -853,39 +853,39 @@ export function registerRalphCommand(program: Command): void {
     .command("ralph")
     .description("Ralph automated task loop and agent control");
 
-  // end-iteration subcommand - allows agent to signal loop end
-  // AC: @ralph-end-iteration ac-cmd, ac-reason, ac-noop-outside
+  // end-loop subcommand - allows agent to signal loop termination
+  // AC: @ralph-end-loop ac-cmd, ac-reason, ac-noop-outside
   ralph
-    .command("end-iteration")
-    .description("Signal ralph to end the current iteration gracefully")
-    .option("--reason <reason>", "Reason for ending the iteration")
+    .command("end-loop")
+    .description("End the ralph loop gracefully (stops all remaining iterations)")
+    .option("--reason <reason>", "Reason for ending the loop")
     .action(async (options) => {
       try {
         const ctx = await initContext();
 
         // Check if we're in a ralph session by looking for any ralph marker
         const taskLimitMarker = await readTaskLimitMarker(ctx.rootDir);
-        const endIterationMarker = await readEndIterationMarker(ctx.rootDir);
+        const endLoopMarker = await readEndLoopMarker(ctx.rootDir);
 
         // Write the marker with reason if provided
-        await writeEndIterationMarker(ctx.rootDir, options.reason);
+        await writeEndLoopMarker(ctx.rootDir, options.reason);
 
         // Determine if we're likely in a ralph session
-        const inRalphSession = taskLimitMarker !== null || endIterationMarker !== null;
+        const inRalphSession = taskLimitMarker !== null || endLoopMarker !== null;
 
         if (!inRalphSession) {
-          // AC: @ralph-end-iteration ac-noop-outside
+          // AC: @ralph-end-loop ac-noop-outside
           warn("No active ralph session detected. Marker written but may have no effect.");
           info("This command is designed to be called by agents during a ralph loop.");
         } else {
-          success("End-iteration signal sent");
+          success("Loop end signal sent");
         }
 
         if (options.reason) {
           info(`Reason: ${options.reason}`);
         }
       } catch (err) {
-        error("Failed to signal end-iteration", err);
+        error("Failed to signal end-loop", err);
         process.exit(EXIT_CODES.ERROR);
       }
     });
@@ -894,6 +894,7 @@ export function registerRalphCommand(program: Command): void {
   ralph
     .command("run", { isDefault: true })
     .description("Run ACP agent in a loop to process ready tasks")
+    .argument("[args...]", "")
     .option("--max-loops <n>", "Maximum iterations", "5")
     .option("--max-retries <n>", "Max retries per iteration on error", "3")
     .option(
@@ -920,7 +921,24 @@ export function registerRalphCommand(program: Command): void {
       "Max tasks per iteration (0 = unlimited)",
       "1",
     )
-    .action(async (options) => {
+    .action(async (args: string[], options) => {
+      // Check for unknown subcommands that fell through to default
+      // Only check args that look like subcommand names (alphanumeric with hyphens, no quotes)
+      if (args.length > 0) {
+        const unknownCmd = args[0];
+        // Skip if it looks like a malformed option or quoted argument
+        const looksLikeSubcommand = /^[a-z][a-z0-9-]*$/i.test(unknownCmd);
+        if (looksLikeSubcommand) {
+          if (unknownCmd === "end-iteration") {
+            error(`Unknown command: ${unknownCmd}. Did you mean 'end-loop'?`);
+            info("The command was renamed from 'end-iteration' to 'end-loop' to clarify it ends the entire loop.");
+          } else {
+            error(`Unknown command: ${unknownCmd}`);
+          }
+          info("Run 'kspec ralph --help' to see available commands.");
+          process.exit(EXIT_CODES.USAGE_ERROR);
+        }
+      }
       try {
         const maxLoops = parseInt(options.maxLoops, 10);
         const maxRetries = parseInt(options.maxRetries, 10);
@@ -1033,7 +1051,7 @@ export function registerRalphCommand(program: Command): void {
         let agent: SpawnedAgent | null = null;
         let acpSessionId: string | null = null;
 
-        // AC: @ralph-end-iteration ac-signal-cleanup, @ralph-task-limit ac-signal-cleanup
+        // AC: @ralph-end-loop ac-signal-cleanup, @ralph-task-limit ac-signal-cleanup
         // Signal handlers for cleanup on Ctrl+C or kill
         // Note: Signal handlers must be synchronous, so we use Promise.finally()
         // to ensure cleanup completes before exit
@@ -1046,7 +1064,7 @@ export function registerRalphCommand(program: Command): void {
           // Clean up marker files, then exit after cleanup completes
           Promise.all([
             clearTaskLimitMarker(ctx.rootDir),
-            clearEndIterationMarker(ctx.rootDir),
+            clearEndLoopMarker(ctx.rootDir),
           ]).finally(() => {
             process.exit(0);
           });
@@ -1065,9 +1083,9 @@ export function registerRalphCommand(program: Command): void {
         let taskLimitReached = false;
         let tasksCompletedThisIteration = 0;
 
-        // End-iteration signal state
-        // AC: @ralph-end-iteration ac-detect, ac-graceful
-        let endIterationRequested = false;
+        // End-loop signal state
+        // AC: @ralph-end-loop ac-detect, ac-graceful
+        let endLoopRequested = false;
 
         try {
           for (let iteration = 1; iteration <= maxLoops; iteration++) {
@@ -1083,13 +1101,13 @@ export function registerRalphCommand(program: Command): void {
             // Also clear any marker from previous iteration of this session
             await clearTaskLimitMarker(ctx.rootDir);
 
-            // AC: @ralph-end-iteration ac-cleanup - Reset end-iteration state
-            endIterationRequested = false;
-            const wasStaleEndIteration = await clearStaleEndIterationMarker(ctx.rootDir);
-            if (wasStaleEndIteration) {
-              info("Cleared stale end-iteration marker from previous session");
+            // AC: @ralph-end-loop ac-cleanup - Reset end-loop state
+            endLoopRequested = false;
+            const wasStaleEndLoop = await clearStaleEndLoopMarker(ctx.rootDir);
+            if (wasStaleEndLoop) {
+              info("Cleared stale end-loop marker from previous session");
             }
-            await clearEndIterationMarker(ctx.rootDir);
+            await clearEndLoopMarker(ctx.rootDir);
 
             // Gather fresh context each iteration (only automation-eligible tasks)
             // AC: @cli-ralph ac-16
@@ -1272,22 +1290,22 @@ export function registerRalphCommand(program: Command): void {
                         }
                       }
 
-                      // AC: @ralph-end-iteration ac-detect
-                      // Detect explicit end-iteration command
-                      if (!endIterationRequested) {
+                      // AC: @ralph-end-loop ac-detect
+                      // Detect explicit end-loop command
+                      if (!endLoopRequested) {
                         const bashCmd = extractBashCommand(update);
-                        if (bashCmd && detectEndIterationCommand(bashCmd)) {
-                          endIterationRequested = true;
+                        if (bashCmd && detectEndLoopCommand(bashCmd)) {
+                          endLoopRequested = true;
                           // Read marker to get reason if present
-                          readEndIterationMarker(ctx.rootDir)
+                          readEndLoopMarker(ctx.rootDir)
                             .then((marker) => {
                               const reason = marker?.reason
                                 ? ` (${marker.reason})`
                                 : "";
-                              info(`End-iteration signal received${reason}`);
+                              info(`End-loop signal received${reason}`);
                             })
                             .catch(() => {
-                              info("End-iteration signal received");
+                              info("End-loop signal received");
                             });
                         }
                       }
@@ -1418,8 +1436,8 @@ export function registerRalphCommand(program: Command): void {
               success(`Completed iteration ${iteration}`);
               consecutiveFailures = 0;
 
-              // AC: @ralph-end-iteration ac-graceful - Check for end-iteration signal
-              if (endIterationRequested) {
+              // AC: @ralph-end-loop ac-graceful - Check for end-loop signal
+              if (endLoopRequested) {
                 info("Agent requested end of loop. Exiting gracefully.");
                 break;
               }
@@ -1484,8 +1502,8 @@ export function registerRalphCommand(program: Command): void {
           // AC: @ralph-task-limit ac-reset - Clear marker file when session ends
           await clearTaskLimitMarker(ctx.rootDir);
 
-          // AC: @ralph-end-iteration ac-cleanup - Clear end-iteration marker when session ends
-          await clearEndIterationMarker(ctx.rootDir);
+          // AC: @ralph-end-loop ac-cleanup - Clear end-loop marker when session ends
+          await clearEndLoopMarker(ctx.rootDir);
 
           // Log session end
           const status =

--- a/tests/ralph/end-loop.test.ts
+++ b/tests/ralph/end-loop.test.ts
@@ -1,16 +1,16 @@
 /**
- * Tests for ralph end-iteration command
+ * Tests for ralph end-loop command
  *
- * AC: @ralph-end-iteration ac-cmd, ac-detect, ac-graceful, ac-reason, ac-cleanup, ac-noop-outside
+ * AC: @ralph-end-loop ac-cmd, ac-detect, ac-graceful, ac-reason, ac-cleanup, ac-noop-outside
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import { kspec, setupTempFixtures, cleanupTempDir } from '../helpers/cli';
 
-const END_ITERATION_MARKER_PATH = '.claude/ralph-end-iteration.json';
+const END_LOOP_MARKER_PATH = '.claude/ralph-end-loop.json';
 
-describe('Ralph end-iteration command', () => {
+describe('Ralph end-loop command', () => {
   let tempDir: string;
 
   beforeEach(async () => {
@@ -21,15 +21,15 @@ describe('Ralph end-iteration command', () => {
     await cleanupTempDir(tempDir);
   });
 
-  describe('kspec ralph end-iteration', () => {
-    // AC: @ralph-end-iteration ac-cmd
+  describe('kspec ralph end-loop', () => {
+    // AC: @ralph-end-loop ac-cmd
     it('should write marker file when invoked', async () => {
-      const result = kspec('ralph end-iteration', tempDir);
+      const result = kspec('ralph end-loop', tempDir);
       // Command should succeed even without active ralph session
       expect(result.exitCode).toBe(0);
 
       // Check marker file was created
-      const markerPath = path.join(tempDir, END_ITERATION_MARKER_PATH);
+      const markerPath = path.join(tempDir, END_LOOP_MARKER_PATH);
       const exists = await fs.access(markerPath).then(() => true).catch(() => false);
       expect(exists).toBe(true);
 
@@ -40,28 +40,28 @@ describe('Ralph end-iteration command', () => {
       expect(marker.timestamp).toBeDefined();
     });
 
-    // AC: @ralph-end-iteration ac-reason
+    // AC: @ralph-end-loop ac-reason
     it('should include reason in marker when provided', async () => {
-      const result = kspec('ralph end-iteration --reason "No eligible tasks"', tempDir);
+      const result = kspec('ralph end-loop --reason "No eligible tasks"', tempDir);
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain('Reason: No eligible tasks');
 
-      const markerPath = path.join(tempDir, END_ITERATION_MARKER_PATH);
+      const markerPath = path.join(tempDir, END_LOOP_MARKER_PATH);
       const content = await fs.readFile(markerPath, 'utf-8');
       const marker = JSON.parse(content);
       expect(marker.reason).toBe('No eligible tasks');
     });
 
-    // AC: @ralph-end-iteration ac-noop-outside
+    // AC: @ralph-end-loop ac-noop-outside
     it('should warn when not in ralph session', async () => {
       // No ralph markers exist, so it should warn
-      const result = kspec('ralph end-iteration', tempDir);
+      const result = kspec('ralph end-loop', tempDir);
       expect(result.exitCode).toBe(0);
       // The warning includes this message
       expect(result.stdout).toContain('This command is designed to be called by agents during a ralph loop');
     });
 
-    // AC: @ralph-end-iteration ac-noop-outside
+    // AC: @ralph-end-loop ac-noop-outside
     it('should succeed without warning when task-limit marker exists', async () => {
       // Create a task-limit marker to simulate active ralph session
       const markerDir = path.join(tempDir, '.claude');
@@ -77,33 +77,33 @@ describe('Ralph end-iteration command', () => {
         }),
       );
 
-      const result = kspec('ralph end-iteration', tempDir);
+      const result = kspec('ralph end-loop', tempDir);
       expect(result.exitCode).toBe(0);
-      expect(result.stdout).toContain('End-iteration signal sent');
+      expect(result.stdout).toContain('Loop end signal sent');
       expect(result.stdout).not.toContain('No active ralph session detected');
     });
   });
 
-  describe('End-iteration detection helper', () => {
-    // The detectEndIterationCommand function is internal
+  describe('End-loop detection helper', () => {
+    // The detectEndLoopCommand function is internal
     // These document expected behavior for integration
 
-    it('should match "kspec ralph end-iteration"', () => {
-      // Pattern: /\bkspec\s+ralph\s+end-iteration\b/
-      const pattern = /\bkspec\s+ralph\s+end-iteration\b/;
-      expect(pattern.test('kspec ralph end-iteration')).toBe(true);
+    it('should match "kspec ralph end-loop"', () => {
+      // Pattern: /\bkspec\s+ralph\s+end-loop\b/
+      const pattern = /\bkspec\s+ralph\s+end-loop\b/;
+      expect(pattern.test('kspec ralph end-loop')).toBe(true);
     });
 
     it('should match with --reason flag', () => {
-      const pattern = /\bkspec\s+ralph\s+end-iteration\b/;
-      expect(pattern.test('kspec ralph end-iteration --reason "done"')).toBe(true);
+      const pattern = /\bkspec\s+ralph\s+end-loop\b/;
+      expect(pattern.test('kspec ralph end-loop --reason "done"')).toBe(true);
     });
 
     it('should NOT match partial commands', () => {
-      const pattern = /\bkspec\s+ralph\s+end-iteration\b/;
+      const pattern = /\bkspec\s+ralph\s+end-loop\b/;
       expect(pattern.test('kspec ralph')).toBe(false);
       expect(pattern.test('kspec ralph run')).toBe(false);
-      expect(pattern.test('ralph end-iteration')).toBe(false);
+      expect(pattern.test('ralph end-loop')).toBe(false);
     });
   });
 });
@@ -119,12 +119,12 @@ describe('Marker file cleanup', () => {
     await cleanupTempDir(tempDir);
   });
 
-  // AC: @ralph-end-iteration ac-cleanup
+  // AC: @ralph-end-loop ac-cleanup
   it('should have correct marker file format', async () => {
-    const result = kspec('ralph end-iteration --reason "test reason"', tempDir);
+    const result = kspec('ralph end-loop --reason "test reason"', tempDir);
     expect(result.exitCode).toBe(0);
 
-    const markerPath = path.join(tempDir, END_ITERATION_MARKER_PATH);
+    const markerPath = path.join(tempDir, END_LOOP_MARKER_PATH);
     const content = await fs.readFile(markerPath, 'utf-8');
     const marker = JSON.parse(content);
 
@@ -138,7 +138,7 @@ describe('Marker file cleanup', () => {
 });
 
 describe('Signal cleanup', () => {
-  // AC: @ralph-end-iteration ac-signal-cleanup
+  // AC: @ralph-end-loop ac-signal-cleanup
   // Static analysis to verify signal handlers are registered correctly.
   // Full integration testing would require spawning ralph and sending signals.
 
@@ -154,7 +154,7 @@ describe('Signal cleanup', () => {
 
     // Verify cleanup functions are called in handlers
     expect(ralphContent).toContain('clearTaskLimitMarker');
-    expect(ralphContent).toContain('clearEndIterationMarker');
+    expect(ralphContent).toContain('clearEndLoopMarker');
 
     // Verify cleanup awaits before exit (uses Promise.finally pattern)
     expect(ralphContent).toContain('Promise.all');


### PR DESCRIPTION
## Summary

- Renamed `kspec ralph end-iteration` → `kspec ralph end-loop` to clarify it ends the ENTIRE loop, not just one iteration
- Updated marker file path from `ralph-end-iteration.json` to `ralph-end-loop.json`
- Added unknown subcommand detection - old command now shows helpful migration message
- Updated task-work skill docs with "Turn Completion vs Loop End" section
- Added "Ralph Loop Model" section to AGENTS.md explaining when NOT to call end-loop

## Root Cause

Agent called `kspec ralph end-iteration` after creating a PR, ending the entire loop at iteration 4 of 30, when there were other ready tasks available. The command name was misleading - "end-iteration" sounds like "end this iteration" but actually ends the ENTIRE LOOP.

## Test plan

- [x] `npm test -- tests/ralph/end-loop.test.ts` passes
- [x] `kspec ralph --help` shows `end-loop` command
- [x] `kspec ralph end-loop --reason "test"` works
- [x] `kspec ralph end-iteration` shows helpful error with migration message

Task: @01KGMM4R
Spec: @ralph-end-loop

🤖 Generated with [Claude Code](https://claude.ai/code)