### PR TITLE
fix: correct factual errors in AGENTS.md Running Services

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -256,11 +256,11 @@ kspec tasks ready --eligible
 ### Daemon
 
 ```bash
-npm run daemon                          # Foreground
-npm run daemon > /tmp/daemon.log 2>&1 & # Background
+kspec serve start                          # Foreground
+kspec serve start --daemon                 # Background (daemonized)
 ```
 
-Default port 3000. Health: `GET /health`.
+Default port 3456. Health: `GET /api/health`.
 
 ### E2E Tests
 
@@ -274,7 +274,7 @@ npm run test:e2e -w packages/web-ui -- tests/e2e/tasks.spec.ts  # Specific file
 **Architecture:**
 - Tests in `packages/web-ui/tests/e2e/`
 - Import from `../fixtures/test-base` (NOT main `tests/fixtures/`)
-- Daemon runs on port 3456 (not 3000)
+- Daemon runs on port 3456
 - Each test gets isolated temp dir
 - E2E fixtures are SEPARATE from unit test fixtures — never mix them
 
@@ -289,7 +289,7 @@ test('my test', async ({ daemon, page }) => {
 ### Web UI Development
 
 ```bash
-npm run dev -w packages/web-ui  # Daemon + UI together
+npm run dev -w packages/web-ui  # Vite dev server (port 5173, connects to daemon on 3456)
 ```
 
 ## Test Fixture Patterns


### PR DESCRIPTION
## Summary
- Fix daemon commands: `npm run daemon` → `kspec serve start` (command didn't exist)
- Fix default port: 3000 → 3456
- Fix health endpoint: `/health` → `/api/health`
- Fix web-ui dev comment: clarify it only starts Vite dev server (port 5173), not daemon+UI

Discovered via cross-pollinate from kynetic-bot#90 — auditing AGENTS.md claims against actual source code.

## Test plan
- [ ] Verify `kspec serve start` matches documented usage
- [ ] Verify daemon default port is 3456
- [ ] Verify health endpoint is `/api/health`

Task: @agents-md-cross-pollinate

Generated with [Claude Code](https://claude.ai/code)