### PR TITLE
fix(ralph): reframe end-loop as rare escape hatch, not normal exit path

### DIFF
--- a/.claude/skills/kspec/SKILL.md
+++ b/.claude/skills/kspec/SKILL.md
@@ -109,7 +109,7 @@ kspec task block @task-slug --reason "Waiting on API spec"
 kspec task unblock @task-slug
 ```
 
-**In loop mode:** Block only for genuine external blockers (human decision needed, spec gap, external dependency). Complexity and difficulty are NOT blockers - push through. Always check `kspec tasks ready --eligible` for other work before ending the loop. See `/task-work` for detailed loop mode guidance.
+**In loop mode:** Block only for genuine external blockers (human decision needed, spec gap, external dependency). Complexity and difficulty are NOT blockers — push through. You MUST verify by running `kspec tasks ready --eligible` before stopping — its output is authoritative. Do not infer task eligibility; the command is the source of truth. See `/task-work` for detailed loop mode guidance.
 
 ### Cancellation
 

--- a/.claude/skills/task-work/SKILL.md
+++ b/.claude/skills/task-work/SKILL.md
@@ -321,12 +321,9 @@ After 3 genuine attempts with different fixes, add a note documenting what you t
 
 ### Exit Conditions
 
-Exit when:
-- **Task work complete** - PR created (normal exit)
-- **No eligible tasks** - `kspec tasks ready --eligible` returns empty
-- **All remaining eligible tasks blocked** - every eligible task has a genuine external blocker
+**Normal exit: Stop responding.** After creating a PR (or blocking a task), simply stop responding. Ralph continues automatically — it checks for remaining eligible tasks at the start of each iteration and exits the loop itself when none remain. You do not need to manage loop termination.
 
-**Important:** "No eligible tasks" means ALL eligible tasks are done or blocked, not just the one you're working on. If one task is blocked, check for others before ending.
+**Important:** "No eligible tasks" means ALL eligible tasks are done or blocked, not just the one you're working on. If one task is blocked, check for others before stopping.
 
 ### Turn Completion vs Loop End
 
@@ -351,8 +348,10 @@ When you hit a genuine blocker on a task, the correct pattern is:
 
 1. **Attempt the work first** - actually try to solve the problem
 2. **Block the specific task** - not the whole loop
-3. **Check for other work** - there may be more eligible tasks
-4. **Continue or end** - only end when nothing remains
+3. **MUST run `kspec tasks ready --eligible`** - its output is authoritative
+4. **If tasks remain: work on the next one.** If empty: stop responding — ralph exits automatically.
+
+**Trust the YAML state.** If a task's `depends_on` is empty, it has no dependencies. If `kspec tasks ready --eligible` lists a task, it IS eligible and ready to work on. Do not invent blocking relationships based on perceived connections between tasks, PRs in CI, or other inferred state. The command output is the source of truth.
 
 | Situation | Action | Correct Response |
 |-----------|--------|------------------|
@@ -362,7 +361,7 @@ When you hit a genuine blocker on a task, the correct pattern is:
 | Task is complex/difficult | **DO THE WORK** | Complexity is not a blocker |
 | Tests are failing | **FIX THEM** | Debug and resolve |
 | Service needs to be running | **START IT** | See "Tasks Requiring Services" |
-| No more eligible tasks exist | `end-loop` | Only valid end condition |
+| No more eligible tasks exist | Stop responding | Ralph auto-exits when no tasks remain |
 
 ```bash
 # Pattern: When you hit a genuine blocker mid-task
@@ -370,29 +369,32 @@ kspec task note @task "Attempted X, Y, Z. Blocked because: [external reason]"
 kspec task block @task --reason "Requires architectural decision on X"
 kspec task set @task --automation needs_review
 
-# Check for other work before ending
+# MUST check for other work — command output is authoritative
 kspec tasks ready --eligible
 # If tasks exist: pick one and continue
-# If empty: then end-loop is appropriate
+# If empty: stop responding — ralph exits the loop automatically
 ```
 
-### Explicit Loop End Signal
+### Explicit Loop End Signal (Rare Escape Hatch)
 
-Use `end-loop` **only** when no more work is possible:
+Ralph automatically exits the loop when no eligible tasks remain — you do not need to signal this. In almost all cases, simply stop responding and let ralph manage loop termination.
+
+`end-loop` exists only for situations where work is stalling across multiple iterations with no productive progress — something ralph's automatic task checks cannot detect. If you are uncertain whether to end, **default to stopping** rather than calling `end-loop`.
 
 ```bash
-kspec ralph end-loop --reason "No eligible tasks remaining"
+# Only if work is genuinely stalling across iterations
+kspec ralph end-loop --reason "No progress across N iterations: [description]"
 ```
 
-**Valid reasons to end:**
-- `kspec tasks ready --eligible` returns empty
-- All remaining eligible tasks are blocked (and you checked)
+**Before calling `end-loop`, you MUST:**
+1. Run `kspec tasks ready --eligible` and confirm it returns empty
+2. Verify the stall is real, not just one difficult task
 
-**Invalid reasons to end:**
-- "This task is hard" → do it anyway
-- "This task needs external decision" → block it and check for other tasks
-- "I've done enough" → check for more eligible tasks first
-- "I just created a PR" → ralph continues automatically, don't call end-loop
+**Do NOT call `end-loop`:**
+- After creating a PR → ralph continues automatically
+- When one task is blocked → block it and check for others
+- When a task is hard → do the work
+- When `kspec tasks ready --eligible` still shows tasks → work on them
 
 ### What Is NOT an Exit Condition
 
@@ -407,7 +409,7 @@ These are NOT reasons to exit, block, or mark needs_review:
 
 ### Key Behaviors
 
-- Only `automation: eligible` tasks are considered
+- Only `automation: eligible` tasks are considered. Automation eligibility is determined solely by the `automation` field, not by task type, title, or description. If a task is marked `eligible`, work on it — do not re-triage based on whether it looks like a "design task" or any other category.
 - Verification still performed (prevent duplicate work)
 - Decisions auto-resolve without prompts
 - PR review handled externally by ralph (not this workflow)

--- a/.claude/skills/triage/docs/automation.md
+++ b/.claude/skills/triage/docs/automation.md
@@ -17,6 +17,8 @@ A task is ready for automation when:
 
 **Having spec + ACs is necessary but not sufficient** - you must also verify the spec is appropriate and ACs are adequate for the task.
 
+**Task type does not determine automation eligibility.** Any non-spike task can be `automation: eligible` — including design tasks, refactoring tasks, documentation tasks, etc. The `automation` field is the definitive source. Once a task is marked `eligible`, do not second-guess it based on type, title, or description.
+
 ## Workflow
 
 ### 1. Get Assessment Overview

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -254,34 +254,41 @@ pending → in_progress → pending_review → completed
 
 When running in automated loop mode (ralph), understanding when to block vs continue is critical.
 
+**Key principle:** One blocked task is NOT "no more work." You MUST run `kspec tasks ready --eligible` and act on its output — it is authoritative.
+
 **The pattern:**
 1. **Attempt the work** - actually try to solve the problem first
 2. **Hit a genuine blocker** - external dependency, needs human decision, spec gap
 3. **Block the task** - with documented reason and what you tried
-4. **Check for other work** - `kspec tasks ready --eligible`
-5. **Continue or end** - only end when ALL eligible tasks are blocked/done
+4. **MUST run `kspec tasks ready --eligible`** - command output is authoritative
+5. **If tasks remain: work on the next one.** If empty: stop responding — ralph exits automatically.
+
+**Trust the YAML state.** Only formal dependencies (`depends_on` field) constitute task-level blocking. If `depends_on` is empty, the task has no dependencies. If `kspec tasks ready --eligible` lists a task, it IS ready. Do not invent blocking relationships based on perceived connections between tasks, PRs in CI, or other inferred state.
 
 **Valid blocking reasons** (external blockers):
 - Requires human architectural decision
 - Needs spec clarification
 - Depends on external API/service not available
-- Blocked by another task
+- Formally blocked by another task (listed in `depends_on`)
 
 **Invalid blocking reasons** (do the work):
 - Task seems complex
 - Tests are failing (fix them)
 - Service needs running (start it)
 - Might take multiple iterations
+- Another task's PR is in CI (not a formal dependency)
 
 ```bash
 # When you hit a genuine blocker after attempting work
 kspec task note @task "Attempted: X, Y, Z. Blocked because: [external reason]"
 kspec task block @task --reason "Requires architectural decision on X"
 kspec task set @task --automation needs_review
-kspec tasks ready --eligible  # Check for other work
-```
 
-**Key principle:** One blocked task is NOT "no more work." Check for other eligible tasks before ending the loop. See `/task-work` skill for detailed loop mode guidance.
+# MUST check for other work — command output is authoritative
+kspec tasks ready --eligible
+# If tasks exist: pick one and continue
+# If empty: stop responding — ralph exits the loop automatically
+```
 
 ### Ralph Loop Model
 
@@ -289,23 +296,25 @@ Ralph operates in a prompt-response loop:
 
 ```
 for each iteration (1..maxLoops):
-  1. Ralph sends task-work prompt
-  2. Agent works on tasks, may create PR(s)
-  3. Agent stops responding (turn complete)
-  4. Ralph sends reflection prompt
-  5. Agent captures learnings, stops responding
-  6. Ralph processes pending_review tasks via subagent
-  7. If no end-loop signal: continue to next iteration
+  1. Ralph checks for eligible tasks — if none remain, exits loop
+  2. Ralph sends task-work prompt
+  3. Agent works on tasks, may create PR(s)
+  4. Agent stops responding (turn complete)
+  5. Ralph sends reflection prompt
+  6. Agent captures learnings, stops responding
+  7. Ralph processes pending_review tasks via subagent
+  8. Continue to next iteration (back to step 1)
 ```
 
 **Key insight:** When you stop responding, ralph continues automatically.
-The loop only ends when:
+The loop ends when (in order of how common):
+- **Ralph's automatic check finds no eligible tasks** (primary mechanism — handles most cases)
 - Max iterations reached
-- Agent explicitly calls `kspec ralph end-loop`
 - Max consecutive failures reached
+- Agent calls `kspec ralph end-loop` (rare escape hatch — only for stalled work across iterations)
 
 **Do NOT call `end-loop` after creating a PR.** Simply stop responding.
-Ralph will continue to the next phase/iteration.
+Ralph will check for remaining work and either continue or exit on its own.
 
 ### Notes (Work Log)
 

--- a/src/cli/commands/ralph.ts
+++ b/src/cli/commands/ralph.ts
@@ -325,7 +325,11 @@ Run the task-work skill in loop mode:
 
 Loop mode means: no confirmations, auto-resolve decisions, automation-eligible tasks only.
 
-Exit when task work is complete or no eligible tasks remain.
+**Normal flow:** Work on a task, create a PR, then stop responding. Ralph continues automatically —
+it checks for remaining eligible tasks at the start of each iteration and exits the loop itself when none remain.
+
+**Do NOT call \`end-loop\` after completing a task.** Simply stop responding.
+\`end-loop\` is a rare escape hatch for when work is stalling across multiple iterations with no progress — not a normal exit path.
 `;
 }
 


### PR DESCRIPTION
## Summary

- Reframe `end-loop` from a normal workflow step to a rare escape hatch across all agent-facing surfaces
- Establish that ralph automatically exits the loop when no eligible tasks remain — agents should just stop responding
- Add "Trust the YAML state" principle: `depends_on` and `automation` fields are authoritative, not agent reasoning
- Clarify that task type does not determine automation eligibility — only the `automation` field matters

## Context

An agent prematurely ended a ralph loop because it:
1. Assumed a task had an informal dependency (PR in CI) when `depends_on: []` was empty
2. Assumed a "design task" wasn't automation-eligible when it was marked `automation: eligible`
3. Called `end-loop` instead of stopping — ralph already exits automatically when no eligible tasks remain

## Files Changed

| File | Change |
|------|--------|
| `src/cli/commands/ralph.ts` | Injected prompt: stop responding is normal, end-loop is rare |
| `.claude/skills/task-work/SKILL.md` | Exit conditions, blocking, loop end signal, key behaviors |
| `AGENTS.md` | Task Blocking and Ralph Loop Model sections |
| `.kspec/kynetic.meta.yaml` | Verification gate in workflow decision step |
| `.claude/skills/triage/docs/automation.md` | Task type vs automation eligibility |
| `.claude/skills/kspec/SKILL.md` | Mandatory verification language |

## Test plan

- [x] `npm run build` passes (ralph.ts compiles)
- [x] `npm test` passes (82/83, 1 pre-existing bun compile failure)
- [x] `kspec validate` schema OK (reference/alignment warnings pre-existing)
- [ ] Manual review: read injected prompt and skill docs as an agent would

🤖 Generated with [Claude Code](https://claude.ai/code)