### PR TITLE
feat: implement plan import and CLI schema introspection

### DIFF
--- a/src/cli/commands/help.ts
+++ b/src/cli/commands/help.ts
@@ -2,7 +2,7 @@
 
 import chalk from "chalk";
 import type { Command } from "commander";
-import { EXIT_CODES } from "../exit-codes.js";
+import { EXIT_CODES, EXIT_CODE_METADATA } from "../exit-codes.js";
 import { type HelpContent, helpContent } from "../help/content.js";
 import { program } from "../index.js";
 import {
@@ -12,7 +12,7 @@ import {
   flattenCommandTree,
   formatCommandUsage,
 } from "../introspection.js";
-import { output } from "../output.js";
+import { output, setJsonMode, isJsonMode } from "../output.js";
 
 /**
  * Show help for a specific topic (command or concept)
@@ -223,6 +223,123 @@ function showJson(): void {
 }
 
 /**
+ * Show exit codes documentation
+ * AC: @cli-schema-introspection ac-2
+ */
+function showExitCodes(): void {
+  console.log(chalk.bold.cyan("kspec - Exit Codes"));
+  console.log(chalk.gray("─".repeat(60)));
+  console.log("\nExit codes returned by kspec commands:\n");
+
+  for (const exitCode of EXIT_CODE_METADATA) {
+    console.log(chalk.bold(`${exitCode.code} - ${exitCode.name}`));
+    console.log(`  ${exitCode.description}`);
+    console.log(chalk.gray(`  Commands: ${exitCode.commands}`));
+    console.log();
+  }
+}
+
+/**
+ * Output exit codes as JSON
+ * AC: @cli-schema-introspection ac-3
+ */
+function showExitCodesJson(): void {
+  const exitCodesData = EXIT_CODE_METADATA.map((ec) => ({
+    code: ec.code,
+    name: ec.name,
+    description: ec.description,
+    commands: ec.commands,
+  }));
+
+  output(exitCodesData);
+}
+
+/**
+ * Generate JSON Schema for a command
+ * AC: @cli-schema-introspection ac-4
+ */
+function showCommandJsonSchema(topic: string): void {
+  const tree = extractCommandTree(program);
+  const command = findCommand(tree, topic.split(" "));
+
+  if (!command) {
+    console.error(chalk.red(`Unknown command: ${topic}`));
+    process.exit(EXIT_CODES.NOT_FOUND);
+  }
+
+  // Build JSON Schema object
+  const schema: Record<string, unknown> = {
+    $schema: "http://json-schema.org/draft-07/schema#",
+    type: "object",
+    title: `${command.name} command options`,
+    description: command.description,
+    properties: {},
+    required: [],
+  };
+
+  const properties: Record<string, unknown> = {};
+  const required: string[] = [];
+
+  // Add arguments as properties
+  for (const arg of command.arguments) {
+    const propName = arg.name;
+    properties[propName] = {
+      type: arg.variadic ? "array" : "string",
+      description: arg.description,
+    };
+
+    if (arg.variadic) {
+      (properties[propName] as Record<string, unknown>).items = {
+        type: "string",
+      };
+    }
+
+    if (arg.required) {
+      required.push(propName);
+    }
+  }
+
+  // Add options as properties
+  for (const opt of command.options) {
+    // Extract option name from flags (e.g., "-f, --force" -> "force")
+    const flagMatch = opt.flags.match(/--([a-zA-Z0-9-]+)/);
+    if (!flagMatch) continue;
+
+    const propName = flagMatch[1];
+
+    // Determine type from flags
+    let type: string = "boolean";
+    if (opt.flags.includes("<")) {
+      type = "string";
+    } else if (opt.flags.includes("[")) {
+      type = "string";
+    }
+
+    const propSchema: Record<string, unknown> = {
+      type,
+      description: opt.description,
+    };
+
+    if (opt.defaultValue !== undefined) {
+      propSchema.default = opt.defaultValue;
+    }
+
+    properties[propName] = propSchema;
+
+    if (opt.required) {
+      required.push(propName);
+    }
+  }
+
+  schema.properties = properties;
+  if (required.length > 0) {
+    schema.required = required;
+  }
+
+  output(schema);
+}
+
+/**
  * Register the help command
  */
 export function registerHelpCommand(program: Command): void {
@@ -231,9 +348,46 @@ export function registerHelpCommand(program: Command): void {
     .description("Extended help for commands and concepts")
     .option("--all", "Show full command reference")
     .option("--json", "Output as JSON")
-    .action((topic?: string, options?: { all?: boolean; json?: boolean }) => {
-      // Handle flags
-      if (options?.json) {
+    .option("--exit-codes", "Show exit code documentation")
+    .option("--json-schema", "Output JSON Schema for command (use with topic)")
+    .action((
+      topic: string | undefined,
+      options: {
+        all?: boolean;
+        json?: boolean;
+        exitCodes?: boolean;
+        jsonSchema?: boolean;
+      },
+    ) => {
+      // Handle exit codes flag
+      if (options?.exitCodes) {
+        // AC: @cli-schema-introspection ac-2, ac-3
+        // Note: globalJsonMode is already set by preAction hook if --json flag present
+        if (isJsonMode()) {
+          showExitCodesJson();
+        } else {
+          showExitCodes();
+        }
+        return;
+      }
+
+      // Handle JSON schema flag
+      if (options?.jsonSchema) {
+        if (!topic) {
+          console.error(
+            chalk.red("Error: --json-schema requires a command topic"),
+          );
+          process.exit(EXIT_CODES.USAGE_ERROR);
+        }
+        // AC: @cli-schema-introspection ac-4
+        setJsonMode(true);
+        showCommandJsonSchema(topic);
+        return;
+      }
+
+      // AC: @cli-schema-introspection ac-1, ac-5
+      // If --json flag is present (globalJsonMode set by preAction hook), show JSON
+      if (isJsonMode()) {
         showJson();
         return;
       }

--- a/tests/help.test.ts
+++ b/tests/help.test.ts
@@ -1,4 +1,5 @@
 // AC: @auto-cli-docs ac-1, ac-2, ac-3, ac-4, ac-5
+// AC: @cli-schema-introspection ac-1, ac-2, ac-3, ac-4, ac-5
 import { describe, it, expect } from 'vitest';
 import { Command } from 'commander';
 import {
@@ -7,6 +8,7 @@ import {
   flattenCommandTree,
   formatCommandUsage,
 } from '../src/cli/introspection.js';
+import { kspec, kspecJson, setupTempFixtures, cleanupTempDir } from './helpers/cli.js';
 
 describe('extractCommandTree', () => {
   it('should extract basic command metadata', () => {
@@ -218,5 +220,81 @@ describe('help command integration', () => {
     const updatedTree = extractCommandTree(program);
     expect(updatedTree.subcommands).toHaveLength(3);
     expect(updatedTree.subcommands.map((c) => c.name)).toContain('delete');
+  });
+});
+
+describe('CLI schema introspection', () => {
+  // AC: @cli-schema-introspection ac-1
+  it('should output help as JSON with commands and content', async () => {
+    const tempDir = await setupTempFixtures();
+    const result = kspecJson<{ commands: unknown; content: unknown }>('help', tempDir);
+    expect(result).toHaveProperty('commands');
+    expect(result).toHaveProperty('content');
+    expect(typeof result.commands).toBe('object');
+    expect(typeof result.content).toBe('object');
+    await cleanupTempDir(tempDir);
+  });
+
+  // AC: @cli-schema-introspection ac-2
+  it('should show exit codes in human-readable format', async () => {
+    const tempDir = await setupTempFixtures();
+    const result = kspec('help --exit-codes', tempDir);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('Exit Codes');
+    expect(result.stdout).toContain('SUCCESS');
+    expect(result.stdout).toContain('ERROR');
+    expect(result.stdout).toContain('USAGE_ERROR');
+    expect(result.stdout).toContain('NOT_FOUND');
+    expect(result.stdout).toContain('VALIDATION_FAILED');
+    expect(result.stdout).toContain('CONFLICT');
+    await cleanupTempDir(tempDir);
+  });
+
+  // AC: @cli-schema-introspection ac-3
+  it('should output exit codes as JSON', async () => {
+    const tempDir = await setupTempFixtures();
+    const result = kspecJson<Array<{ code: number; name: string; description: string; commands: string }>>(
+      'help --exit-codes',
+      tempDir
+    );
+    expect(Array.isArray(result)).toBe(true);
+    expect(result.length).toBeGreaterThan(0);
+
+    const successCode = result.find((ec) => ec.name === 'SUCCESS');
+    expect(successCode).toBeDefined();
+    expect(successCode?.code).toBe(0);
+    expect(successCode?.description).toContain('success');
+    await cleanupTempDir(tempDir);
+  });
+
+  // AC: @cli-schema-introspection ac-4
+  it('should output JSON Schema for a command', async () => {
+    const tempDir = await setupTempFixtures();
+    const result = kspecJson<{
+      $schema: string;
+      type: string;
+      title: string;
+      properties: Record<string, unknown>;
+    }>('help task --json-schema', tempDir);
+
+    expect(result.$schema).toContain('json-schema.org');
+    expect(result.type).toBe('object');
+    expect(result).toHaveProperty('properties');
+    expect(typeof result.properties).toBe('object');
+    await cleanupTempDir(tempDir);
+  });
+
+  // AC: @cli-schema-introspection ac-5
+  it('should produce valid JSON without ANSI codes when --json is used', async () => {
+    const tempDir = await setupTempFixtures();
+    const result = kspec('help --json', tempDir);
+    expect(result.exitCode).toBe(0);
+
+    // Should be valid JSON
+    expect(() => JSON.parse(result.stdout)).not.toThrow();
+
+    // Should not contain ANSI escape codes
+    expect(result.stdout).not.toMatch(/\x1b\[/);
+    await cleanupTempDir(tempDir);
   });
 });


### PR DESCRIPTION
## Summary

This PR includes two feature implementations:

### 1. Plan Import Command (`plan import`)
- Parses plan markdown documents with YAML front matter
- Auto-generates spec items and tasks from structured plans
- Handles parent-child relationships via topological sorting
- Supports dry-run mode and module targeting
- Stores plan records with bidirectional linking

### 2. CLI Schema Introspection
- `kspec help --json` - outputs command tree and help content as JSON
- `kspec help --exit-codes` - displays all exit codes with descriptions
- `kspec help --exit-codes --json` - outputs exit codes as JSON array  
- `kspec help <command> --json-schema` - generates JSON Schema for command options

## Test Plan

- [x] All existing tests pass (1708 passed, 5 pre-existing failures unrelated to changes)
- [x] Plan import: 18/19 tests passing (Commander --json parsing issue remains)
- [x] Plan document parser: 23 tests passing
- [x] Schema introspection: 5 new E2E tests, all passing
- [x] Total: 22 tests in help.test.ts, all passing

## Changes

**New files:**
- `src/cli/commands/plan-import.ts` - plan import command implementation
- `tests/cli-plan-import.test.ts` - comprehensive E2E tests

**Modified files:**
- `src/cli/commands/help.ts` - added schema introspection features
- `src/cli/commands/plan.ts` - integrated plan import command
- `tests/help.test.ts` - added 5 introspection tests

Task: @01KGKSTH (plan import)
Task: @01KGGXA8 (schema introspection)
Spec: @plan-import
Spec: @cli-schema-introspection

🤖 Generated with [Claude Code](https://claude.ai/claude-code)