### PR TITLE
docs(skill): add YAML quoting and trait slug guidance to spec-plan

### DIFF
--- a/.claude/skills/spec-plan/SKILL.md
+++ b/.claude/skills/spec-plan/SKILL.md
@@ -90,7 +90,7 @@ The import path uses structured markdown documents. The parser (`parsePlanDocume
   type: feature
   parent: "@auth"
   traits:
-    - error-guidance
+    - trait-error-guidance
   acceptance_criteria:
     - id: ac-1
       given: User clicks "Sign in with Google"
@@ -153,7 +153,9 @@ kspec item trait add @spec @trait
 # ❌ Broken - short name
 traits:
   - json-output
+```
 
+```yaml
 # ✅ Correct - full slug
 traits:
   - trait-json-output
@@ -186,24 +188,29 @@ Plans track status: `draft` -> `approved` -> `active` -> `completed` (or `reject
 
 Plan documents embed YAML code blocks that are parsed as structured data. Common pitfalls:
 
-### Embedded Quotes Break Parsing
+### Mixed Quoting Breaks Parsing
 
-YAML scalar values containing double quotes cause parse failures:
+Mixing quoted and unquoted text in a single value causes parse failures:
 
 ```yaml
-# ❌ Broken - embedded quotes in scalar
+# ❌ Broken - quoted text followed by unquoted text
 acceptance_criteria:
   - id: ac-1
-    when: "kspec foo" is run  # Parser sees this as malformed
+    when: "kspec foo" is run  # Parser sees malformed mixed quoting
+```
 
-# ✅ Fixed - use block scalar or avoid inner quotes
+```yaml
+# ✅ Fixed - use block scalar for complex text
 acceptance_criteria:
   - id: ac-1
     when: |
       "kspec foo" is run
+```
 
-  # Or rephrase to avoid quotes
-  - id: ac-2
+```yaml
+# ✅ Or rephrase to avoid quotes entirely
+acceptance_criteria:
+  - id: ac-1
     when: user runs kspec foo command
 ```
 


### PR DESCRIPTION
## Summary

- Added **YAML Syntax Issues** section to spec-plan skill documenting:
  - Embedded quotes breaking YAML parsing in AC fields
  - Colons in values requiring quoting
  - Best practices (avoid inner quotes, use block scalars, dry-run first)

- Updated **Trait Considerations** section:
  - Changed examples to use full trait slugs (`trait-json-output` instead of `json-output`)
  - Added explicit warning that plan import only auto-prefixes `@`, not `@trait-`
  - Added good/bad examples

## Test plan

- [x] Documentation changes only
- [x] Examples are syntactically valid YAML

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Task: @01KGTNV7
Task: @01KGTNXP