### PR TITLE
fix(ralph): handle array-of-objects in tool output

### DIFF
--- a/src/ralph/events.ts
+++ b/src/ralph/events.ts
@@ -209,7 +209,7 @@ function extractToolOutput(
 ): string | undefined {
   // Try rawOutput first
   if (update.rawOutput !== undefined) {
-    return truncateOutput(String(update.rawOutput));
+    return truncateOutput(stringify(update.rawOutput));
   }
 
   // Try _meta.claudeCode.toolResponse (Claude Code pattern)
@@ -226,13 +226,13 @@ function extractToolOutput(
           (toolResponse.stderr ? `\n${toolResponse.stderr}` : "");
         return truncateOutput(combined.trim());
       }
-      return truncateOutput(String(toolResponse));
+      return truncateOutput(stringify(toolResponse));
     }
   }
 
   // Try output field
   if (update.output !== undefined) {
-    return truncateOutput(String(update.output));
+    return truncateOutput(stringify(update.output));
   }
 
   return undefined;
@@ -245,7 +245,7 @@ function extractOriginalOutput(
   update: Record<string, unknown>,
 ): string | undefined {
   if (update.rawOutput !== undefined) {
-    return String(update.rawOutput);
+    return stringify(update.rawOutput);
   }
 
   const meta = update._meta as Record<string, unknown> | undefined;
@@ -263,10 +263,35 @@ function extractOriginalOutput(
   }
 
   if (update.output !== undefined) {
-    return String(update.output);
+    return stringify(update.output);
   }
 
   return undefined;
+}
+
+/**
+ * Safely stringify a value that may be a string, array of content blocks, or object.
+ * Handles ACP tool results delivered as arrays like [{type:'text',text:'...'},...]
+ */
+function stringify(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (Array.isArray(value)) {
+    // Array of content blocks: extract .text fields
+    const texts = value
+      .map((item) =>
+        typeof item === "string"
+          ? item
+          : typeof item === "object" && item !== null && "text" in item
+            ? String((item as { text: unknown }).text)
+            : JSON.stringify(item),
+      )
+      .filter(Boolean);
+    return texts.join("\n");
+  }
+  if (typeof value === "object" && value !== null) {
+    return JSON.stringify(value);
+  }
+  return String(value);
 }
 
 /**

--- a/tests/ralph.test.ts
+++ b/tests/ralph.test.ts
@@ -822,6 +822,82 @@ describe('ralph event translator', () => {
         status: 'running',
       });
     });
+
+    it('handles rawOutput as array of content blocks instead of [object Object]', () => {
+      const translator = createTranslator();
+
+      translator.translate({
+        sessionUpdate: 'tool_call',
+        toolCallId: 'toolu_arr1',
+        rawInput: { command: 'some-cmd' },
+        _meta: { claudeCode: { toolName: 'Bash' } },
+      } as SessionUpdate);
+
+      const event = translator.translate({
+        sessionUpdate: 'tool_call_update',
+        toolCallId: 'toolu_arr1',
+        status: 'completed',
+        rawOutput: [
+          { type: 'text', text: 'Line one' },
+          { type: 'text', text: 'Line two' },
+        ],
+      } as SessionUpdate);
+
+      expect(event).not.toBeNull();
+      const data = event!.data as { output: string };
+      expect(data.output).toContain('Line one');
+      expect(data.output).toContain('Line two');
+      expect(data.output).not.toContain('[object Object]');
+    });
+
+    it('handles output field as array of content blocks', () => {
+      const translator = createTranslator();
+
+      translator.translate({
+        sessionUpdate: 'tool_call',
+        toolCallId: 'toolu_arr2',
+        rawInput: {},
+        _meta: { claudeCode: { toolName: 'Read' } },
+      } as SessionUpdate);
+
+      const event = translator.translate({
+        sessionUpdate: 'tool_call_update',
+        toolCallId: 'toolu_arr2',
+        status: 'completed',
+        output: [
+          { type: 'text', text: 'File content here' },
+        ],
+      } as SessionUpdate);
+
+      expect(event).not.toBeNull();
+      const data = event!.data as { output: string };
+      expect(data.output).toBe('File content here');
+      expect(data.output).not.toContain('[object Object]');
+    });
+
+    it('handles output as plain object via JSON.stringify', () => {
+      const translator = createTranslator();
+
+      translator.translate({
+        sessionUpdate: 'tool_call',
+        toolCallId: 'toolu_obj1',
+        rawInput: {},
+        _meta: { claudeCode: { toolName: 'Task' } },
+      } as SessionUpdate);
+
+      const event = translator.translate({
+        sessionUpdate: 'tool_call_update',
+        toolCallId: 'toolu_obj1',
+        status: 'completed',
+        rawOutput: { result: 'success', count: 42 },
+      } as SessionUpdate);
+
+      expect(event).not.toBeNull();
+      const data = event!.data as { output: string };
+      expect(data.output).toContain('"result"');
+      expect(data.output).toContain('success');
+      expect(data.output).not.toContain('[object Object]');
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

- Fixes ralph log rendering `[object Object],[object Object]` when ACP delivers tool results as arrays of content blocks
- Added `stringify()` helper in `events.ts` that properly extracts `.text` fields from content block arrays and JSON.stringifies plain objects
- Replaced all 5 `String()` call sites in `extractToolOutput()` and `extractOriginalOutput()`

## Test plan

- [x] Added 3 test cases: array of content blocks, single content block, plain object
- [x] All 55 ralph tests pass

Task: @01KGVARW

🤖 Generated with [Claude Code](https://claude.com/claude-code)