### PR TITLE
feat(cli): enrich session start with pending_review and completed task notes

### DIFF
--- a/src/cli/commands/session.ts
+++ b/src/cli/commands/session.ts
@@ -412,6 +412,21 @@ export async function gatherSessionContext(
 
   // Get recent notes from active, pending_review, and recently completed tasks
   // AC: @cmd-session-start ac-1, ac-2
+  // Collect notes per-status first to prevent one status from starving others
+  const noteLimitPerStatus = options.full ? limit : Math.ceil(limit / 3);
+
+  const inProgressNotes = collectRecentNotes(
+    allTasks.filter((t) => t.status === "in_progress"),
+    index,
+    { limit: noteLimitPerStatus, since: sinceDate },
+  );
+
+  const pendingReviewNotes = collectRecentNotes(
+    allTasks.filter((t) => t.status === "pending_review"),
+    index,
+    { limit: noteLimitPerStatus, since: sinceDate },
+  );
+
   const recentlyCompletedForNotes = allTasks
     .filter((t) => t.status === "completed" && t.completed_at)
     .sort((a, b) => {
@@ -421,17 +436,18 @@ export async function gatherSessionContext(
     })
     .slice(0, 5); // Last 3-5 completed tasks per AC-2
 
-  const tasksForNotes = [
-    ...allTasks.filter((t) => t.status === "in_progress"),
-    ...allTasks.filter((t) => t.status === "pending_review"),
-    ...recentlyCompletedForNotes,
-  ];
-
-  const recentNotes = collectRecentNotes(
-    tasksForNotes,
+  const completedNotes = collectRecentNotes(
+    recentlyCompletedForNotes,
     index,
-    { limit: options.full ? limit * 2 : limit, since: sinceDate },
+    { limit: noteLimitPerStatus, since: sinceDate },
   );
+
+  // Combine notes from all statuses, preserving representation from each
+  const recentNotes = [...inProgressNotes, ...pendingReviewNotes, ...completedNotes]
+    .sort(
+      (a, b) =>
+        new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
+    );
 
   // Get incomplete todos from active tasks
   const activeTodos = collectIncompleteTodos(

--- a/tests/cli/session-start-notes.test.ts
+++ b/tests/cli/session-start-notes.test.ts
@@ -189,6 +189,54 @@ describe('session start notes enrichment', () => {
     });
   });
 
+  // AC: @cmd-session-start ac-1, ac-2
+  describe('mixed-status note starvation prevention', () => {
+    it('should include pending_review and completed notes even with many in_progress notes', { timeout: 20000 }, () => {
+      // Create many in_progress tasks with notes (potential starvation scenario)
+      for (let i = 1; i <= 5; i++) {
+        kspec(`task add --title "Active ${i}" --slug active-${i}`, tempDir);
+        kspec(`task start @active-${i}`, tempDir);
+        kspec(`task note @active-${i} "Active note ${i}"`, tempDir);
+      }
+
+      // Create a pending_review task with notes
+      kspec('task add --title "Review task" --slug review-task', tempDir);
+      kspec('task start @review-task', tempDir);
+      kspec('task note @review-task "Review note"', tempDir);
+      kspec('task submit @review-task', tempDir);
+
+      // Create a completed task with notes
+      kspec('task add --title "Done task" --slug done-task', tempDir);
+      kspec('task start @done-task', tempDir);
+      kspec('task note @done-task "Done note"', tempDir);
+      kspec('task submit @done-task', tempDir);
+      kspec('task complete @done-task --reason "Finished"', tempDir);
+
+      // Get session context
+      const session = kspecJson<SessionContext>('session start --json', tempDir);
+
+      // All three status types should be represented
+      const inProgressNotes = session.recent_notes.filter(
+        (n) => n.task_status === 'in_progress',
+      );
+      const pendingReviewNotes = session.recent_notes.filter(
+        (n) => n.task_status === 'pending_review',
+      );
+      const completedNotes = session.recent_notes.filter(
+        (n) => n.task_status === 'completed',
+      );
+
+      // Each status should have notes present (not starved out)
+      expect(inProgressNotes.length).toBeGreaterThan(0);
+      expect(pendingReviewNotes.length).toBeGreaterThan(0);
+      expect(completedNotes.length).toBeGreaterThan(0);
+
+      // Verify specific notes are present
+      expect(pendingReviewNotes.some((n) => n.content.includes('Review note'))).toBe(true);
+      expect(completedNotes.some((n) => n.content.includes('Done note'))).toBe(true);
+    });
+  });
+
   describe('task_status field in JSON output', () => {
     it('should include task_status field for all notes', () => {
       // Create tasks in different states with notes


### PR DESCRIPTION
## Summary
- Adds notes from pending_review tasks to session start output, grouped separately from in_progress notes
- Includes notes from last 3-5 recently completed tasks in a "Recently Completed" group
- Adds `task_status` field to JSON output for programmatic access

## Test plan
- [x] Verify pending_review task notes appear in "Pending Review" section
- [x] Verify completed task notes appear in "Recently Completed" section  
- [x] Verify notes are properly grouped by status in human-readable output
- [x] Verify JSON output includes task_status field
- [x] Run `npm test -- tests/cli/session-start-notes.test.ts` - 8 tests pass

Implements: @cmd-session-start ac-1, ac-2
Task: @01KGTZEY

🤖 Generated with [Claude Code](https://claude.com/claude-code)