### PR TITLE
feat(skills): add codex skill for GPT-5.3-codex review integration

### DIFF
--- a/.claude/skills/codex/SKILL.md
+++ b/.claude/skills/codex/SKILL.md
@@ -70,11 +70,12 @@ If no PR is found, error: "No PR found for task @task-ref. Create a PR first wit
 For straightforward diff review, prefer the native `codex exec review` subcommand:
 
 ```bash
-codex exec review \
+codex exec \
   -m gpt-5.3-codex \
   -c model_reasoning_effort="high" \
   -s danger-full-access \
   --skip-git-repo-check \
+  review \
   "$(cat <<'PROMPT'
 Also check for:
 - AC coverage: every spec AC should have test with `// AC: @spec-ref ac-N` annotation
@@ -82,20 +83,9 @@ Also check for:
 - Test quality: no fluff tests, prefer E2E over unit
 
 After reviewing, post your review to GitHub using `gh pr review <NUMBER>`.
-For inline comments, write a JSON body file and post via gh api:
-
-```json
-// Write to /tmp/codex-pr-review-body.json
-{
-  "event": "REQUEST_CHANGES",
-  "body": "## Review Summary\n\nOverall assessment...",
-  "comments": [
-    {"path": "src/file.ts", "line": 42, "body": "Review comment (markdown)"}
-  ]
-}
-```
-
-Then post: `gh api repos/{owner}/{repo}/pulls/<NUMBER>/reviews --method POST --input /tmp/codex-pr-review-body.json`
+For inline comments, write a JSON body to /tmp/codex-pr-review-body.json with this structure:
+  {"event":"REQUEST_CHANGES","body":"summary","comments":[{"path":"src/file.ts","line":42,"body":"comment"}]}
+Then post: gh api repos/{owner}/{repo}/pulls/<NUMBER>/reviews --method POST --input /tmp/codex-pr-review-body.json
 
 Also write the full review to /tmp/codex-pr-<NUMBER>-review.md
 


### PR DESCRIPTION
## Summary
- Adds `/codex` skill for delegating code analysis and reviews to OpenAI Codex CLI (GPT-5.3-codex)
- Four modes with preset reasoning: PR review (high), plan review (high), spec review (high), general (medium)
- PR reviews post inline GitHub comments via `gh api --input` with proper JSON payload
- Plan/spec reviews write structured feedback to `/tmp/codex-*.md`
- Uses `danger-full-access` sandbox so Codex can run `gh`, `kspec`, etc. directly
- Includes `codex exec review` native subcommand path for straightforward diff reviews
- Fixes identified by Codex self-review: correct CLI flags, sandbox policy, API payload format, severity labels, resume syntax

## Test plan
- [x] Skill auto-discovered by Claude Code (appears in available skills list)
- [x] Self-reviewed by Codex — found and fixed 4 MUST-FIX and 5 SHOULD-FIX issues
- [ ] Manual test: `/codex review #<PR>` posts inline comments
- [ ] Manual test: `/codex review-plan @plan-slug` writes feedback to `/tmp`

Generated with [Claude Code](https://claude.ai/code)