### PR TITLE
feat(batch): add command annotations for mutating/read-only classification

### DIFF
--- a/src/cli/batch-exec.ts
+++ b/src/cli/batch-exec.ts
@@ -258,19 +258,33 @@ export function validateBatchCommands(
       continue;
     }
 
-    // 2. Apply command filter if provided
+    // 2. Reject nested batch commands
+    // AC: @batch-allowed-commands ac-batch-itself
+    if (found.name === "batch") {
+      errors.push({
+        index: i,
+        id: cmd.id,
+        command: cmd.command,
+        type: "rejected_command",
+        message: "Nested batch commands are not allowed",
+      });
+      continue;
+    }
+
+    // 3. Apply command filter if provided
+    // AC: @batch-allowed-commands ac-denylist
     if (options?.commandFilter && !options.commandFilter(found)) {
       errors.push({
         index: i,
         id: cmd.id,
         command: cmd.command,
         type: "rejected_command",
-        message: `Command "${cmd.command}" is not allowed in batch mode`,
+        message: `Command "${cmd.command}" is not allowed in batch mode. Only mutating commands can be used in batch.`,
       });
       continue;
     }
 
-    // 3. Check for unknown args
+    // 4. Check for unknown args
     const { names: knownNames, required: requiredNames } =
       getKnownArgNames(found);
 
@@ -292,7 +306,7 @@ export function validateBatchCommands(
       }
     }
 
-    // 4. Check for missing required args
+    // 5. Check for missing required args
     for (const reqName of requiredNames) {
       const camelName = kebabToCamel(reqName);
       if (

--- a/src/cli/command-annotations.ts
+++ b/src/cli/command-annotations.ts
@@ -1,0 +1,33 @@
+/**
+ * Command annotation registry for batch mode classification.
+ *
+ * Uses a WeakMap to associate Commander commands with metadata
+ * (mutating vs read-only) without monkey-patching Commander internals.
+ * GC-friendly: annotations are released when commands are collected.
+ */
+
+import type { Command } from "commander";
+import type { CommandMeta } from "./introspection.js";
+
+const annotations = new WeakMap<Command, { mutating: boolean }>();
+
+/** Annotate a Commander command as mutating. Returns same instance for chaining. */
+export function markMutating(cmd: Command): Command {
+  annotations.set(cmd, { mutating: true });
+  return cmd;
+}
+
+/** Read annotation for a command (used by extractCommandTree). */
+export function getAnnotation(cmd: Command): { mutating: boolean } | undefined {
+  return annotations.get(cmd);
+}
+
+/**
+ * Factory for batch validation filter — allows only mutating commands.
+ *
+ * AC: @batch-allowed-commands ac-allowlist
+ * AC: @batch-allowed-commands ac-denylist
+ */
+export function createBatchCommandFilter(): (cmd: CommandMeta) => boolean {
+  return (cmd) => cmd.mutating === true;
+}

--- a/src/cli/commands/derive.ts
+++ b/src/cli/commands/derive.ts
@@ -1,4 +1,5 @@
 import type { Command } from "commander";
+import { markMutating } from "../command-annotations.js";
 import {
   AlignmentIndex,
   createNote,
@@ -401,8 +402,7 @@ function getParentTaskRef(
  * Register the 'derive' command
  */
 export function registerDeriveCommand(program: Command): void {
-  program
-    .command("derive [ref]")
+  markMutating(program.command("derive [ref]"))
     .description("Create task(s) from spec item(s)")
     .option("--all", "Derive tasks for all spec items without linked tasks")
     .option(

--- a/src/cli/commands/inbox.ts
+++ b/src/cli/commands/inbox.ts
@@ -1,5 +1,6 @@
 import * as readline from "node:readline";
 import type { Command } from "commander";
+import { markMutating } from "../command-annotations.js";
 import {
   createInboxItem,
   createTask,
@@ -71,8 +72,7 @@ export function registerInboxCommands(program: Command): void {
     .description("Low-friction capture for ideas (not yet tasks)");
 
   // kspec inbox add <text>
-  inbox
-    .command("add <text>")
+  markMutating(inbox.command("add <text>"))
     .description("Capture an idea quickly")
     .option("--tag <tag...>", "Add tags for categorization")
     .addHelpText(
@@ -159,8 +159,7 @@ Examples:
     });
 
   // kspec inbox promote <ref>
-  inbox
-    .command("promote <ref>")
+  markMutating(inbox.command("promote <ref>"))
     .description("Convert inbox item to task")
     .option("--title <title>", "Task title (prompts if not provided)")
     .option(
@@ -238,8 +237,7 @@ Examples:
     });
 
   // kspec inbox delete <ref>
-  inbox
-    .command("delete <ref>")
+  markMutating(inbox.command("delete <ref>"))
     .description("Remove an inbox item")
     .option("--force", "Skip confirmation")
     .action(async (ref: string, options) => {

--- a/src/cli/commands/item.ts
+++ b/src/cli/commands/item.ts
@@ -1,5 +1,6 @@
 import chalk from "chalk";
 import type { Command } from "commander";
+import { markMutating } from "../command-annotations.js";
 import {
   AlignmentIndex,
   addChildItem,
@@ -560,8 +561,7 @@ export function registerItemCommands(program: Command): void {
     });
 
   // kspec item add - create a new spec item under a parent
-  item
-    .command("add")
+  markMutating(item.command("add"))
     .description("Create a new spec item under a parent")
     .requiredOption(
       "--under <ref>",
@@ -672,8 +672,7 @@ Examples:
     });
 
   // kspec item set - update a spec item field
-  item
-    .command("set <ref>")
+  markMutating(item.command("set <ref>"))
     .description("Update a spec item field")
     .option("--title <title>", "Set title")
     .option("--type <type>", "Set type")
@@ -840,8 +839,7 @@ Examples:
     });
 
   // kspec item delete - delete a spec item
-  item
-    .command("delete <ref>")
+  markMutating(item.command("delete <ref>"))
     .description("Delete a spec item (including nested items)")
     .option("--force", "Skip confirmation")
     .option("--cascade", "Delete item and all descendants")
@@ -1014,8 +1012,7 @@ Examples:
     });
 
   // kspec item patch - update item fields via JSON
-  item
-    .command("patch [ref]")
+  markMutating(item.command("patch [ref]"))
     .description("Update spec item fields via JSON patch")
     .option("--data <json>", "JSON data to patch")
     .option("--bulk", "Read patches from stdin (JSONL or JSON array)")
@@ -1271,8 +1268,7 @@ Examples:
     });
 
   // kspec item note <ref> <message>
-  item
-    .command("note <ref> <message>")
+  markMutating(item.command("note <ref> <message>"))
     .description("Add a note to a spec item")
     .option("--author <author>", "Note author")
     .option("--supersedes <ulid>", "ULID of note this supersedes")
@@ -1439,8 +1435,7 @@ Examples:
     });
 
   // kspec item ac add <ref>
-  acCmd
-    .command("add <ref>")
+  markMutating(acCmd.command("add <ref>"))
     .description("Add an acceptance criterion to a spec item")
     .option("--id <id>", "AC identifier (auto-generated if not provided)")
     .requiredOption("--given <text>", "The precondition (Given...)")
@@ -1485,8 +1480,7 @@ Examples:
     });
 
   // kspec item ac set <ref> <ac-id>
-  acCmd
-    .command("set <ref> <acId>")
+  markMutating(acCmd.command("set <ref> <acId>"))
     .description("Update an acceptance criterion")
     .option("--id <newId>", "Rename the AC ID")
     .option("--given <text>", "Update the precondition")
@@ -1554,8 +1548,7 @@ Examples:
     });
 
   // kspec item ac remove <ref> <ac-id>
-  acCmd
-    .command("remove <ref> <acId>")
+  markMutating(acCmd.command("remove <ref> <acId>"))
     .description("Remove an acceptance criterion")
     .option("--force", "Skip confirmation")
     .action(async (ref: string, acId: string, options) => {

--- a/src/cli/commands/link.ts
+++ b/src/cli/commands/link.ts
@@ -1,5 +1,6 @@
 import chalk from "chalk";
 import type { Command } from "commander";
+import { markMutating } from "../command-annotations.js";
 import {
   type AnyLoadedItem,
   buildIndexes,
@@ -48,8 +49,7 @@ export function registerLinkCommands(program: Command): void {
     .description("Manage relationships between spec items");
 
   // kspec link create
-  link
-    .command("create")
+  markMutating(link.command("create"))
     .description("Create a relationship from one item to another")
     .argument("<from>", "Source item reference (e.g., @my-item)")
     .argument("<to>", "Target item reference (e.g., @other-item)")
@@ -320,8 +320,7 @@ export function registerLinkCommands(program: Command): void {
     });
 
   // kspec link delete
-  link
-    .command("delete")
+  markMutating(link.command("delete"))
     .description("Remove a relationship between items")
     .argument("<from>", "Source item reference")
     .argument("<to>", "Target item reference")

--- a/src/cli/commands/meta.ts
+++ b/src/cli/commands/meta.ts
@@ -12,6 +12,7 @@ import chalk from "chalk";
 import Table from "cli-table3";
 import type { Command } from "commander";
 import { ulid } from "ulid";
+import { markMutating } from "../command-annotations.js";
 import {
   type Agent,
   type Convention,
@@ -768,8 +769,7 @@ export function registerMetaCommands(program: Command): void {
 
   // AC-obs-1: kspec meta observe <type> <content>
   // AC: @meta-observe-cmd from-inbox-conversion
-  meta
-    .command("observe [type] [content]")
+  markMutating(meta.command("observe [type] [content]"))
     .description("Create an observation (friction, success, question, idea)")
     .option(
       "--workflow <ref>",
@@ -1007,8 +1007,7 @@ export function registerMetaCommands(program: Command): void {
     });
 
   // AC-obs-3, AC-obs-6, AC-obs-8: kspec meta promote
-  meta
-    .command("promote <ref>")
+  markMutating(meta.command("promote <ref>"))
     .description("Promote observation to a task")
     .requiredOption("--title <title>", "Task title")
     .option("--priority <priority>", "Task priority (1-5)", "2")
@@ -1091,8 +1090,7 @@ export function registerMetaCommands(program: Command): void {
 
   // AC-obs-4, AC-obs-7, AC-obs-9: kspec meta resolve
   // AC: @trait-multi-ref-batch - Batch support with --refs flag
-  meta
-    .command("resolve [ref] [resolution]")
+  markMutating(meta.command("resolve [ref] [resolution]"))
     .description("Resolve an observation (or multiple with --refs)")
     .option("--refs <refs...>", "Resolve multiple observations by ref")
     .option(
@@ -1243,8 +1241,7 @@ Examples:
     );
 
   // Meta add command - create new meta items
-  meta
-    .command("add <type>")
+  markMutating(meta.command("add <type>"))
     .description("Create a new meta item (agent, workflow, or convention)")
     .option("--id <id>", "Semantic ID (required for agents and workflows)")
     .option("--domain <domain>", "Domain (required for conventions)")
@@ -1415,8 +1412,7 @@ Examples:
     });
 
   // Meta set command - update existing meta items
-  meta
-    .command("set <ref>")
+  markMutating(meta.command("set <ref>"))
     .description("Update an existing meta item")
     .option("--name <name>", "Update name (for agents)")
     .option("--description <desc>", "Update description")
@@ -1540,8 +1536,7 @@ Examples:
     });
 
   // Meta delete command - delete meta items
-  meta
-    .command("delete <ref>")
+  markMutating(meta.command("delete <ref>"))
     .description("Delete a meta item")
     .option("--confirm", "Skip confirmation prompt")
     .action(async (ref: string, options) => {
@@ -1699,8 +1694,7 @@ Examples:
     });
 
   // meta-focus-cmd: kspec meta focus [ref]
-  meta
-    .command("focus [ref]")
+  markMutating(meta.command("focus [ref]"))
     .description("Get or set session focus")
     .option("--clear", "Clear current focus")
     .action(async (ref: string | undefined, options) => {
@@ -1749,8 +1743,7 @@ Examples:
     });
 
   // meta-thread-cmd: kspec meta thread <action> [text]
-  meta
-    .command("thread <action> [text]")
+  markMutating(meta.command("thread <action> [text]"))
     .description("Manage active threads")
     .action(async (action: string, text: string | undefined) => {
       try {
@@ -1841,8 +1834,7 @@ Examples:
     });
 
   // meta-question-cmd: kspec meta question <action> [text]
-  meta
-    .command("question <action> [text]")
+  markMutating(meta.command("question <action> [text]"))
     .description("Manage open questions")
     .action(async (action: string, text: string | undefined) => {
       try {

--- a/src/cli/commands/module.ts
+++ b/src/cli/commands/module.ts
@@ -2,6 +2,7 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import type { Command } from "commander";
 import { ulid } from "ulid";
+import { markMutating } from "../command-annotations.js";
 import {
   buildIndexes,
   checkSlugUniqueness,
@@ -24,8 +25,7 @@ export function registerModuleCommands(program: Command): void {
     .description("Module management commands");
 
   // kspec module add - create a new module YAML file
-  module
-    .command("add")
+  markMutating(module.command("add"))
     .description("Create a new module YAML file")
     .requiredOption("--title <title>", "Module title")
     .requiredOption("--slug <slug>", "Module slug (becomes filename)")

--- a/src/cli/commands/plan-import.ts
+++ b/src/cli/commands/plan-import.ts
@@ -6,6 +6,7 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import type { Command } from "commander";
+import { markMutating } from "../command-annotations.js";
 import {
   addChildItem,
   buildIndexes,
@@ -38,8 +39,7 @@ import { ulid } from "ulid";
  * AC: @plan-import ac-11, ac-15, ac-32
  */
 export function registerPlanImportCommand(planCommand: Command): void {
-  planCommand
-    .command("import <path>")
+  markMutating(planCommand.command("import <path>"))
     .description("Import plan document and auto-generate specs/tasks")
     .requiredOption(
       "--module <ref>",

--- a/src/cli/commands/plan.ts
+++ b/src/cli/commands/plan.ts
@@ -6,6 +6,7 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import type { Command } from "commander";
+import { markMutating } from "../command-annotations.js";
 import {
   createPlan,
   createTask,
@@ -70,8 +71,7 @@ export function registerPlanCommands(program: Command): void {
 
   // kspec plan add
   // AC: @plan-crud ac-1, ac-2
-  plan
-    .command("add")
+  markMutating(plan.command("add"))
     .description("Create a new plan")
     .requiredOption("--title <title>", "Plan title")
     .option("--content <text>", "Plan content (markdown)")
@@ -214,8 +214,7 @@ Examples:
 
   // kspec plan set <ref>
   // AC: @plan-crud ac-3, ac-4
-  plan
-    .command("set <ref>")
+  markMutating(plan.command("set <ref>"))
     .description("Update plan fields")
     .option("--title <title>", "Update title")
     .option("--status <status>", "Update status")
@@ -344,8 +343,7 @@ Examples:
 
   // kspec plan note <ref> <text>
   // AC: @plan-crud ac-9
-  plan
-    .command("note <ref> <text>")
+  markMutating(plan.command("note <ref> <text>"))
     .description("Add a note to a plan")
     .action(async (ref: string, text: string) => {
       try {
@@ -381,8 +379,7 @@ Examples:
 
   // kspec plan derive <ref>
   // AC: @plan-derive ac-5, ac-6
-  plan
-    .command("derive <ref>")
+  markMutating(plan.command("derive <ref>"))
     .description("Create a task from a plan")
     .option("--title <title>", "Override task title")
     .option("--priority <n>", "Set task priority (1-5)", parseInt)

--- a/src/cli/commands/task.ts
+++ b/src/cli/commands/task.ts
@@ -1,6 +1,7 @@
 import * as path from "node:path";
 import chalk from "chalk";
 import type { Command } from "commander";
+import { markMutating } from "../command-annotations.js";
 import {
   checkSlugUniqueness,
   createNote,
@@ -597,8 +598,7 @@ export function registerTaskCommands(program: Command): void {
     });
 
   // kspec task add
-  task
-    .command("add")
+  markMutating(task.command("add"))
     .description("Create a new task")
     .requiredOption("--title <title>", "Task title")
     .option("--description <description>", "Task description")
@@ -795,8 +795,7 @@ Examples:
     });
 
   // kspec task set <ref>
-  task
-    .command("set [ref]")
+  markMutating(task.command("set [ref]"))
     .description("Update task fields")
     .option(
       "--refs <refs...>",
@@ -951,8 +950,7 @@ Examples:
     });
 
   // kspec task patch <ref>
-  task
-    .command("patch <ref>")
+  markMutating(task.command("patch <ref>"))
     .description("Update task with JSON data")
     .option("--data <json>", "JSON object with fields to update")
     .option("--dry-run", "Show what would change without writing")
@@ -1065,8 +1063,7 @@ Examples:
     });
 
   // kspec task start <ref>
-  task
-    .command("start <ref>")
+  markMutating(task.command("start <ref>"))
     .description("Start working on a task (pending -> in_progress)")
     .option("--no-sync", "Skip syncing spec implementation status")
     .action(async (ref: string, options) => {
@@ -1175,8 +1172,7 @@ Examples:
   // kspec task complete <ref> | --refs <refs...>
   // AC: @multi-ref-batch ac-1 - Basic multi-ref syntax
   // AC: @multi-ref-batch ac-2 - Backward compatibility
-  task
-    .command("complete [ref]")
+  markMutating(task.command("complete [ref]"))
     .description("Complete a task (pending_review -> completed)")
     .option("--refs <refs...>", "Complete multiple tasks by ref")
     .option("--reason <reason>", "Completion reason/notes")
@@ -1413,8 +1409,7 @@ Examples:
 
   // kspec task submit <ref>
   // Transitions in_progress → pending_review (code done, awaiting merge)
-  task
-    .command("submit <ref>")
+  markMutating(task.command("submit <ref>"))
     .description("Submit task for review (transitions to pending_review)")
     .action(async (ref: string) => {
       try {
@@ -1453,8 +1448,7 @@ Examples:
     });
 
   // kspec task block <ref>
-  task
-    .command("block <ref>")
+  markMutating(task.command("block <ref>"))
     .description("Block a task")
     .requiredOption("--reason <reason>", "Reason for blocking")
     .action(async (ref: string, options) => {
@@ -1495,8 +1489,7 @@ Examples:
     });
 
   // kspec task unblock <ref>
-  task
-    .command("unblock <ref>")
+  markMutating(task.command("unblock <ref>"))
     .description("Unblock a task")
     .action(async (ref: string) => {
       try {
@@ -1534,8 +1527,7 @@ Examples:
 
   // kspec task cancel <ref> | --refs <refs...>
   // AC: @multi-ref-batch ac-1, ac-2
-  task
-    .command("cancel [ref]")
+  markMutating(task.command("cancel [ref]"))
     .description("Cancel a task")
     .option("--refs <refs...>", "Cancel multiple tasks by ref")
     .option("--reason <reason>", "Cancellation reason")
@@ -1612,8 +1604,7 @@ Examples:
 
   // kspec task reset <ref>
   // AC: @spec-task-reset ac-1, ac-2, ac-3, ac-4, ac-5, ac-6
-  task
-    .command("reset <ref>")
+  markMutating(task.command("reset <ref>"))
     .description("Reset a task to pending state")
     .action(async (ref: string) => {
       try {
@@ -1711,8 +1702,7 @@ Examples:
 
   // kspec task delete <ref> | --refs <refs...>
   // AC: @multi-ref-batch ac-1, ac-2
-  task
-    .command("delete [ref]")
+  markMutating(task.command("delete [ref]"))
     .description("Delete a task permanently")
     .option("--refs <refs...>", "Delete multiple tasks by ref")
     .option("--force", "Skip confirmation (required for --refs)")
@@ -1815,8 +1805,7 @@ Examples:
     });
 
   // kspec task note <ref> <message>
-  task
-    .command("note <ref> <message>")
+  markMutating(task.command("note <ref> <message>"))
     .description("Add a note to a task")
     .option("--author <author>", "Note author")
     .option("--supersedes <ulid>", "ULID of note this supersedes")
@@ -2120,8 +2109,7 @@ Examples:
   const todoCmd = task.command("todo").description("Manage task todos");
 
   // kspec task todo add <ref> <text>
-  todoCmd
-    .command("add <ref> <text>")
+  markMutating(todoCmd.command("add <ref> <text>"))
     .description("Add a todo to a task")
     .option("--author <author>", "Todo author")
     .action(async (ref: string, text: string, options) => {
@@ -2162,8 +2150,7 @@ Examples:
     });
 
   // kspec task todo done <ref> <id>
-  todoCmd
-    .command("done <ref> <id>")
+  markMutating(todoCmd.command("done <ref> <id>"))
     .description("Mark a todo as done")
     .action(async (ref: string, idStr: string) => {
       try {
@@ -2218,8 +2205,7 @@ Examples:
     });
 
   // kspec task todo undone <ref> <id>
-  todoCmd
-    .command("undone <ref> <id>")
+  markMutating(todoCmd.command("undone <ref> <id>"))
     .description("Mark a todo as not done")
     .action(async (ref: string, idStr: string) => {
       try {

--- a/src/cli/commands/trait.ts
+++ b/src/cli/commands/trait.ts
@@ -1,5 +1,6 @@
 import chalk from "chalk";
 import type { Command } from "commander";
+import { markMutating } from "../command-annotations.js";
 import {
   buildIndexes,
   checkSlugUniqueness,
@@ -25,8 +26,7 @@ export function registerTraitCommands(program: Command): void {
 
   // kspec trait add <title>
   // AC: @trait-cli ac-1, ac-2
-  trait
-    .command("add <title>")
+  markMutating(trait.command("add <title>"))
     .description("Create a new trait")
     .option("--description <desc>", "Trait description")
     .option("--slug <slug>", "Human-friendly slug")
@@ -242,8 +242,7 @@ export function registerItemTraitCommands(itemCommand: Command): void {
 
   // kspec item trait add <spec-ref> <trait-ref>
   // AC: @trait-cli ac-5, ac-6, ac-7
-  traitCmd
-    .command("add <specRef> <traitRef>")
+  markMutating(traitCmd.command("add <specRef> <traitRef>"))
     .description("Add a trait to a spec item")
     .action(async (specRef: string, traitRef: string) => {
       try {
@@ -313,8 +312,7 @@ export function registerItemTraitCommands(itemCommand: Command): void {
 
   // kspec item trait remove <spec-ref> <trait-ref>
   // AC: @trait-cli ac-8
-  traitCmd
-    .command("remove <specRef> <traitRef>")
+  markMutating(traitCmd.command("remove <specRef> <traitRef>"))
     .description("Remove a trait from a spec item")
     .action(async (specRef: string, traitRef: string) => {
       try {

--- a/src/cli/commands/workflow.ts
+++ b/src/cli/commands/workflow.ts
@@ -12,6 +12,7 @@ import chalk from "chalk";
 import Table from "cli-table3";
 import type { Command } from "commander";
 import { ulid } from "ulid";
+import { markMutating } from "../command-annotations.js";
 import {
   deleteWorkflowRuns,
   findActiveRuns,
@@ -925,8 +926,7 @@ export function registerWorkflowCommand(program: Command): void {
     .command("workflow")
     .description("Manage workflow runs");
 
-  workflow
-    .command("start")
+  markMutating(workflow.command("start"))
     .description("Start a new workflow run")
     .argument("<workflow-ref>", "Workflow reference (@id or @ulid)")
     .option("--task <task-ref>", "Link run to a task")
@@ -949,16 +949,14 @@ export function registerWorkflowCommand(program: Command): void {
     .option("--json", "Output JSON")
     .action(workflowShow);
 
-  workflow
-    .command("abort")
+  markMutating(workflow.command("abort"))
     .description("Abort an active workflow run")
     .argument("<run-ref>", "Run reference (@ulid or ulid prefix)")
     .option("--reason <text>", "Reason for aborting")
     .option("--json", "Output JSON")
     .action(workflowAbort);
 
-  workflow
-    .command("next")
+  markMutating(workflow.command("next"))
     .description("Advance workflow run to next step")
     .argument("[run-ref]", "Run reference (optional if only one active run)")
     .option("--skip", "Mark current step as skipped")
@@ -976,22 +974,19 @@ export function registerWorkflowCommand(program: Command): void {
     .option("--json", "Output JSON")
     .action(workflowNext);
 
-  workflow
-    .command("pause")
+  markMutating(workflow.command("pause"))
     .description("Pause an active workflow run")
     .argument("<run-ref>", "Run reference (@ulid or ulid prefix)")
     .option("--json", "Output JSON")
     .action(workflowPause);
 
-  workflow
-    .command("resume")
+  markMutating(workflow.command("resume"))
     .description("Resume a paused workflow run")
     .argument("<run-ref>", "Run reference (@ulid or ulid prefix)")
     .option("--json", "Output JSON")
     .action(workflowResume);
 
-  workflow
-    .command("prune")
+  markMutating(workflow.command("prune"))
     .description("Remove old or stale workflow runs")
     .option(
       "--older-than <duration>",

--- a/src/cli/introspection.ts
+++ b/src/cli/introspection.ts
@@ -7,6 +7,7 @@
  */
 
 import type { Command, Option as CommanderOption } from "commander";
+import { getAnnotation } from "./command-annotations.js";
 
 /**
  * Metadata for a single command option
@@ -60,6 +61,8 @@ export interface CommandMeta {
   subcommands: CommandMeta[];
   /** Whether this command is hidden */
   hidden: boolean;
+  /** Whether this command mutates kspec state (annotated via markMutating) */
+  mutating: boolean;
 }
 
 /**
@@ -128,6 +131,7 @@ export function extractCommandTree(
     options,
     subcommands,
     hidden: isHidden(command),
+    mutating: getAnnotation(command)?.mutating ?? false,
   };
 }
 

--- a/tests/batch-allowed-commands.test.ts
+++ b/tests/batch-allowed-commands.test.ts
@@ -1,0 +1,326 @@
+import { describe, it, expect } from "vitest";
+import { Command } from "commander";
+import {
+  markMutating,
+  getAnnotation,
+  createBatchCommandFilter,
+} from "../src/cli/command-annotations.js";
+import { extractCommandTree } from "../src/cli/introspection.js";
+import type { CommandMeta } from "../src/cli/introspection.js";
+import { validateBatchCommands } from "../src/cli/batch-exec.js";
+
+// ── Test Program ────────────────────────────────────────────────────
+// Minimal annotated Commander program for isolated testing.
+
+function createAnnotatedTestProgram(): Command {
+  const program = new Command("kspec");
+
+  // task group with mixed mutating/read-only subcommands
+  const task = program.command("task").description("Task management");
+  markMutating(task.command("add"))
+    .description("Add a task")
+    .requiredOption("--title <title>", "Task title");
+  task.command("list").description("List tasks"); // read-only
+  markMutating(task.command("start"))
+    .description("Start a task")
+    .argument("<ref>", "Task reference");
+
+  // mutating leaf command
+  markMutating(program.command("derive [ref]")).description(
+    "Derive task from spec",
+  );
+
+  // read-only leaf command
+  program.command("search <pattern>").description("Search for items");
+
+  // batch command for nested-batch test
+  program.command("batch").description("Batch execute commands");
+
+  return program;
+}
+
+function getAnnotatedTree(): CommandMeta {
+  return extractCommandTree(createAnnotatedTestProgram());
+}
+
+// ── Annotation Registry Tests ───────────────────────────────────────
+
+describe("command-annotations", () => {
+  it("markMutating returns the same Command instance (chaining)", () => {
+    const cmd = new Command("test");
+    const result = markMutating(cmd);
+    expect(result).toBe(cmd);
+  });
+
+  it("getAnnotation returns mutating: true for annotated commands", () => {
+    const cmd = new Command("test");
+    markMutating(cmd);
+    expect(getAnnotation(cmd)).toEqual({ mutating: true });
+  });
+
+  it("getAnnotation returns undefined for unannotated commands", () => {
+    const cmd = new Command("test");
+    expect(getAnnotation(cmd)).toBeUndefined();
+  });
+
+  it("default annotation is read-only (mutating: false in CommandMeta)", () => {
+    const tree = getAnnotatedTree();
+    const search = tree.subcommands.find((c) => c.name === "search");
+    expect(search).toBeDefined();
+    expect(search!.mutating).toBe(false);
+  });
+});
+
+// ── CommandMeta.mutating Tests ──────────────────────────────────────
+
+describe("CommandMeta.mutating via extractCommandTree", () => {
+  const tree = getAnnotatedTree();
+
+  it("annotated leaf command has mutating: true", () => {
+    const derive = tree.subcommands.find((c) => c.name === "derive");
+    expect(derive).toBeDefined();
+    expect(derive!.mutating).toBe(true);
+  });
+
+  it("annotated nested command has mutating: true", () => {
+    const task = tree.subcommands.find((c) => c.name === "task");
+    const add = task!.subcommands.find((c) => c.name === "add");
+    expect(add).toBeDefined();
+    expect(add!.mutating).toBe(true);
+  });
+
+  it("unannotated leaf command has mutating: false", () => {
+    const search = tree.subcommands.find((c) => c.name === "search");
+    expect(search!.mutating).toBe(false);
+  });
+
+  it("unannotated nested command has mutating: false", () => {
+    const task = tree.subcommands.find((c) => c.name === "task");
+    const list = task!.subcommands.find((c) => c.name === "list");
+    expect(list!.mutating).toBe(false);
+  });
+
+  it("command group itself has mutating: false", () => {
+    const task = tree.subcommands.find((c) => c.name === "task");
+    expect(task!.mutating).toBe(false);
+  });
+});
+
+// ── AC: ac-allowlist ────────────────────────────────────────────────
+
+describe("ac-allowlist: mutating commands accepted in batch", () => {
+  const tree = getAnnotatedTree();
+  const filter = createBatchCommandFilter();
+
+  it("mutating leaf command passes filter", () => {
+    const result = validateBatchCommands(
+      [{ command: "derive", args: { ref: "@spec" } }],
+      tree,
+      { commandFilter: filter },
+    );
+    const rejected = result.errors.filter(
+      (e) => e.type === "rejected_command",
+    );
+    expect(rejected).toHaveLength(0);
+  });
+
+  it("mutating nested command passes filter", () => {
+    const result = validateBatchCommands(
+      [{ command: "task add", args: { title: "Test" } }],
+      tree,
+      { commandFilter: filter },
+    );
+    const rejected = result.errors.filter(
+      (e) => e.type === "rejected_command",
+    );
+    expect(rejected).toHaveLength(0);
+  });
+
+  it("batch with all mutating commands validates cleanly", () => {
+    const result = validateBatchCommands(
+      [
+        { command: "task add", args: { title: "One" } },
+        { command: "task start", args: { ref: "@t" } },
+        { command: "derive", args: { ref: "@s" } },
+      ],
+      tree,
+      { commandFilter: filter },
+    );
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it("createBatchCommandFilter accepts commands with mutating: true", () => {
+    const filterFn = createBatchCommandFilter();
+    const meta: CommandMeta = {
+      name: "add",
+      fullPath: ["kspec", "task", "add"],
+      description: "",
+      aliases: [],
+      arguments: [],
+      options: [],
+      subcommands: [],
+      hidden: false,
+      mutating: true,
+    };
+    expect(filterFn(meta)).toBe(true);
+  });
+});
+
+// ── AC: ac-denylist ─────────────────────────────────────────────────
+
+describe("ac-denylist: read-only commands rejected in batch", () => {
+  const tree = getAnnotatedTree();
+  const filter = createBatchCommandFilter();
+
+  it("read-only leaf command is rejected", () => {
+    const result = validateBatchCommands(
+      [{ command: "search", args: { pattern: "test" } }],
+      tree,
+      { commandFilter: filter },
+    );
+    expect(result.valid).toBe(false);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].type).toBe("rejected_command");
+  });
+
+  it("read-only nested command is rejected", () => {
+    const result = validateBatchCommands(
+      [{ command: "task list", args: {} }],
+      tree,
+      { commandFilter: filter },
+    );
+    expect(result.valid).toBe(false);
+    expect(result.errors[0].type).toBe("rejected_command");
+  });
+
+  it("rejection message explains batch is for mutating operations", () => {
+    const result = validateBatchCommands(
+      [{ command: "search", args: { pattern: "test" } }],
+      tree,
+      { commandFilter: filter },
+    );
+    expect(result.errors[0].message).toContain("mutating");
+    expect(result.errors[0].message).toContain("not allowed in batch");
+  });
+
+  it("createBatchCommandFilter rejects commands with mutating: false", () => {
+    const filterFn = createBatchCommandFilter();
+    const meta: CommandMeta = {
+      name: "list",
+      fullPath: ["kspec", "task", "list"],
+      description: "",
+      aliases: [],
+      arguments: [],
+      options: [],
+      subcommands: [],
+      hidden: false,
+      mutating: false,
+    };
+    expect(filterFn(meta)).toBe(false);
+  });
+});
+
+// ── AC: ac-batch-itself ─────────────────────────────────────────────
+
+describe("ac-batch-itself: nested batch commands rejected", () => {
+  const tree = getAnnotatedTree();
+  const filter = createBatchCommandFilter();
+
+  it("batch command is rejected with specific message", () => {
+    const result = validateBatchCommands(
+      [{ command: "batch", args: {} }],
+      tree,
+      { commandFilter: filter },
+    );
+    expect(result.valid).toBe(false);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].type).toBe("rejected_command");
+    expect(result.errors[0].message).toBe(
+      "Nested batch commands are not allowed",
+    );
+  });
+
+  it("nested batch rejection is distinct from read-only rejection", () => {
+    const result = validateBatchCommands(
+      [
+        { command: "batch", args: {}, id: "nested" },
+        { command: "search", args: { pattern: "x" }, id: "readonly" },
+      ],
+      tree,
+      { commandFilter: filter },
+    );
+    expect(result.errors).toHaveLength(2);
+
+    const nestedErr = result.errors.find((e) => e.id === "nested");
+    const readonlyErr = result.errors.find((e) => e.id === "readonly");
+
+    expect(nestedErr!.message).toBe("Nested batch commands are not allowed");
+    expect(readonlyErr!.message).toContain("mutating");
+    expect(nestedErr!.message).not.toEqual(readonlyErr!.message);
+  });
+
+  it("nested batch rejection happens before commandFilter check", () => {
+    // Even without a filter, batch should be rejected
+    const result = validateBatchCommands(
+      [{ command: "batch", args: {} }],
+      tree,
+      // No commandFilter — batch rejection is unconditional
+    );
+    expect(result.valid).toBe(false);
+    expect(result.errors[0].type).toBe("rejected_command");
+    expect(result.errors[0].message).toBe(
+      "Nested batch commands are not allowed",
+    );
+  });
+});
+
+// ── Integration Tests ───────────────────────────────────────────────
+
+describe("batch-allowed-commands integration", () => {
+  const tree = getAnnotatedTree();
+  const filter = createBatchCommandFilter();
+
+  it("mixed batch: only read-only and nested-batch rejected", () => {
+    const result = validateBatchCommands(
+      [
+        { command: "task add", args: { title: "OK" }, id: "mutating-1" },
+        { command: "task list", args: {}, id: "readonly-1" },
+        { command: "derive", args: { ref: "@s" }, id: "mutating-2" },
+        { command: "batch", args: {}, id: "nested-batch" },
+        { command: "search", args: { pattern: "x" }, id: "readonly-2" },
+      ],
+      tree,
+      { commandFilter: filter },
+    );
+    expect(result.valid).toBe(false);
+    // 3 errors: readonly-1, nested-batch, readonly-2
+    expect(result.errors).toHaveLength(3);
+
+    const errorIds = result.errors.map((e) => e.id);
+    expect(errorIds).toContain("readonly-1");
+    expect(errorIds).toContain("nested-batch");
+    expect(errorIds).toContain("readonly-2");
+
+    // mutating commands are NOT in errors
+    expect(errorIds).not.toContain("mutating-1");
+    expect(errorIds).not.toContain("mutating-2");
+  });
+
+  it("mixed batch produces distinct error messages for each rejection type", () => {
+    const result = validateBatchCommands(
+      [
+        { command: "batch", args: {}, id: "nested" },
+        { command: "task list", args: {}, id: "readonly" },
+      ],
+      tree,
+      { commandFilter: filter },
+    );
+
+    const messages = result.errors.map((e) => e.message);
+    // Nested batch has its own message
+    expect(messages).toContain("Nested batch commands are not allowed");
+    // Read-only has the mutating explanation
+    expect(messages.some((m) => m.includes("mutating"))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Creates a WeakMap-based annotation registry (`command-annotations.ts`) with `markMutating()`, `getAnnotation()`, and `createBatchCommandFilter()` — no monkey-patching Commander internals
- Adds `mutating: boolean` field to `CommandMeta` in introspection (defaults to `false` for deny-by-default behavior)
- Annotates all 49 mutating commands across 11 registration files (task, item, inbox, trait, meta, plan, plan-import, module, derive, link, workflow)
- Updates batch-exec rejection message to explain "Only mutating commands can be used in batch"
- Adds nested-batch rejection before the `commandFilter` check with distinct error message

## AC Coverage

| AC | Coverage |
|----|----------|
| `ac-allowlist` | Tests verify mutating commands pass filter, `CommandMeta.mutating` is `true` for annotated commands, batch with all mutating validates cleanly |
| `ac-denylist` | Tests verify read-only commands rejected with `rejected_command` type, message contains "mutating" explanation, `CommandMeta.mutating` is `false` for unannotated |
| `ac-batch-itself` | Tests verify `batch` command rejected with "Nested batch commands are not allowed", rejection happens even without commandFilter |

## Test plan

- [x] 22 new tests in `tests/batch-allowed-commands.test.ts` — all pass
- [x] 40 existing `tests/batch-schema.test.ts` tests — no regressions
- [x] `npm run build` — TypeScript compiles cleanly
- [x] Full test suite — 1784/1785 pass (1 pre-existing daemon-executable failure)

Task: @implement-batch-allowed-commands
Spec: @batch-allowed-commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)