### PR TITLE
fix(daemon): eliminate all explicit `any` types for strict mode compliance

### DIFF
--- a/packages/daemon/src/middleware/project-context.ts
+++ b/packages/daemon/src/middleware/project-context.ts
@@ -74,8 +74,8 @@ export function projectContextMiddleware(options: ProjectContextMiddlewareOption
           }
 
           return { projectContext };
-        } catch (err: any) {
-          const message = err.message;
+        } catch (err: unknown) {
+          const message = err instanceof Error ? err.message : String(err);
 
           // AC: @multi-directory-daemon ac-3, ac-20b
           if (

--- a/packages/daemon/src/pid.ts
+++ b/packages/daemon/src/pid.ts
@@ -50,8 +50,8 @@ export class PidFileManager {
       } finally {
         closeSync(fd);
       }
-    } catch (err: any) {
-      if (err.code === 'EEXIST') {
+    } catch (err: unknown) {
+      if (err instanceof Error && 'code' in err && (err as NodeJS.ErrnoException).code === 'EEXIST') {
         // File already exists - check if daemon is actually running
         if (this.isDaemonRunning()) {
           throw new Error('Daemon already running');

--- a/packages/daemon/src/project-context.ts
+++ b/packages/daemon/src/project-context.ts
@@ -105,9 +105,10 @@ export class ProjectContextManager {
       if (context) {
         context.watcherActive = true;
       }
-    } catch (error: any) {
+    } catch (error: unknown) {
       // AC: @multi-directory-daemon ac-19 - Handle OS limits (EMFILE/ENFILE)
-      if (error.code === 'EMFILE' || error.code === 'ENFILE') {
+      const code = error instanceof Error && 'code' in error ? (error as NodeJS.ErrnoException).code : undefined;
+      if (code === 'EMFILE' || code === 'ENFILE') {
         throw new Error('Unable to watch project - resource limit reached');
       }
       throw error;

--- a/packages/daemon/src/routes/projects.ts
+++ b/packages/daemon/src/routes/projects.ts
@@ -80,9 +80,10 @@ export function createProjectsRoutes(options: ProjectsRouteOptions) {
           // Start watcher for the registered project
           try {
             await projectManager.startWatcher(body.path);
-          } catch (error: any) {
+          } catch (error: unknown) {
             // AC: @multi-directory-daemon ac-19 - Handle OS limits
-            if (error.message.includes('resource limit')) {
+            const message = error instanceof Error ? error.message : String(error);
+            if (message.includes('resource limit')) {
               return errorResponse(503, {
                 error: 'Unable to watch project - resource limit reached',
               });
@@ -98,16 +99,19 @@ export function createProjectsRoutes(options: ProjectsRouteOptions) {
               watcherStatus: context.watcherActive ? 'active' : 'stopped',
             },
           };
-        } catch (error: any) {
+        } catch (error: unknown) {
+          const message = error instanceof Error ? error.message : String(error);
+          const code = error instanceof Error && 'code' in error ? (error as NodeJS.ErrnoException).code : undefined;
+
           // AC: @multi-directory-daemon ac-5 - Invalid project (no .kspec/)
-          if (error.message.includes('.kspec/ not found')) {
+          if (message.includes('.kspec/ not found')) {
             return errorResponse(400, {
               error: `Invalid kspec project - .kspec/ not found at ${body.path}`,
             });
           }
 
           // AC: @multi-directory-daemon ac-8b - Permission denied
-          if (error.code === 'EACCES' || error.code === 'EPERM') {
+          if (code === 'EACCES' || code === 'EPERM') {
             return errorResponse(403, {
               error: `Permission denied - cannot read ${body.path}`,
             });
@@ -115,7 +119,7 @@ export function createProjectsRoutes(options: ProjectsRouteOptions) {
 
           // Generic error
           return errorResponse(500, {
-            error: error.message || 'Failed to register project',
+            error: message || 'Failed to register project',
           });
         }
       },
@@ -149,9 +153,9 @@ export function createProjectsRoutes(options: ProjectsRouteOptions) {
           success: true,
           message: `Project unregistered: ${projectPath}`,
         };
-      } catch (error: any) {
+      } catch (error: unknown) {
         return errorResponse(500, {
-          error: error.message || 'Failed to unregister project',
+          error: error instanceof Error ? error.message : 'Failed to unregister project',
         });
       }
     });

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -71,7 +71,7 @@ function resolveWebUiPath(webUiDir?: string): string | null {
 let pubsubManager: PubSubManager;
 let heartbeatManager: HeartbeatManager;
 let wsHandler: WebSocketHandler;
-let projectManager: any; // ProjectContextManager instance
+let projectManager: import('./project-context').ProjectContextManager | undefined;
 
 /**
  * Middleware to enforce localhost-only connections.
@@ -231,7 +231,7 @@ export async function createServer(options: ServerOptions) {
         const requestId = ulid(); // Temporary ID to correlate upgrade with open
 
         try {
-          const manager = (store as any).projectManager;
+          const manager = (store as Record<string, unknown>).projectManager as import('./project-context').ProjectContextManager | undefined;
           if (!manager) {
             // Fallback: project manager not initialized yet
             wsProjectPaths.set(requestId, startupProjectPath);
@@ -251,9 +251,9 @@ export async function createServer(options: ServerOptions) {
             // AC: @multi-directory-daemon ac-22, ac-23 - Use default or reject
             try {
               projectContext = manager.getProject();
-            } catch (err: any) {
+            } catch (err: unknown) {
               // AC: @multi-directory-daemon ac-23 - Reject when no default
-              if (err.message.includes('No default project configured')) {
+              if (err instanceof Error && err.message.includes('No default project configured')) {
                 throw new Error('No project specified');
               }
               throw err;
@@ -263,8 +263,8 @@ export async function createServer(options: ServerOptions) {
           // Store resolved path for open() handler
           wsProjectPaths.set(requestId, projectContext.path);
           return { wsRequestId: requestId };
-        } catch (err: any) {
-          console.error(`[daemon] WebSocket connection rejected: ${err.message}`);
+        } catch (err: unknown) {
+          console.error(`[daemon] WebSocket connection rejected: ${err instanceof Error ? err.message : String(err)}`);
           throw err;
         }
       },
@@ -274,7 +274,7 @@ export async function createServer(options: ServerOptions) {
 
         // AC: @multi-directory-daemon ac-21 - Get bound project path
         // Fallback to startup project if not found (shouldn't happen)
-        const requestId = (ws.data as any).wsRequestId;
+        const requestId = (ws.data as ConnectionData & { wsRequestId?: string }).wsRequestId;
         const projectPath = requestId ? wsProjectPaths.get(requestId) || startupProjectPath : startupProjectPath;
 
         // Clean up temporary mapping

--- a/packages/daemon/src/websocket/handler.ts
+++ b/packages/daemon/src/websocket/handler.ts
@@ -123,7 +123,7 @@ export class WebSocketHandler {
     request_id: string | undefined,
     success: boolean,
     error?: string,
-    details?: any
+    details?: string
   ) {
     const ack: CommandAck = {
       ack: true,

--- a/packages/daemon/src/websocket/pubsub.ts
+++ b/packages/daemon/src/websocket/pubsub.ts
@@ -70,7 +70,7 @@ export class PubSubManager {
    * AC: @api-contract ac-29, @trait-websocket-protocol ac-3, ac-6
    * AC: @multi-directory-daemon ac-18, ac-21 - Filter by project binding
    */
-  broadcast(topic: string, event: string, data: any, projectPath?: string) {
+  broadcast(topic: string, event: string, data: Record<string, unknown>, projectPath?: string) {
     for (const [sessionId, ws] of this.connections) {
       // AC: @multi-directory-daemon ac-18 - Only send to connections bound to same project
       if (projectPath && ws.data.projectPath !== projectPath) {

--- a/packages/daemon/src/websocket/types.ts
+++ b/packages/daemon/src/websocket/types.ts
@@ -29,7 +29,7 @@ export interface CommandAck {
   request_id?: string;
   success: boolean;
   error?: string;
-  details?: any;
+  details?: string;
 }
 
 // AC: @api-contract ac-25, @trait-websocket-protocol ac-1
@@ -47,7 +47,7 @@ export interface BroadcastEvent {
   timestamp: string;
   topic: string;
   event: string;
-  data: any;
+  data: Record<string, unknown>;
 }
 
 // Internal connection metadata


### PR DESCRIPTION
## Summary
- Replace all 15 explicit `any` casts across 8 daemon source files with proper TypeScript types
- Error catches (`catch (err: any)`) now use `unknown` with `instanceof Error` type guards
- Elysia framework store/context access uses typed casts instead of `as any`
- Event payload types use `string` (ack details) and `Record<string, unknown>` (broadcast data)

## Test plan
- [x] Zero `any` casts remain in `packages/daemon/src/`
- [x] `npx tsc --noEmit` passes clean
- [x] `npm run build` succeeds
- [x] All 1713 tests pass (1 pre-existing failure in `daemon-executable.test.ts` unrelated)

Task: @01KGGTR7
Spec: @daemon-server

Generated with [Claude Code](https://claude.ai/code)