### PR TITLE
fix(ralph): increase ACP prompt timeout from 5min to 30min

### DIFF
--- a/src/cli/commands/ralph.ts
+++ b/src/cli/commands/ralph.ts
@@ -43,6 +43,7 @@ import {
   createTranslator,
   DEFAULT_SUBAGENT_PREFIX,
   DEFAULT_SUBAGENT_TIMEOUT,
+  RALPH_PROMPT_TIMEOUT,
   runSubagent,
   type SubagentContext,
 } from "../../ralph/index.js";
@@ -1238,6 +1239,10 @@ export function registerRalphCommand(program: Command): void {
                       clientInfo: {
                         name: "kspec-ralph",
                         version: packageVersion,
+                      },
+                      methodTimeouts: {
+                        "session/prompt": RALPH_PROMPT_TIMEOUT,
+                        "session/resume": RALPH_PROMPT_TIMEOUT,
                       },
                     },
                   });

--- a/src/ralph/index.ts
+++ b/src/ralph/index.ts
@@ -29,6 +29,7 @@ export {
   buildSubagentPrompt,
   DEFAULT_SUBAGENT_PREFIX,
   DEFAULT_SUBAGENT_TIMEOUT,
+  RALPH_PROMPT_TIMEOUT,
   runSubagent,
   type SubagentConfig,
   type SubagentContext,

--- a/src/ralph/subagent.ts
+++ b/src/ralph/subagent.ts
@@ -79,6 +79,14 @@ export const DEFAULT_SUBAGENT_TIMEOUT = 10 * 60 * 1000;
 /** Default output prefix for subagent */
 export const DEFAULT_SUBAGENT_PREFIX = "[REVIEW SUBAGENT]";
 
+/**
+ * Default ACP prompt timeout for ralph agents: 30 minutes.
+ * The framing layer default (5 min) is too aggressive — API slowness,
+ * extended thinking, and large context processing can exceed it even
+ * with the keepalive mechanism (which resets on tool calls/notifications).
+ */
+export const RALPH_PROMPT_TIMEOUT = 30 * 60 * 1000;
+
 // ============================================================================
 // Prompt Builder
 // ============================================================================
@@ -176,6 +184,10 @@ export async function runSubagent(
         clientInfo: {
           name: "kspec-ralph-subagent",
           version: "1.0.0",
+        },
+        methodTimeouts: {
+          "session/prompt": RALPH_PROMPT_TIMEOUT,
+          "session/resume": RALPH_PROMPT_TIMEOUT,
         },
       },
     });


### PR DESCRIPTION
## Summary

- Adds `RALPH_PROMPT_TIMEOUT` constant (30 minutes) for ralph agent ACP communication
- Applies timeout override to both main ralph agent and review subagent spawn sites via `methodTimeouts`
- Keeps the 5-minute default for non-ralph ACP usage unchanged

The framing layer's keepalive resets the timer on tool calls/notifications, but API slowness and extended thinking can still exceed 5 minutes between activity. 30 minutes gives sufficient headroom.

## Test plan

- [x] All 104 ralph tests pass
- [x] All 43 ACP tests pass
- [x] Build succeeds

Task: @01KGVB8X

🤖 Generated with [Claude Code](https://claude.com/claude-code)