### PR TITLE
Fix relationship ref deduplication to use resolved ULIDs

### DIFF
--- a/src/cli/commands/item.ts
+++ b/src/cli/commands/item.ts
@@ -798,7 +798,8 @@ Examples:
         }
 
         // Helper to validate relationship refs (must exist and be a spec item, not a task)
-        const validateRelationshipRef = (refStr: string, flagName: string): void => {
+        // Returns { ulid, canonicalRef } for deduplication and user-friendly storage
+        const validateRelationshipRef = (refStr: string, flagName: string): { ulid: string; canonicalRef: string } => {
           const refResult = refIndex.resolve(refStr);
           if (!refResult.ok) {
             error(errors.reference.itemNotFound(refStr));
@@ -810,21 +811,41 @@ Examples:
             error(`${flagName} reference must be a spec item, not a task: ${refStr}`);
             process.exit(EXIT_CODES.USAGE_ERROR);
           }
+          // Use primary slug if available for user-friendly storage, otherwise ULID
+          const item = refResult.item as LoadedSpecItem;
+          const canonicalRef = item.slugs?.[0] ? `@${item.slugs[0]}` : `@${refResult.ulid}`;
+          return { ulid: refResult.ulid, canonicalRef };
+        };
+
+        // Helper to resolve existing refs to ULIDs for deduplication
+        const resolveRefsToUlids = (refs: string[]): Set<string> => {
+          const ulids = new Set<string>();
+          for (const ref of refs) {
+            const result = refIndex.resolve(ref);
+            if (result.ok) {
+              ulids.add(result.ulid);
+            }
+          }
+          return ulids;
         };
 
         // AC: @item-set ac-5 - --relates-to validation
+        // Store resolved ULID for deduplication and canonical ref for storage
+        let relatesToResolved: { ulid: string; canonicalRef: string } | undefined;
         if (options.relatesTo) {
-          validateRelationshipRef(options.relatesTo, "--relates-to");
+          relatesToResolved = validateRelationshipRef(options.relatesTo, "--relates-to");
         }
 
         // AC: @item-set ac-6 - --implements validation
+        let implementsResolved: { ulid: string; canonicalRef: string } | undefined;
         if (options.implements) {
-          validateRelationshipRef(options.implements, "--implements");
+          implementsResolved = validateRelationshipRef(options.implements, "--implements");
         }
 
         // AC: @item-set ac-7 - --depends-on validation
+        let dependsOnResolved: { ulid: string; canonicalRef: string } | undefined;
         if (options.dependsOn) {
-          validateRelationshipRef(options.dependsOn, "--depends-on");
+          dependsOnResolved = validateRelationshipRef(options.dependsOn, "--depends-on");
         }
 
         // Build updates object
@@ -870,10 +891,12 @@ Examples:
         }
 
         // AC: @item-set ac-5 - Handle relates_to (append semantics)
-        if (options.relatesTo) {
+        // Uses resolved ULIDs for deduplication and stores canonical slug format
+        if (relatesToResolved) {
           const current = foundItem.relates_to || [];
-          if (!current.includes(options.relatesTo)) {
-            updates.relates_to = [...current, options.relatesTo];
+          const existingUlids = resolveRefsToUlids(current);
+          if (!existingUlids.has(relatesToResolved.ulid)) {
+            updates.relates_to = [...current, relatesToResolved.canonicalRef];
           }
         }
         if (options.clearRelatesTo) {
@@ -881,10 +904,12 @@ Examples:
         }
 
         // AC: @item-set ac-6 - Handle implements (append semantics)
-        if (options.implements) {
+        // Uses resolved ULIDs for deduplication and stores canonical slug format
+        if (implementsResolved) {
           const current = foundItem.implements || [];
-          if (!current.includes(options.implements)) {
-            updates.implements = [...current, options.implements];
+          const existingUlids = resolveRefsToUlids(current);
+          if (!existingUlids.has(implementsResolved.ulid)) {
+            updates.implements = [...current, implementsResolved.canonicalRef];
           }
         }
         if (options.clearImplements) {
@@ -892,10 +917,12 @@ Examples:
         }
 
         // AC: @item-set ac-7 - Handle depends_on (append semantics)
-        if (options.dependsOn) {
+        // Uses resolved ULIDs for deduplication and stores canonical slug format
+        if (dependsOnResolved) {
           const current = foundItem.depends_on || [];
-          if (!current.includes(options.dependsOn)) {
-            updates.depends_on = [...current, options.dependsOn];
+          const existingUlids = resolveRefsToUlids(current);
+          if (!existingUlids.has(dependsOnResolved.ulid)) {
+            updates.depends_on = [...current, dependsOnResolved.canonicalRef];
           }
         }
         if (options.clearDependsOn) {

--- a/tests/item-set-relationships.test.ts
+++ b/tests/item-set-relationships.test.ts
@@ -73,7 +73,27 @@ describe('Item Set Relationship Flags', () => {
 
       // Verify only one reference
       const item = kspecJson<{ relates_to: string[] }>('item get @item-a', tempDir);
-      expect(item.relates_to.filter(r => r === '@item-b')).toHaveLength(1);
+      // After fix: stores canonical @ULID format, so check count by resolved identity
+      expect(item.relates_to).toHaveLength(1);
+    });
+
+    it('should not add duplicate relates_to via mixed ref forms (slug then ULID)', () => {
+      // Create two items
+      kspec('item add --under @test-core --title "Item A" --type requirement --slug item-a', tempDir);
+      kspec('item add --under @test-core --title "Item B" --type requirement --slug item-b', tempDir);
+
+      // Get the ULID of item-b
+      const itemB = kspecJson<{ _ulid: string }>('item get @item-b', tempDir);
+      const itemBUlid = itemB._ulid;
+
+      // Add relationship via slug
+      kspec('item set @item-a --relates-to @item-b', tempDir);
+      // Try to add again via ULID
+      kspec(`item set @item-a --relates-to @${itemBUlid}`, tempDir);
+
+      // Verify only one reference (semantic deduplication)
+      const item = kspecJson<{ relates_to: string[] }>('item get @item-a', tempDir);
+      expect(item.relates_to).toHaveLength(1);
     });
 
     it('should error when relates_to reference does not exist', () => {
@@ -126,6 +146,24 @@ describe('Item Set Relationship Flags', () => {
       const result = kspec('item set @req --implements @nonexistent', tempDir, { expectFail: true });
       expect(result.exitCode).toBe(3); // NOT_FOUND
     });
+
+    it('should not add duplicate implements via mixed ref forms (slug then ULID)', () => {
+      kspec('item add --under @test-core --title "Feature X" --type feature --slug feature-x', tempDir);
+      kspec('item add --under @test-core --title "Requirement Y" --type requirement --slug req-y', tempDir);
+
+      // Get the ULID of feature-x
+      const featureX = kspecJson<{ _ulid: string }>('item get @feature-x', tempDir);
+      const featureXUlid = featureX._ulid;
+
+      // Add relationship via slug
+      kspec('item set @req-y --implements @feature-x', tempDir);
+      // Try to add again via ULID
+      kspec(`item set @req-y --implements @${featureXUlid}`, tempDir);
+
+      // Verify only one reference (semantic deduplication)
+      const item = kspecJson<{ implements: string[] }>('item get @req-y', tempDir);
+      expect(item.implements).toHaveLength(1);
+    });
   });
 
   describe('--depends-on flag', () => {
@@ -159,6 +197,24 @@ describe('Item Set Relationship Flags', () => {
 
       const result = kspec('item set @dependent --depends-on @nonexistent', tempDir, { expectFail: true });
       expect(result.exitCode).toBe(3); // NOT_FOUND
+    });
+
+    it('should not add duplicate depends_on via mixed ref forms (slug then ULID)', () => {
+      kspec('item add --under @test-core --title "Prereq" --type requirement --slug prereq', tempDir);
+      kspec('item add --under @test-core --title "Dependent" --type requirement --slug dependent', tempDir);
+
+      // Get the ULID of prereq
+      const prereq = kspecJson<{ _ulid: string }>('item get @prereq', tempDir);
+      const prereqUlid = prereq._ulid;
+
+      // Add relationship via slug
+      kspec('item set @dependent --depends-on @prereq', tempDir);
+      // Try to add again via ULID
+      kspec(`item set @dependent --depends-on @${prereqUlid}`, tempDir);
+
+      // Verify only one reference (semantic deduplication)
+      const item = kspecJson<{ depends_on: string[] }>('item get @dependent', tempDir);
+      expect(item.depends_on).toHaveLength(1);
     });
   });
 


### PR DESCRIPTION
## Summary
- Fix duplicate prevention in `item set` relationship flags to use resolved ULIDs instead of raw string comparison
- The same target can no longer be added multiple times using different valid ref forms (`@slug` vs `@ULID`)
- Stores canonical slug format for user-friendly display while deduplicating by resolved identity

## Issue
Codex review identified that `--relates-to`, `--implements`, and `--depends-on` duplicate prevention was string-based, not reference-identity-based. This allowed semantic duplicates when the same target was referenced via different forms.

Repro:
1. `kspec item set @item-a --relates-to @item-b`
2. `kspec item set @item-a --relates-to @<item-b-ulid>`
3. `item get @item-a --json` => `relates_to` contained both refs to the same item

## Changes
- `validateRelationshipRef` now returns `{ ulid, canonicalRef }` for deduplication and user-friendly storage
- Added `resolveRefsToUlids` helper to resolve existing refs for comparison
- Stores canonical slug format (primary slug if available, otherwise ULID)
- Added 3 new tests for mixed-ref duplicate prevention

## Test plan
- [x] All 22 item-set-relationships tests pass
- [x] All 153 integration tests pass
- [x] New tests verify mixed-ref deduplication for all three flags

Task: @01KGTVH6
Spec: @item-set

🤖 Generated with [Claude Code](https://claude.com/claude-code)