### PR TITLE
fix(docs): add missing rejected status to plan lifecycle

### DIFF
--- a/.claude/skills/spec-plan/SKILL.md
+++ b/.claude/skills/spec-plan/SKILL.md
@@ -138,7 +138,7 @@ See `/spec` for full trait reference.
 
 ## Plan Lifecycle
 
-Plans track status: `draft` -> `approved` -> `active` -> `completed`
+Plans track status: `draft` -> `approved` -> `active` -> `completed` (or `rejected` from any non-terminal state)
 
 - **Import** auto-creates plan as `active` (specs being created)
 - **Manual** creates plan as `approved` (you're committing to the work)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -573,7 +573,7 @@ kspec plan note @plan-ref "Progress..."  # add note
 kspec plan derive @plan-ref              # create task from plan
 ```
 
-**Plan lifecycle:** `draft` → `approved` → `active` → `completed`
+**Plan lifecycle:** `draft` → `approved` → `active` → `completed` (or `rejected` from any non-terminal state)
 
 **Import path** parses structured markdown with `## Specs` (YAML array), `## Tasks` (`derive_from_specs: true` + optional manual tasks), and `## Implementation Notes`. See `/spec-plan` for full format reference.
 


### PR DESCRIPTION
## Summary

- Add `rejected` status to plan lifecycle documentation in both AGENTS.md and SKILL.md
- The plan schema defines five statuses (`draft`, `approved`, `active`, `completed`, `rejected`) but docs only showed four

Addresses review comment from PR #316.

## Test plan

- [x] Documentation-only change

Generated with [Claude Code](https://claude.ai/code)