### PR TITLE
chore: gitignore .claude-research/ analysis artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ coverage/
 .kspec/
 !tests/fixtures/**/.kspec/
 
+# Research artifacts
+.claude-research/
+
 # Session context
 .kspec-session
 bun.lock


### PR DESCRIPTION
## Summary
- Adds `.claude-research/` to `.gitignore` to keep CLI usage analysis artifacts (parsing tools, raw data, HTML reports) out of the repo

These artifacts were generated during a telemetry analysis session (18,581 events across 4 projects) that informed the CLI agent-UX improvement specs now tracked in kspec as `@plan-cli-agent-ux-improvements`.

## Test plan
- [x] Verify `.claude-research/` directory is excluded from git tracking
- [x] No other gitignore entries affected

Generated with [Claude Code](https://claude.ai/code)