### PR TITLE
feat(batch): add batch command schema, parsing, and validation

### DIFF
--- a/src/cli/batch-exec.ts
+++ b/src/cli/batch-exec.ts
@@ -1,0 +1,362 @@
+/**
+ * Batch command parsing, validation, and error reporting.
+ *
+ * Parses JSON batch input from stdin/file/inline, validates command paths
+ * against the CLI's introspection tree, and produces helpful error messages.
+ */
+
+import * as fs from "node:fs/promises";
+import { ZodError } from "zod";
+import {
+  BatchInputSchema,
+  type BatchCommand,
+  type BatchInput,
+} from "../schema/batch.js";
+import type { CommandMeta } from "./introspection.js";
+import { findCommand, flattenCommandTree } from "./introspection.js";
+import { findClosestCommand } from "./suggest.js";
+
+// ── Input Source Types ───────────────────────────────────────────────
+
+export type BatchInputSource =
+  | { type: "stdin" }
+  | { type: "file"; path: string }
+  | { type: "inline"; json: string };
+
+// ── Error Types ─────────────────────────────────────────────────────
+
+export class BatchParseError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "BatchParseError";
+  }
+}
+
+export type BatchValidationErrorType =
+  | "unknown_command"
+  | "missing_required"
+  | "unknown_arg"
+  | "rejected_command";
+
+export interface BatchValidationError {
+  /** Index in the batch array */
+  index: number;
+  /** Correlation ID if provided */
+  id?: string;
+  /** The command string from input */
+  command: string;
+  /** Error classification */
+  type: BatchValidationErrorType;
+  /** Human-readable error message */
+  message: string;
+  /** Suggested correction (e.g. closest command name) */
+  suggestion?: string;
+}
+
+export interface BatchValidationResult {
+  /** Whether all commands passed validation */
+  valid: boolean;
+  /** Validated commands (only present when valid) */
+  commands: BatchCommand[];
+  /** Validation errors */
+  errors: BatchValidationError[];
+}
+
+export interface ValidateBatchOptions {
+  /**
+   * Optional predicate to filter which commands are allowed.
+   * Extension point for allowed-commands task (@01KGR05NE).
+   * When provided, commands that don't pass the filter are rejected
+   * with a "rejected_command" error.
+   */
+  commandFilter?: (cmd: CommandMeta) => boolean;
+}
+
+// ── Parsing ─────────────────────────────────────────────────────────
+
+/**
+ * Read raw text from a batch input source.
+ */
+async function readSource(source: BatchInputSource): Promise<string> {
+  switch (source.type) {
+    case "inline":
+      return source.json;
+
+    case "file":
+      try {
+        return await fs.readFile(source.path, "utf-8");
+      } catch (err) {
+        throw new BatchParseError(
+          `Failed to read batch file: ${(err as Error).message}`,
+        );
+      }
+
+    case "stdin": {
+      const chunks: Buffer[] = [];
+      for await (const chunk of process.stdin) {
+        chunks.push(chunk as Buffer);
+      }
+      const text = Buffer.concat(chunks).toString("utf-8");
+      if (!text.trim()) {
+        throw new BatchParseError("No input received on stdin");
+      }
+      return text;
+    }
+  }
+}
+
+/**
+ * Parse batch input from a source, returning validated commands.
+ *
+ * @throws {BatchParseError} on invalid JSON, empty array, or schema violations
+ */
+export async function parseBatchInput(
+  source: BatchInputSource,
+): Promise<BatchInput> {
+  const raw = await readSource(source);
+
+  // Parse JSON — preserve the native error message which includes position
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new BatchParseError(
+      `Invalid JSON: ${(err as SyntaxError).message}`,
+    );
+  }
+
+  // Validate against schema
+  try {
+    return BatchInputSchema.parse(parsed);
+  } catch (err) {
+    if (err instanceof ZodError) {
+      const messages = err.errors.map((e) => {
+        const path = e.path.length > 0 ? ` at ${e.path.join(".")}` : "";
+        return `${e.message}${path}`;
+      });
+      throw new BatchParseError(
+        `Batch validation failed: ${messages.join("; ")}`,
+      );
+    }
+    throw err;
+  }
+}
+
+// ── Validation ──────────────────────────────────────────────────────
+
+/**
+ * Extract the option name from Commander flag syntax.
+ * e.g. "-f, --force" → "force", "--spec-ref <value>" → "spec-ref"
+ */
+function extractOptionName(flags: string): string | null {
+  const match = flags.match(/--([a-zA-Z0-9-]+)/);
+  return match ? match[1] : null;
+}
+
+/**
+ * Convert a kebab-case string to camelCase.
+ * e.g. "spec-ref" → "specRef"
+ */
+function kebabToCamel(s: string): string {
+  return s.replace(/-([a-z])/g, (_, c) => c.toUpperCase());
+}
+
+/**
+ * Get all known argument and option names for a command, returning both
+ * kebab-case and camelCase variants.
+ */
+function getKnownArgNames(
+  cmd: CommandMeta,
+): { names: Set<string>; required: string[] } {
+  const names = new Set<string>();
+  const required: string[] = [];
+
+  // Positional arguments
+  for (const arg of cmd.arguments) {
+    names.add(arg.name);
+    names.add(kebabToCamel(arg.name));
+    if (arg.required) {
+      required.push(arg.name);
+    }
+  }
+
+  // Options
+  for (const opt of cmd.options) {
+    const optName = extractOptionName(opt.flags);
+    if (optName) {
+      names.add(optName);
+      names.add(kebabToCamel(optName));
+      if (opt.mandatory) {
+        required.push(optName);
+      }
+    }
+  }
+
+  return { names, required };
+}
+
+/**
+ * Collect all leaf command paths from a command tree as space-joined strings.
+ */
+function collectLeafCommandPaths(tree: CommandMeta): string[] {
+  const flat = flattenCommandTree(tree);
+  return flat
+    .filter((cmd) => cmd.subcommands.length === 0)
+    .map((cmd) => cmd.fullPath.slice(1).join(" ")) // skip root name
+    .filter((path) => path.length > 0);
+}
+
+/**
+ * Validate batch commands against the CLI's command tree.
+ *
+ * AC: @batch-command-schema ac-command-field — validates command paths
+ * AC: @batch-command-schema ac-args-mapping — validates arg names
+ * AC: @batch-command-schema ac-unknown-command — suggests similar commands
+ * AC: @batch-command-schema ac-missing-required — identifies missing args
+ * AC: @batch-command-schema ac-id-field — preserves id in errors
+ */
+export function validateBatchCommands(
+  commands: BatchCommand[],
+  program: CommandMeta,
+  options?: ValidateBatchOptions,
+): BatchValidationResult {
+  const errors: BatchValidationError[] = [];
+  const validLeafPaths = collectLeafCommandPaths(program);
+
+  for (let i = 0; i < commands.length; i++) {
+    const cmd = commands[i];
+    const parts = cmd.command.trim().split(/\s+/);
+
+    // 1. Resolve command path
+    const found = findCommand(program, parts);
+
+    if (!found) {
+      // Unknown command — suggest closest
+      const suggestion = findClosestCommand(cmd.command, validLeafPaths);
+      errors.push({
+        index: i,
+        id: cmd.id,
+        command: cmd.command,
+        type: "unknown_command",
+        message: `Unknown command: "${cmd.command}"`,
+        suggestion: suggestion ?? undefined,
+      });
+      continue;
+    }
+
+    // Reject command groups (non-leaf nodes)
+    if (found.subcommands.length > 0) {
+      const suggestion = findClosestCommand(cmd.command, validLeafPaths);
+      errors.push({
+        index: i,
+        id: cmd.id,
+        command: cmd.command,
+        type: "unknown_command",
+        message: `"${cmd.command}" is a command group, not an executable command`,
+        suggestion: suggestion ?? undefined,
+      });
+      continue;
+    }
+
+    // 2. Apply command filter if provided
+    if (options?.commandFilter && !options.commandFilter(found)) {
+      errors.push({
+        index: i,
+        id: cmd.id,
+        command: cmd.command,
+        type: "rejected_command",
+        message: `Command "${cmd.command}" is not allowed in batch mode`,
+      });
+      continue;
+    }
+
+    // 3. Check for unknown args
+    const { names: knownNames, required: requiredNames } =
+      getKnownArgNames(found);
+
+    // Collect all known names as flat array for suggestion matching
+    const knownNamesArray = Array.from(knownNames);
+
+    for (const argKey of Object.keys(cmd.args)) {
+      // Accept both kebab-case and camelCase
+      if (!knownNames.has(argKey)) {
+        const suggestion = findClosestCommand(argKey, knownNamesArray);
+        errors.push({
+          index: i,
+          id: cmd.id,
+          command: cmd.command,
+          type: "unknown_arg",
+          message: `Unknown argument "${argKey}" for command "${cmd.command}"`,
+          suggestion: suggestion ?? undefined,
+        });
+      }
+    }
+
+    // 4. Check for missing required args
+    for (const reqName of requiredNames) {
+      const camelName = kebabToCamel(reqName);
+      if (
+        !(reqName in cmd.args) &&
+        !(camelName in cmd.args) &&
+        // Skip if provided via positional alias
+        !Object.keys(cmd.args).some(
+          (k) => kebabToCamel(k) === camelName,
+        )
+      ) {
+        errors.push({
+          index: i,
+          id: cmd.id,
+          command: cmd.command,
+          type: "missing_required",
+          message: `Missing required argument "${reqName}" for command "${cmd.command}"`,
+        });
+      }
+    }
+  }
+
+  return {
+    valid: errors.length === 0,
+    commands,
+    errors,
+  };
+}
+
+// ── Error Reporting ─────────────────────────────────────────────────
+
+/**
+ * Format validation errors for human or JSON output.
+ *
+ * @param result - Validation result containing errors
+ * @param json - If true, return JSON string; otherwise human-readable lines
+ * @returns Formatted error string
+ */
+export function reportBatchValidationErrors(
+  result: BatchValidationResult,
+  json: boolean = false,
+): string {
+  if (result.valid) {
+    return json ? JSON.stringify({ valid: true, errors: [] }) : "";
+  }
+
+  if (json) {
+    return JSON.stringify(
+      {
+        valid: false,
+        errors: result.errors,
+      },
+      null,
+      2,
+    );
+  }
+
+  // Human-readable format
+  const lines: string[] = [];
+  for (const err of result.errors) {
+    const label = err.id ?? `#${err.index}`;
+    lines.push(`[${label}] ${err.message}`);
+    if (err.suggestion) {
+      lines.push(`  Did you mean: ${err.suggestion}?`);
+    }
+  }
+  return lines.join("\n");
+}

--- a/src/cli/introspection.ts
+++ b/src/cli/introspection.ts
@@ -16,8 +16,10 @@ export interface OptionMeta {
   flags: string;
   /** Option description */
   description: string;
-  /** Whether option is required */
+  /** Whether the option's value is required when used (i.e. <value> not [value]) */
   required: boolean;
+  /** Whether the option itself must be provided (i.e. requiredOption) */
+  mandatory: boolean;
   /** Default value if any */
   defaultValue?: unknown;
   /** Whether option can be repeated */
@@ -68,6 +70,7 @@ function extractOptionMeta(option: CommanderOption): OptionMeta {
     flags: option.flags,
     description: option.description || "",
     required: option.required,
+    mandatory: (option as any).mandatory ?? false,
     defaultValue: option.defaultValue,
     variadic: option.variadic,
   };

--- a/src/schema/batch.ts
+++ b/src/schema/batch.ts
@@ -1,0 +1,68 @@
+import { z } from "zod";
+
+/**
+ * Schema for a single command in a batch execution payload.
+ *
+ * AC: @batch-command-schema ac-command-field — command is a string command path
+ * AC: @batch-command-schema ac-args-mapping — args map to CLI parameters
+ * AC: @batch-command-schema ac-id-field — optional correlation id
+ */
+export const BatchCommandSchema = z.object({
+  /** CLI command path, e.g. "task add" or "item note" */
+  command: z.string().min(1, "Command path is required"),
+  /** Arguments/options keyed by flag name (without --) or positional arg name */
+  args: z.record(z.string(), z.unknown()).default({}),
+  /** Optional correlation ID for matching results to commands */
+  id: z.string().optional(),
+});
+
+export type BatchCommand = z.infer<typeof BatchCommandSchema>;
+
+/**
+ * Schema for the full batch input — an array of commands.
+ * Must contain at least one command.
+ */
+export const BatchInputSchema = z
+  .array(BatchCommandSchema)
+  .min(1, "Batch must contain at least one command");
+
+export type BatchInput = z.infer<typeof BatchInputSchema>;
+
+/**
+ * Result of executing a single batch command.
+ */
+export interface BatchCommandResult {
+  /** Index in the original batch array */
+  index: number;
+  /** Correlation ID if provided */
+  id?: string;
+  /** The command path that was executed */
+  command: string;
+  /** Whether execution succeeded */
+  success: boolean;
+  /** Command output on success */
+  output?: unknown;
+  /** Error message on failure */
+  error?: string;
+}
+
+/**
+ * Summary counts for batch execution.
+ */
+export interface BatchExecSummary {
+  total: number;
+  succeeded: number;
+  failed: number;
+}
+
+/**
+ * Complete result of a batch execution.
+ */
+export interface BatchExecResult {
+  /** Overall success (true only if all commands succeeded) */
+  success: boolean;
+  /** Aggregate counts */
+  summary: BatchExecSummary;
+  /** Per-command results */
+  results: BatchCommandResult[];
+}

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -6,3 +6,4 @@ export * from "./meta.js";
 export * from "./plan.js";
 export * from "./spec.js";
 export * from "./task.js";
+export * from "./batch.js";

--- a/tests/batch-schema.test.ts
+++ b/tests/batch-schema.test.ts
@@ -1,0 +1,565 @@
+import { describe, it, expect } from "vitest";
+import { Command } from "commander";
+import {
+  BatchCommandSchema,
+  BatchInputSchema,
+} from "../src/schema/batch.js";
+import {
+  parseBatchInput,
+  validateBatchCommands,
+  reportBatchValidationErrors,
+  BatchParseError,
+} from "../src/cli/batch-exec.js";
+import { extractCommandTree } from "../src/cli/introspection.js";
+import type { CommandMeta } from "../src/cli/introspection.js";
+
+// ── Test Program ────────────────────────────────────────────────────
+// Minimal Commander program that mirrors real CLI structure for testing.
+
+function createTestProgram(): Command {
+  const program = new Command("kspec");
+
+  // task group with subcommands
+  const task = program.command("task").description("Task management");
+  task
+    .command("add")
+    .description("Add a task")
+    .requiredOption("--title <title>", "Task title")
+    .option("--spec-ref <ref>", "Spec reference")
+    .option("--priority <n>", "Priority level")
+    .argument("<ref>", "Parent reference");
+  task
+    .command("note")
+    .description("Add a note to a task")
+    .argument("<ref>", "Task reference")
+    .argument("<content>", "Note content");
+  task
+    .command("start")
+    .description("Start a task")
+    .argument("<ref>", "Task reference");
+  task
+    .command("complete")
+    .description("Complete a task")
+    .argument("<ref>", "Task reference")
+    .option("--reason <reason>", "Completion reason")
+    .option("--force", "Force completion");
+
+  // item group with subcommands
+  const item = program.command("item").description("Spec item management");
+  item
+    .command("add")
+    .description("Add a spec item")
+    .requiredOption("--title <title>", "Item title")
+    .option("--under <ref>", "Parent item")
+    .option("--type <type>", "Item type");
+  item
+    .command("note")
+    .description("Add note to an item")
+    .argument("<ref>", "Item reference")
+    .argument("<content>", "Note content");
+
+  // validate (leaf command, no subcommands)
+  program
+    .command("validate")
+    .description("Validate spec files")
+    .option("--strict", "Strict mode");
+
+  return program;
+}
+
+function getTestTree(): CommandMeta {
+  return extractCommandTree(createTestProgram());
+}
+
+// ── Schema Tests ────────────────────────────────────────────────────
+
+describe("BatchCommandSchema", () => {
+  it("accepts valid command object", () => {
+    const result = BatchCommandSchema.parse({
+      command: "task add",
+      args: { title: "My Task" },
+      id: "cmd-1",
+    });
+    expect(result.command).toBe("task add");
+    expect(result.args).toEqual({ title: "My Task" });
+    expect(result.id).toBe("cmd-1");
+  });
+
+  it("defaults args to empty object", () => {
+    const result = BatchCommandSchema.parse({ command: "validate" });
+    expect(result.args).toEqual({});
+  });
+
+  // AC: @batch-command-schema ac-id-field — id is optional
+  it("accepts command without id", () => {
+    const result = BatchCommandSchema.parse({
+      command: "task start",
+      args: { ref: "@my-task" },
+    });
+    expect(result.id).toBeUndefined();
+  });
+
+  it("rejects empty command string", () => {
+    expect(() => BatchCommandSchema.parse({ command: "" })).toThrow();
+  });
+
+  it("rejects missing command field", () => {
+    expect(() => BatchCommandSchema.parse({ args: {} })).toThrow();
+  });
+});
+
+describe("BatchInputSchema", () => {
+  it("accepts array of valid commands", () => {
+    const result = BatchInputSchema.parse([
+      { command: "task add", args: { title: "One" } },
+      { command: "task add", args: { title: "Two" } },
+    ]);
+    expect(result).toHaveLength(2);
+  });
+
+  it("rejects empty array", () => {
+    expect(() => BatchInputSchema.parse([])).toThrow(
+      /at least one command/i,
+    );
+  });
+
+  it("rejects non-array input", () => {
+    expect(() => BatchInputSchema.parse({ command: "task add" })).toThrow();
+  });
+});
+
+// ── Parse Tests ─────────────────────────────────────────────────────
+
+describe("parseBatchInput", () => {
+  it("parses inline JSON", async () => {
+    const input = JSON.stringify([
+      { command: "task start", args: { ref: "@my-task" } },
+    ]);
+    const result = await parseBatchInput({ type: "inline", json: input });
+    expect(result).toHaveLength(1);
+    expect(result[0].command).toBe("task start");
+  });
+
+  it("parses multiple commands from inline JSON", async () => {
+    const input = JSON.stringify([
+      { command: "task add", args: { title: "First" }, id: "a" },
+      { command: "task add", args: { title: "Second" }, id: "b" },
+    ]);
+    const result = await parseBatchInput({ type: "inline", json: input });
+    expect(result).toHaveLength(2);
+    expect(result[0].id).toBe("a");
+    expect(result[1].id).toBe("b");
+  });
+
+  // AC: parent ac-invalid-json — invalid JSON throws with position info
+  it("throws BatchParseError on invalid JSON with position info", async () => {
+    await expect(
+      parseBatchInput({ type: "inline", json: "{bad json" }),
+    ).rejects.toThrow(BatchParseError);
+
+    await expect(
+      parseBatchInput({ type: "inline", json: "{bad json" }),
+    ).rejects.toThrow(/Invalid JSON/);
+  });
+
+  // AC: parent ac-empty-batch — empty array rejected
+  it("throws BatchParseError on empty array", async () => {
+    await expect(
+      parseBatchInput({ type: "inline", json: "[]" }),
+    ).rejects.toThrow(BatchParseError);
+
+    await expect(
+      parseBatchInput({ type: "inline", json: "[]" }),
+    ).rejects.toThrow(/at least one command/i);
+  });
+
+  it("throws BatchParseError when command field is missing", async () => {
+    await expect(
+      parseBatchInput({
+        type: "inline",
+        json: JSON.stringify([{ args: { title: "No command" } }]),
+      }),
+    ).rejects.toThrow(BatchParseError);
+  });
+
+  it("throws BatchParseError on non-existent file", async () => {
+    await expect(
+      parseBatchInput({ type: "file", path: "/nonexistent/file.json" }),
+    ).rejects.toThrow(BatchParseError);
+
+    await expect(
+      parseBatchInput({ type: "file", path: "/nonexistent/file.json" }),
+    ).rejects.toThrow(/Failed to read batch file/);
+  });
+});
+
+// ── Validation Tests ────────────────────────────────────────────────
+
+describe("validateBatchCommands", () => {
+  const tree = getTestTree();
+
+  // AC: @batch-command-schema ac-command-field
+  describe("command path resolution", () => {
+    it("accepts valid single-level command", () => {
+      const result = validateBatchCommands(
+        [{ command: "validate", args: {} }],
+        tree,
+      );
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it("accepts valid multi-level command path", () => {
+      const result = validateBatchCommands(
+        [{ command: "task add", args: { title: "Test", ref: "@parent" } }],
+        tree,
+      );
+      // May have missing required errors but not unknown_command errors
+      const unknownErrs = result.errors.filter(
+        (e) => e.type === "unknown_command",
+      );
+      expect(unknownErrs).toHaveLength(0);
+    });
+
+    it("accepts deeply nested command path", () => {
+      const result = validateBatchCommands(
+        [
+          {
+            command: "task note",
+            args: { ref: "@task", content: "note text" },
+          },
+        ],
+        tree,
+      );
+      const unknownErrs = result.errors.filter(
+        (e) => e.type === "unknown_command",
+      );
+      expect(unknownErrs).toHaveLength(0);
+    });
+
+    it("rejects command group (non-leaf)", () => {
+      const result = validateBatchCommands(
+        [{ command: "task", args: {} }],
+        tree,
+      );
+      expect(result.valid).toBe(false);
+      expect(result.errors[0].type).toBe("unknown_command");
+      expect(result.errors[0].message).toContain("command group");
+    });
+
+    it("rejects with commandFilter", () => {
+      const result = validateBatchCommands(
+        [{ command: "validate", args: {} }],
+        tree,
+        {
+          commandFilter: (cmd) => cmd.name !== "validate",
+        },
+      );
+      expect(result.valid).toBe(false);
+      expect(result.errors[0].type).toBe("rejected_command");
+      expect(result.errors[0].message).toContain("not allowed");
+    });
+
+    it("allows commands passing commandFilter", () => {
+      const result = validateBatchCommands(
+        [{ command: "validate", args: {} }],
+        tree,
+        {
+          commandFilter: () => true,
+        },
+      );
+      expect(result.valid).toBe(true);
+    });
+  });
+
+  // AC: @batch-command-schema ac-args-mapping
+  describe("argument mapping", () => {
+    it("accepts kebab-case option names", () => {
+      const result = validateBatchCommands(
+        [
+          {
+            command: "task add",
+            args: { title: "Test", ref: "@parent", "spec-ref": "@spec" },
+          },
+        ],
+        tree,
+      );
+      const unknownArgErrs = result.errors.filter(
+        (e) => e.type === "unknown_arg",
+      );
+      expect(unknownArgErrs).toHaveLength(0);
+    });
+
+    it("accepts camelCase option names", () => {
+      const result = validateBatchCommands(
+        [
+          {
+            command: "task add",
+            args: { title: "Test", ref: "@parent", specRef: "@spec" },
+          },
+        ],
+        tree,
+      );
+      const unknownArgErrs = result.errors.filter(
+        (e) => e.type === "unknown_arg",
+      );
+      expect(unknownArgErrs).toHaveLength(0);
+    });
+
+    it("accepts positional args by name", () => {
+      const result = validateBatchCommands(
+        [{ command: "task start", args: { ref: "@my-task" } }],
+        tree,
+      );
+      const unknownArgErrs = result.errors.filter(
+        (e) => e.type === "unknown_arg",
+      );
+      expect(unknownArgErrs).toHaveLength(0);
+    });
+
+    it("flags unknown args with suggestion", () => {
+      const result = validateBatchCommands(
+        [
+          {
+            command: "task add",
+            args: { title: "Test", ref: "@parent", tittle: "typo" },
+          },
+        ],
+        tree,
+      );
+      const unknownArgErrs = result.errors.filter(
+        (e) => e.type === "unknown_arg",
+      );
+      expect(unknownArgErrs).toHaveLength(1);
+      expect(unknownArgErrs[0].message).toContain("tittle");
+      expect(unknownArgErrs[0].suggestion).toBe("title");
+    });
+  });
+
+  // AC: @batch-command-schema ac-unknown-command
+  describe("unknown command handling", () => {
+    it("reports unknown command with index", () => {
+      const result = validateBatchCommands(
+        [{ command: "taks add", args: {} }],
+        tree,
+      );
+      expect(result.valid).toBe(false);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0].type).toBe("unknown_command");
+      expect(result.errors[0].index).toBe(0);
+      expect(result.errors[0].command).toBe("taks add");
+    });
+
+    it("suggests closest valid command", () => {
+      const result = validateBatchCommands(
+        [{ command: "task ad", args: {} }],
+        tree,
+      );
+      expect(result.errors[0].type).toBe("unknown_command");
+      expect(result.errors[0].suggestion).toBe("task add");
+    });
+
+    it("handles completely invalid command with no suggestion", () => {
+      const result = validateBatchCommands(
+        [{ command: "zzzzzzzzzzzzzzz", args: {} }],
+        tree,
+      );
+      expect(result.errors[0].type).toBe("unknown_command");
+      expect(result.errors[0].suggestion).toBeUndefined();
+    });
+  });
+
+  // AC: @batch-command-schema ac-missing-required
+  describe("missing required args", () => {
+    it("detects missing required option", () => {
+      const result = validateBatchCommands(
+        [{ command: "task add", args: { ref: "@parent" } }],
+        tree,
+      );
+      const missingErrs = result.errors.filter(
+        (e) => e.type === "missing_required",
+      );
+      expect(missingErrs.length).toBeGreaterThanOrEqual(1);
+      const titleErr = missingErrs.find((e) => e.message.includes("title"));
+      expect(titleErr).toBeDefined();
+    });
+
+    it("detects missing required positional arg", () => {
+      const result = validateBatchCommands(
+        [{ command: "task start", args: {} }],
+        tree,
+      );
+      const missingErrs = result.errors.filter(
+        (e) => e.type === "missing_required",
+      );
+      expect(missingErrs.length).toBeGreaterThanOrEqual(1);
+      expect(missingErrs[0].message).toContain("ref");
+    });
+
+    it("identifies missing args by name", () => {
+      const result = validateBatchCommands(
+        [{ command: "task note", args: {} }],
+        tree,
+      );
+      const missingErrs = result.errors.filter(
+        (e) => e.type === "missing_required",
+      );
+      const names = missingErrs.map((e) => e.message);
+      expect(names.some((m) => m.includes("ref"))).toBe(true);
+      expect(names.some((m) => m.includes("content"))).toBe(true);
+    });
+
+    it("passes when all required args are present", () => {
+      const result = validateBatchCommands(
+        [
+          {
+            command: "task add",
+            args: { title: "Test", ref: "@parent" },
+          },
+        ],
+        tree,
+      );
+      const missingErrs = result.errors.filter(
+        (e) => e.type === "missing_required",
+      );
+      expect(missingErrs).toHaveLength(0);
+    });
+  });
+
+  // AC: @batch-command-schema ac-id-field
+  describe("id field handling", () => {
+    it("preserves id in validation errors", () => {
+      const result = validateBatchCommands(
+        [{ command: "nonexistent", args: {}, id: "my-cmd-1" }],
+        tree,
+      );
+      expect(result.errors[0].id).toBe("my-cmd-1");
+    });
+
+    it("uses index when id is absent", () => {
+      const result = validateBatchCommands(
+        [{ command: "nonexistent", args: {} }],
+        tree,
+      );
+      expect(result.errors[0].index).toBe(0);
+      expect(result.errors[0].id).toBeUndefined();
+    });
+
+    it("tracks correct index in multi-command batch", () => {
+      const result = validateBatchCommands(
+        [
+          { command: "validate", args: {} },
+          { command: "nonexistent", args: {}, id: "bad-one" },
+          { command: "task start", args: { ref: "@t" } },
+        ],
+        tree,
+      );
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0].index).toBe(1);
+      expect(result.errors[0].id).toBe("bad-one");
+    });
+  });
+
+  describe("mixed errors", () => {
+    it("collects multiple error types from a single batch", () => {
+      const result = validateBatchCommands(
+        [
+          { command: "nonexistent", args: {} },
+          { command: "task add", args: {} },
+          {
+            command: "task start",
+            args: { ref: "@t", bogus: true },
+          },
+        ],
+        tree,
+      );
+      expect(result.valid).toBe(false);
+      const types = result.errors.map((e) => e.type);
+      expect(types).toContain("unknown_command");
+      expect(types).toContain("missing_required");
+      expect(types).toContain("unknown_arg");
+    });
+  });
+});
+
+// ── Error Reporting Tests ───────────────────────────────────────────
+
+describe("reportBatchValidationErrors", () => {
+  it("returns empty string for valid result", () => {
+    const output = reportBatchValidationErrors({
+      valid: true,
+      commands: [],
+      errors: [],
+    });
+    expect(output).toBe("");
+  });
+
+  it("formats human-readable errors with index", () => {
+    const output = reportBatchValidationErrors({
+      valid: false,
+      commands: [],
+      errors: [
+        {
+          index: 0,
+          command: "taks add",
+          type: "unknown_command",
+          message: 'Unknown command: "taks add"',
+          suggestion: "task add",
+        },
+      ],
+    });
+    expect(output).toContain("[#0]");
+    expect(output).toContain("Unknown command");
+    expect(output).toContain("Did you mean: task add?");
+  });
+
+  it("formats human-readable errors with id when present", () => {
+    const output = reportBatchValidationErrors({
+      valid: false,
+      commands: [],
+      errors: [
+        {
+          index: 0,
+          id: "my-cmd",
+          command: "taks add",
+          type: "unknown_command",
+          message: 'Unknown command: "taks add"',
+        },
+      ],
+    });
+    expect(output).toContain("[my-cmd]");
+    expect(output).not.toContain("[#0]");
+  });
+
+  it("produces valid JSON in json mode", () => {
+    const output = reportBatchValidationErrors(
+      {
+        valid: false,
+        commands: [],
+        errors: [
+          {
+            index: 0,
+            command: "bad",
+            type: "unknown_command",
+            message: "Unknown command",
+          },
+        ],
+      },
+      true,
+    );
+    const parsed = JSON.parse(output);
+    expect(parsed.valid).toBe(false);
+    expect(parsed.errors).toHaveLength(1);
+    expect(parsed.errors[0].type).toBe("unknown_command");
+  });
+
+  it("returns valid JSON for valid result in json mode", () => {
+    const output = reportBatchValidationErrors(
+      { valid: true, commands: [], errors: [] },
+      true,
+    );
+    const parsed = JSON.parse(output);
+    expect(parsed.valid).toBe(true);
+    expect(parsed.errors).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Add Zod schemas (`BatchCommandSchema`, `BatchInputSchema`) and result types for batch command execution input
- Implement `parseBatchInput()` supporting stdin, file, and inline JSON sources with descriptive parse errors
- Implement `validateBatchCommands()` that checks command paths against CLI introspection tree, validates arg names (kebab + camelCase), detects missing required args, and suggests corrections via fuzzy matching
- Add `reportBatchValidationErrors()` with human-readable and JSON output modes
- Add `mandatory` field to `OptionMeta` in introspection to distinguish `requiredOption` from value-required options
- 40 unit tests covering all 5 acceptance criteria plus parse error paths

## Test plan

- [x] `npx vitest tests/batch-schema.test.ts` — 40 tests pass
- [x] `npm run build` — types compile cleanly
- [x] Full test suite — no regressions (86/87 files pass; 1 pre-existing daemon-executable failure)

Task: @implement-batch-command-schema
Spec: @batch-command-schema

Generated with [Claude Code](https://claude.ai/code)