### PR TITLE
fix(plan-import): scope implementation notes per-spec instead of duplicating to all tasks

### DIFF
--- a/.claude/skills/spec-plan/SKILL.md
+++ b/.claude/skills/spec-plan/SKILL.md
@@ -90,6 +90,8 @@ The import path uses structured markdown documents. The parser (`parsePlanDocume
   slug: token-refresh
   type: requirement
   parent: "@oauth-provider"
+  implementation_notes: |
+    Use sliding window with 15min expiry for token refresh.
 ```
 
 ## Tasks
@@ -106,13 +108,13 @@ derive_from_specs: true
 
 ## Implementation Notes
 
-Use passport.js for OAuth. Token refresh should use sliding window with 15min expiry.
+Use passport.js for OAuth. General architecture follows existing auth patterns.
 ```
 
 **Section details:**
-- `## Specs` - YAML code block with array of spec objects. Fields: `title` (required), `slug`, `type`, `parent` (use `@ref`), `description`, `acceptance_criteria` (each needs `id`, `given`, `when`, `then`), `traits` (array of trait IDs)
+- `## Specs` - YAML code block with array of spec objects. Fields: `title` (required), `slug`, `type`, `parent` (use `@ref`), `description`, `acceptance_criteria` (each needs `id`, `given`, `when`, `then`), `traits` (array of trait IDs), `implementation_notes` (plain text, scoped to this spec's derived task)
 - `## Tasks` - `derive_from_specs: true|false` as a bare line (creates a task per spec). Optional YAML code block with additional manual tasks (fields: `title` required, `slug`, `priority`, `description`, `tags`). Manual tasks get `plan_ref` but no `spec_ref`
-- `## Implementation Notes` - Plain text, propagated as initial note to all derived tasks
+- `## Implementation Notes` - Plain text, attached to the plan record. Per-spec notes use the `implementation_notes` field in each spec's YAML entry
 
 ## Trait Considerations
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -575,7 +575,7 @@ kspec plan derive @plan-ref              # create task from plan
 
 **Plan lifecycle:** `draft` → `approved` → `active` → `completed` (or `rejected` from any non-terminal state)
 
-**Import path** parses structured markdown with `## Specs` (YAML array), `## Tasks` (`derive_from_specs: true` + optional manual tasks), and `## Implementation Notes`. See `/spec-plan` for full format reference.
+**Import path** parses structured markdown with `## Specs` (YAML array with optional per-spec `implementation_notes`), `## Tasks` (`derive_from_specs: true` + optional manual tasks), and `## Implementation Notes` (global, attached to plan record). See `/spec-plan` for full format reference.
 
 ### Inbox vs Observations
 

--- a/src/cli/commands/plan-import.ts
+++ b/src/cli/commands/plan-import.ts
@@ -173,6 +173,16 @@ async function importPlan(
   const newPlan = createPlan(planInput);
   const planRef = `@${planSlug}`;
 
+  // AC: @plan-import ac-13 - Attach global implementation notes to plan record
+  if (parsed.implementationNotes) {
+    newPlan.notes.push({
+      _ulid: ulid(),
+      created_at: new Date().toISOString(),
+      author,
+      content: `Implementation notes:\n\n${parsed.implementationNotes}`,
+    });
+  }
+
   // Initialize result
   const result: ImportResult = {
     createdSpecs: [],
@@ -379,13 +389,25 @@ async function importPlan(
 
         const newTask = createTask(taskInput);
 
-        // AC: @plan-import ac-13 - Add implementation notes
-        if (parsed.implementationNotes) {
+        // AC: @plan-import ac-13 - Scoped implementation notes
+        const planSpec = parsed.specs.find(s =>
+          (s.slug || generateSlug(s.title)) === specSlug
+        );
+        if (planSpec?.implementation_notes) {
+          // Per-spec notes go directly to this task
           newTask.notes.push({
             _ulid: ulid(),
             created_at: new Date().toISOString(),
             author,
-            content: `Implementation notes from plan:\n\n${parsed.implementationNotes}`,
+            content: `Implementation notes:\n\n${planSpec.implementation_notes}`,
+          });
+        } else if (parsed.implementationNotes) {
+          // No per-spec notes — reference the plan
+          newTask.notes.push({
+            _ulid: ulid(),
+            created_at: new Date().toISOString(),
+            author,
+            content: `See plan ${planRef} for implementation notes`,
           });
         }
 

--- a/src/parser/plan-document.ts
+++ b/src/parser/plan-document.ts
@@ -24,6 +24,7 @@ export const PlanSpecSchema = z.object({
   description: z.string().optional(),
   acceptance_criteria: z.array(AcceptanceCriterionSchema).optional(),
   traits: z.array(z.string()).optional(),
+  implementation_notes: z.string().min(1).optional(),
 });
 
 export type PlanSpec = z.infer<typeof PlanSpecSchema>;

--- a/tests/cli-plan-import.test.ts
+++ b/tests/cli-plan-import.test.ts
@@ -81,7 +81,7 @@ derive_from_specs: true
   });
 
   // AC: @plan-import ac-13
-  it("should add implementation notes to derived tasks", async () => {
+  it("should add global implementation notes to plan record and reference to tasks", async () => {
     const planPath = path.join(tempDir, "test-plan.md");
     await fs.writeFile(
       planPath,
@@ -108,7 +108,16 @@ Follow coding standards Y.
 
     kspec(`plan import "${planPath}" --module @test-core`, tempDir);
 
-    // Check that task has the implementation notes
+    // Plan record should have the global implementation notes
+    const plan = kspecJson<{ notes: Array<{ content: string }> }>(
+      "plan get @test-plan --json",
+      tempDir,
+    );
+    expect(plan.notes).toHaveLength(1);
+    expect(plan.notes[0].content).toContain("Implementation notes:");
+    expect(plan.notes[0].content).toContain("Use pattern X");
+
+    // Task without per-spec notes should get a reference to the plan
     const allTasks = kspecJson<Array<{ notes: Array<{ content: string }>; plan_ref: string }>>(
       "task list --json",
       tempDir,
@@ -116,8 +125,170 @@ Follow coding standards Y.
     const tasks = allTasks.filter(t => t.plan_ref === "@test-plan");
     expect(tasks).toHaveLength(1);
     expect(tasks[0].notes).toHaveLength(1);
-    expect(tasks[0].notes[0].content).toContain("Implementation notes from plan");
-    expect(tasks[0].notes[0].content).toContain("Use pattern X");
+    expect(tasks[0].notes[0].content).toContain("See plan @test-plan for implementation notes");
+  });
+
+  // AC: @plan-import ac-13 - Per-spec implementation notes
+  it("should add per-spec implementation notes to the corresponding task only", async () => {
+    const planPath = path.join(tempDir, "per-spec-notes.md");
+    await fs.writeFile(
+      planPath,
+      `# Per Spec Notes Plan
+
+## Specs
+
+\`\`\`yaml
+- title: Feature Alpha
+  slug: feature-alpha
+  type: feature
+  implementation_notes: |
+    Use pattern A for alpha implementation.
+
+- title: Feature Beta
+  slug: feature-beta
+  type: feature
+  implementation_notes: |
+    Use pattern B for beta implementation.
+\`\`\`
+
+## Tasks
+
+derive_from_specs: true
+`,
+    );
+
+    kspec(`plan import "${planPath}" --module @test-core`, tempDir);
+
+    const allTasks = kspecJson<Array<{ title: string; notes: Array<{ content: string }>; plan_ref: string }>>(
+      "task list --json",
+      tempDir,
+    );
+    const tasks = allTasks.filter(t => t.plan_ref === "@per-spec-notes-plan");
+
+    expect(tasks).toHaveLength(2);
+
+    const alphaTask = tasks.find(t => t.title === "Implement Feature Alpha");
+    const betaTask = tasks.find(t => t.title === "Implement Feature Beta");
+
+    expect(alphaTask).toBeDefined();
+    expect(alphaTask!.notes).toHaveLength(1);
+    expect(alphaTask!.notes[0].content).toContain("Use pattern A");
+    expect(alphaTask!.notes[0].content).not.toContain("Use pattern B");
+
+    expect(betaTask).toBeDefined();
+    expect(betaTask!.notes).toHaveLength(1);
+    expect(betaTask!.notes[0].content).toContain("Use pattern B");
+    expect(betaTask!.notes[0].content).not.toContain("Use pattern A");
+  });
+
+  // AC: @plan-import ac-13 - Mixed: some specs with per-spec notes, some without
+  it("should scope per-spec notes and reference plan for specs without", async () => {
+    const planPath = path.join(tempDir, "mixed-notes.md");
+    await fs.writeFile(
+      planPath,
+      `# Mixed Notes Plan
+
+## Specs
+
+\`\`\`yaml
+- title: Feature With Notes
+  slug: feature-with-notes
+  type: feature
+  implementation_notes: |
+    Specific implementation details for this feature.
+
+- title: Feature Without Notes
+  slug: feature-without-notes
+  type: feature
+\`\`\`
+
+## Tasks
+
+derive_from_specs: true
+
+## Implementation Notes
+
+Global architecture notes for the plan.
+`,
+    );
+
+    kspec(`plan import "${planPath}" --module @test-core`, tempDir);
+
+    const allTasks = kspecJson<Array<{ title: string; notes: Array<{ content: string }>; plan_ref: string }>>(
+      "task list --json",
+      tempDir,
+    );
+    const tasks = allTasks.filter(t => t.plan_ref === "@mixed-notes-plan");
+
+    expect(tasks).toHaveLength(2);
+
+    const withNotes = tasks.find(t => t.title === "Implement Feature With Notes");
+    const withoutNotes = tasks.find(t => t.title === "Implement Feature Without Notes");
+
+    // Task with per-spec notes gets those notes
+    expect(withNotes).toBeDefined();
+    expect(withNotes!.notes).toHaveLength(1);
+    expect(withNotes!.notes[0].content).toContain("Specific implementation details");
+    expect(withNotes!.notes[0].content).not.toContain("See plan");
+
+    // Task without per-spec notes gets plan reference
+    expect(withoutNotes).toBeDefined();
+    expect(withoutNotes!.notes).toHaveLength(1);
+    expect(withoutNotes!.notes[0].content).toContain("See plan @mixed-notes-plan for implementation notes");
+
+    // Plan record should have global notes
+    const plan = kspecJson<{ notes: Array<{ content: string }> }>(
+      "plan get @mixed-notes-plan --json",
+      tempDir,
+    );
+    expect(plan.notes).toHaveLength(1);
+    expect(plan.notes[0].content).toContain("Global architecture notes");
+  });
+
+  // AC: @plan-import ac-13 - Backward compatibility: old format without per-spec notes
+  it("should handle old-format plan without per-spec notes", async () => {
+    const planPath = path.join(tempDir, "old-format.md");
+    await fs.writeFile(
+      planPath,
+      `# Old Format Plan
+
+## Specs
+
+\`\`\`yaml
+- title: Legacy Feature
+  slug: legacy-feature
+  type: feature
+\`\`\`
+
+## Tasks
+
+derive_from_specs: true
+
+## Implementation Notes
+
+These are the global notes only.
+`,
+    );
+
+    kspec(`plan import "${planPath}" --module @test-core`, tempDir);
+
+    // Plan record should have global notes
+    const plan = kspecJson<{ notes: Array<{ content: string }> }>(
+      "plan get @old-format-plan --json",
+      tempDir,
+    );
+    expect(plan.notes).toHaveLength(1);
+    expect(plan.notes[0].content).toContain("These are the global notes only");
+
+    // Task should get plan reference (not the full global notes)
+    const allTasks = kspecJson<Array<{ notes: Array<{ content: string }>; plan_ref: string }>>(
+      "task list --json",
+      tempDir,
+    );
+    const tasks = allTasks.filter(t => t.plan_ref === "@old-format-plan");
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0].notes).toHaveLength(1);
+    expect(tasks[0].notes[0].content).toContain("See plan @old-format-plan for implementation notes");
   });
 
   // AC: @plan-import ac-14, ac-25
@@ -617,15 +788,23 @@ Ensure backward compatibility.
     expect(plan.derived_specs).toHaveLength(2);
     expect(plan.derived_tasks).toHaveLength(3);
 
-    // Verify tasks have implementation notes
-    const tasks = kspecJson<Array<{ notes: Array<{ content: string }> }>>(
+    // Verify plan record has global implementation notes
+    const planRecord = kspecJson<{ notes: Array<{ content: string }> }>(
+      "plan get @complete-feature-plan --json",
+      tempDir,
+    );
+    expect(planRecord.notes).toHaveLength(1);
+    expect(planRecord.notes[0].content).toContain("Follow existing patterns");
+
+    // Verify derived tasks reference the plan (no per-spec notes in this plan)
+    const tasks = kspecJson<Array<{ notes: Array<{ content: string }>; plan_ref: string }>>(
       "task list --json",
       tempDir,
     );
     const derivedTasks = tasks.filter(
-      (t) => t.notes.length > 0 && t.notes[0].content.includes("Implementation notes"),
+      (t) => t.plan_ref === "@complete-feature-plan" && t.notes.length > 0 && t.notes[0].content.includes("See plan"),
     );
-    expect(derivedTasks).toHaveLength(2); // Both derived tasks should have notes
+    expect(derivedTasks).toHaveLength(2); // Both derived tasks should reference the plan
   });
 
   // Bug fix: acceptance criteria should be preserved during import

--- a/tests/plan-document-parser.test.ts
+++ b/tests/plan-document-parser.test.ts
@@ -225,6 +225,8 @@ derive_from_specs: true
   traits:
     - "@json-output"
     - "@dry-run"
+  implementation_notes: |
+    Use existing patterns for this feature.
 \`\`\`
 `;
 
@@ -246,7 +248,32 @@ derive_from_specs: true
         },
       ],
       traits: ["@json-output", "@dry-run"],
+      implementation_notes: "Use existing patterns for this feature.\n",
     });
+  });
+
+  it("should parse implementation_notes on some specs and not others", () => {
+    const plan = `
+# Test Plan
+
+## Specs
+
+\`\`\`yaml
+- title: Spec With Notes
+  slug: with-notes
+  implementation_notes: |
+    Specific notes for this spec.
+
+- title: Spec Without Notes
+  slug: without-notes
+\`\`\`
+`;
+
+    const result = parsePlanDocument(plan);
+
+    expect(result.specs).toHaveLength(2);
+    expect(result.specs[0].implementation_notes).toBe("Specific notes for this spec.\n");
+    expect(result.specs[1].implementation_notes).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Summary

- **Schema**: Added optional `implementation_notes` field to `PlanSpecSchema` for per-spec scoping
- **Plan record**: Global `## Implementation Notes` now attach to the plan record only (not every task)
- **Task scoping**: Per-spec `implementation_notes` go to the corresponding derived task; tasks without per-spec notes get a brief reference (`See plan @plan-ref for implementation notes`)
- **Tests**: 4 new integration tests (per-spec notes, mixed mode, backward compat, parser) + 2 updated existing tests
- **Docs**: Updated SKILL.md format reference, AGENTS.md import path description, and example plan

## Test plan

- [x] `npm run build` — clean compile
- [x] `npm test` — 1722/1722 tests pass (1 pre-existing bun compilation skip)
- [ ] CI passes on PR
- [ ] Manual verification: import plan with mix of per-spec and global notes

Task: @01KGR0K5
Spec: @plan-import

Generated with [Claude Code](https://claude.ai/code)