### PR TITLE
fix(ralph): remove doubled [REVIEW SUBAGENT] prefix in subagent output

### DIFF
--- a/src/ralph/cli-renderer.ts
+++ b/src/ralph/cli-renderer.ts
@@ -290,9 +290,10 @@ export function createPrefixedRenderer(prefix: string): RalphRenderer {
     const originalLog = console.log;
     const originalWrite = process.stdout.write;
 
-    // Wrap console.log to add prefix
+    // Wrap console.log - prefix is handled by stdout.write wrapper below,
+    // so we just delegate to the original and mark line start.
     console.log = (...args: unknown[]) => {
-      originalLog(prefixStr, ...args);
+      originalLog(...args);
       state.atLineStart = true;
     };
 
@@ -340,7 +341,7 @@ export function createPrefixedRenderer(prefix: string): RalphRenderer {
     },
     newSection(label) {
       state.atLineStart = true;
-      withPrefixedOutput(() => inner.newSection?.(`${prefix} ${label}`));
+      withPrefixedOutput(() => inner.newSection?.(label));
     },
   };
 }

--- a/tests/ralph.test.ts
+++ b/tests/ralph.test.ts
@@ -940,13 +940,71 @@ describe('subagent module', () => {
 
   // AC: @ralph-subagent-spawning ac-11
   describe('createPrefixedRenderer', () => {
-    it('creates renderer with prefix in newSection', () => {
+    it('does not double prefix for console.log output', () => {
       const renderer = createPrefixedRenderer('[TEST]');
 
-      expect(renderer.newSection).toBeDefined();
-      // newSection should include the prefix - we can't easily test console output
-      // but we verify the function exists and can be called
-      expect(typeof renderer.newSection).toBe('function');
+      // Spy on console.log to capture what the wrapper passes to the original
+      const logCalls: unknown[][] = [];
+      const spy = vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+        logCalls.push(args);
+      });
+
+      try {
+        renderer.newSection?.('My Section');
+      } finally {
+        spy.mockRestore();
+      }
+
+      // The wrapper should NOT pass the prefix as an extra argument to console.log.
+      // The stdout.write wrapper handles prefixing, so console.log should receive
+      // only the original arguments (no doubled prefix).
+      const allArgs = logCalls.map(args => args.map(String).join(' ')).join('\n');
+      expect(allArgs).toContain('My Section');
+
+      // Count prefix occurrences per line - should never appear doubled
+      for (const call of logCalls) {
+        const line = call.map(String).join(' ');
+        const prefixCount = (line.match(/\[TEST\]/g) || []).length;
+        expect(prefixCount, `Line has doubled prefix: ${line}`).toBeLessThanOrEqual(1);
+      }
+    });
+
+    it('does not double prefix for streaming content via stdout.write', () => {
+      const renderer = createPrefixedRenderer('[TEST]');
+
+      // Capture process.stdout.write output - this IS used by streaming render events
+      const chunks: string[] = [];
+      const originalWrite = process.stdout.write;
+      process.stdout.write = ((chunk: unknown) => {
+        if (typeof chunk === 'string') chunks.push(chunk);
+        return true;
+      }) as typeof process.stdout.write;
+
+      // Also suppress console.log (vitest intercepts it differently)
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      try {
+        // Render a streaming agent_message event which goes through stdout.write
+        renderer.render({
+          timestamp: 0,
+          data: {
+            kind: 'agent_message',
+            content: 'Hello World\n',
+            isStreaming: true,
+          },
+        });
+      } finally {
+        process.stdout.write = originalWrite;
+        logSpy.mockRestore();
+      }
+
+      const output = chunks.join('');
+      expect(output).toContain('Hello World');
+      // Prefix should appear at most once per line
+      for (const line of output.split('\n')) {
+        const prefixCount = (line.match(/\[TEST\]/g) || []).length;
+        expect(prefixCount, `Line has doubled prefix: ${line}`).toBeLessThanOrEqual(1);
+      }
     });
 
     it('creates renderer with render function', () => {


### PR DESCRIPTION
## Summary

- Fixed doubled `[REVIEW SUBAGENT]` prefix in ralph loop review subagent output
- Root cause: `createPrefixedRenderer` applied the prefix twice — once in the `console.log` wrapper and again in the `process.stdout.write` wrapper (since console.log flows through stdout.write)
- Additionally, `newSection()` manually prepended the prefix to the label before passing it through the wrappers
- Fix: let `process.stdout.write` be the single source of prefix injection

## Test plan

- [x] Added test verifying no double-prefix for `console.log` output path
- [x] Added test verifying no double-prefix for `process.stdout.write` streaming path
- [x] All 52 ralph tests pass
- [x] Full test suite passes (3 pre-existing failures unrelated to change)

Task: @01KGP2PP

Generated with [Claude Code](https://claude.ai/code)