### PR TITLE
feat(cli): auto-namespace plan slugs to prevent collision with spec slugs

### DIFF
--- a/src/cli/commands/plan-import.ts
+++ b/src/cli/commands/plan-import.ts
@@ -162,7 +162,16 @@ async function importPlan(
   // Create plan record
   // AC: @plan-import ac-24, ac-28
   // Auto-namespace plan slugs with "plan-" prefix to prevent collision with spec slugs
-  const planSlug = `plan-${generateSlug(parsed.title)}`;
+  // Ensure uniqueness by appending counter if needed
+  const plans = await loadPlans(ctx);
+  let planSlug = `plan-${generateSlug(parsed.title)}`;
+  let counter = 1;
+  const baseSlug = planSlug;
+  while (plans.some(p => p.slugs.includes(planSlug))) {
+    planSlug = `${baseSlug}-${counter}`;
+    counter++;
+  }
+
   const planInput: PlanInput = {
     title: parsed.title,
     content: parsed.content,

--- a/src/cli/commands/plan.ts
+++ b/src/cli/commands/plan.ts
@@ -121,17 +121,33 @@ Examples:
         };
 
         // Auto-namespace plan slugs with "plan-" prefix to prevent collision with spec slugs
-        // If user provides a slug, check for collision with spec items
-        // If no slug provided, auto-generate with "plan-" prefix
-        const planSlug = options.slug || `plan-${generateSlug(options.title)}`;
+        // If user provides a slug, check for collision with spec items and plans
+        // If no slug provided, auto-generate with "plan-" prefix and ensure uniqueness
+        const plans = await loadPlans(ctx);
+        let planSlug = options.slug || `plan-${generateSlug(options.title)}`;
 
-        // Check for collision with spec items when manual slug is provided
+        // Check for collision with spec items and plans
+        const { refIndex } = await buildIndexes(ctx);
         if (options.slug) {
-          const { refIndex } = await buildIndexes(ctx);
-          const collision = refIndex.resolve(`@${options.slug}`);
-          if (collision.ok) {
+          // Manual slug: check for collision with spec items
+          const specCollision = refIndex.resolve(`@${options.slug}`);
+          if (specCollision.ok) {
             error(`Slug "${options.slug}" collides with existing spec item. Use a different slug or omit --slug for auto-namespaced slug.`);
             process.exit(EXIT_CODES.CONFLICT);
+          }
+          // Check for collision with existing plans
+          const planCollision = plans.find(p => p.slugs.includes(options.slug));
+          if (planCollision) {
+            error(`Slug "${options.slug}" collides with existing plan. Use a different slug.`);
+            process.exit(EXIT_CODES.CONFLICT);
+          }
+        } else {
+          // Auto-generated slug: ensure uniqueness by appending counter if needed
+          let counter = 1;
+          const baseSlug = planSlug;
+          while (plans.some(p => p.slugs.includes(planSlug))) {
+            planSlug = `${baseSlug}-${counter}`;
+            counter++;
           }
         }
 
@@ -281,9 +297,15 @@ Examples:
           if (!foundPlan.slugs.includes(options.slug)) {
             // Check for collision with spec items
             const { refIndex } = await buildIndexes(ctx);
-            const collision = refIndex.resolve(`@${options.slug}`);
-            if (collision.ok) {
+            const specCollision = refIndex.resolve(`@${options.slug}`);
+            if (specCollision.ok) {
               error(`Slug "${options.slug}" collides with existing spec item. Use a different slug.`);
+              process.exit(EXIT_CODES.CONFLICT);
+            }
+            // Check for collision with other plans
+            const planCollision = plans.find(p => p._ulid !== foundPlan._ulid && p.slugs.includes(options.slug));
+            if (planCollision) {
+              error(`Slug "${options.slug}" collides with existing plan. Use a different slug.`);
               process.exit(EXIT_CODES.CONFLICT);
             }
             foundPlan.slugs.push(options.slug);

--- a/tests/cli-plan-import.test.ts
+++ b/tests/cli-plan-import.test.ts
@@ -901,6 +901,55 @@ Ensure backward compatibility.
     expect(plan.slugs).toContain("plan-namespace-test");
   });
 
+  it("should auto-generate unique plan slugs when importing same title twice", async () => {
+    // Import the same plan twice
+    const planPath = path.join(tempDir, "duplicate-plan.md");
+    await fs.writeFile(
+      planPath,
+      `# Duplicate Import
+
+## Specs
+
+\`\`\`yaml
+- title: Feature
+  slug: duplicate-feature
+  type: feature
+\`\`\`
+`,
+    );
+
+    kspec(`plan import "${planPath}" --module @test-core`, tempDir);
+
+    // Create new spec slug for second import to avoid skip
+    await fs.writeFile(
+      planPath,
+      `# Duplicate Import
+
+## Specs
+
+\`\`\`yaml
+- title: Feature Two
+  slug: duplicate-feature-two
+  type: feature
+\`\`\`
+`,
+    );
+    kspec(`plan import "${planPath}" --module @test-core`, tempDir);
+
+    // Both plans should be retrievable with different slugs
+    const plan1 = kspecJson<{ slugs: string[] }>(
+      "plan get @plan-duplicate-import --json",
+      tempDir,
+    );
+    expect(plan1.slugs).toContain("plan-duplicate-import");
+
+    const plan2 = kspecJson<{ slugs: string[] }>(
+      "plan get @plan-duplicate-import-1 --json",
+      tempDir,
+    );
+    expect(plan2.slugs).toContain("plan-duplicate-import-1");
+  });
+
   // Bug fix: dry-run path should also preserve ACs and normalize traits
   it("should normalize traits in dry-run mode (no crash)", async () => {
     const planPath = path.join(tempDir, "dry-trait-plan.md");

--- a/tests/cli-plan.test.ts
+++ b/tests/cli-plan.test.ts
@@ -157,6 +157,40 @@ describe("Integration: plan commands", () => {
       expect(result.stderr).toContain("collides with existing spec item");
       expect(result.exitCode).toBe(5); // EXIT_CODES.CONFLICT
     });
+
+    it("should error when provided slug collides with existing plan", () => {
+      // Create first plan with custom slug
+      kspec('plan add --title "First Plan" --content "Content" --slug my-custom-slug', tempDir);
+
+      // Try to create second plan with same slug
+      const result = kspecRun(
+        'plan add --title "Second Plan" --content "Content" --slug my-custom-slug',
+        tempDir,
+        { expectFail: true },
+      );
+
+      expect(result.stderr).toContain("collides with existing plan");
+      expect(result.exitCode).toBe(5); // EXIT_CODES.CONFLICT
+    });
+
+    it("should auto-generate unique slug when same title is used twice", () => {
+      // Create two plans with the same title
+      kspec('plan add --title "Duplicate Title" --content "First"', tempDir);
+      kspec('plan add --title "Duplicate Title" --content "Second"', tempDir);
+
+      // Both should be retrievable with different slugs
+      const plan1 = kspecJson<{ title: string; slugs: string[] }>(
+        "plan get @plan-duplicate-title --json",
+        tempDir,
+      );
+      expect(plan1.slugs).toContain("plan-duplicate-title");
+
+      const plan2 = kspecJson<{ title: string; slugs: string[] }>(
+        "plan get @plan-duplicate-title-1 --json",
+        tempDir,
+      );
+      expect(plan2.slugs).toContain("plan-duplicate-title-1");
+    });
   });
 
   describe("plan get", () => {
@@ -313,6 +347,21 @@ describe("Integration: plan commands", () => {
       );
 
       expect(result.stderr).toContain("collides with existing spec item");
+      expect(result.exitCode).toBe(5); // EXIT_CODES.CONFLICT
+    });
+
+    it("should error when adding slug that collides with existing plan", () => {
+      // Create another plan with a known slug
+      kspec('plan add --title "Other Plan" --content "Content" --slug other-plan-slug', tempDir);
+
+      // Try to add that slug to the first plan
+      const result = kspecRun(
+        "plan set @01 --slug other-plan-slug",
+        tempDir,
+        { expectFail: true },
+      );
+
+      expect(result.stderr).toContain("collides with existing plan");
       expect(result.exitCode).toBe(5); // EXIT_CODES.CONFLICT
     });
   });


### PR DESCRIPTION
## Summary

- Auto-prefix plan slugs with "plan-" to prevent collision with spec item slugs
- Add collision detection when user provides manual --slug to plan add/set commands
- Ensure auto-generated plan slugs are unique across existing plans
- Bug fix for issues encountered during real plan imports where plan and spec shared the same slug

## Changes

1. **plan import**: Auto-generates plan slug as `plan-<title-slug>` with uniqueness check
2. **plan add**: Auto-generates slug with "plan-" prefix and ensures uniqueness against existing plans
3. **plan add/set**: Checks for collision with both spec items AND existing plans when manual `--slug` is provided

## Test plan

- [x] Added 7 new tests covering auto-namespacing, collision detection, and uniqueness
- [x] Updated 27 existing tests to expect new `plan-` prefixed slugs
- [x] All 69 plan-related tests pass
- [x] Codex review verified all MUST-FIX issues addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)