### PR TITLE
fix: auto-prefix @ on depends_on refs and warn on missing plan YAML block

### DIFF
--- a/src/cli/commands/derive.ts
+++ b/src/cli/commands/derive.ts
@@ -332,7 +332,9 @@ async function deriveTaskFromSpec(
     priority: options.priority ?? normalizePriority(specItem.priority),
     slugs: [slug],
     tags: [...(specItem.tags || [])],
-    depends_on: options.dependsOn || [],
+    depends_on: (options.dependsOn || []).map((ref: string) =>
+      ref.startsWith("@") ? ref : `@${ref}`,
+    ),
     notes: initialNotes,
   };
 

--- a/src/cli/commands/task.ts
+++ b/src/cli/commands/task.ts
@@ -318,7 +318,9 @@ async function setTaskFields(
           };
         }
       }
-      updatedTask.depends_on = options.dependsOn;
+      updatedTask.depends_on = options.dependsOn.map((ref: string) =>
+        ref.startsWith("@") ? ref : `@${ref}`,
+      );
       changes.push("depends_on");
     }
 
@@ -803,7 +805,9 @@ Examples:
           priority: priorityResult.value,
           slugs: options.slug ? [options.slug] : [],
           tags: parseTagsArray(options.tag),
-          depends_on: options.dependsOn || [],
+          depends_on: (options.dependsOn || []).map((ref: string) =>
+            ref.startsWith("@") ? ref : `@${ref}`,
+          ),
           automation: automationValue,
         };
 

--- a/src/parser/plan-document.ts
+++ b/src/parser/plan-document.ts
@@ -130,6 +130,11 @@ function extractSpecsSection(content: string, errors: ParseError[]): PlanSpec[] 
   const yamlMatch = specsContent.match(/```(?:yaml)?\s*\n([\s\S]*?)\n```/);
 
   if (!yamlMatch) {
+    errors.push({
+      type: "validation",
+      message:
+        "Specs section found but contains no YAML code block. Wrap specs in ```yaml ... ```",
+    });
     return [];
   }
 

--- a/tests/plan-document-parser.test.ts
+++ b/tests/plan-document-parser.test.ts
@@ -479,6 +479,70 @@ describe("Parent Reference Validation", () => {
   });
 });
 
+describe("Plan Document Parser - missing YAML block warning", () => {
+  // AC: @plan-import ac-34
+  it("should warn when Specs section exists but has no YAML code block", () => {
+    const plan = `
+# Test Plan
+
+## Specs
+
+Here are the specs I want to create:
+- Feature A
+- Feature B
+
+## Implementation Notes
+
+Some notes here.
+`;
+
+    const result = parsePlanDocument(plan);
+
+    expect(result.specs).toHaveLength(0);
+    expect(result.errors.length).toBeGreaterThan(0);
+    expect(result.errors.some(e =>
+      e.type === "validation" && e.message.includes("no YAML code block")
+    )).toBe(true);
+  });
+
+  it("should not warn when Specs section has a YAML code block", () => {
+    const plan = `
+# Test Plan
+
+## Specs
+
+\`\`\`yaml
+- title: Feature A
+  slug: feature-a
+  type: feature
+  description: A feature
+\`\`\`
+`;
+
+    const result = parsePlanDocument(plan);
+
+    expect(result.errors.filter(e =>
+      e.type === "validation" && e.message.includes("no YAML code block")
+    )).toHaveLength(0);
+  });
+
+  it("should not warn when there is no Specs section at all", () => {
+    const plan = `
+# Test Plan
+
+## Implementation Notes
+
+Just some notes, no specs section.
+`;
+
+    const result = parsePlanDocument(plan);
+
+    expect(result.errors.filter(e =>
+      e.message.includes("no YAML code block")
+    )).toHaveLength(0);
+  });
+});
+
 describe("createSpecItem", () => {
   it("should preserve acceptance_criteria when provided", () => {
     const ac = [

--- a/tests/task-add-depends-on.test.ts
+++ b/tests/task-add-depends-on.test.ts
@@ -121,4 +121,48 @@ describe('Integration: task add --depends-on', () => {
     expect(task.depends_on).toHaveLength(1);
     expect(task.depends_on[0]).toContain(depUlid.slice(0, 8));
   });
+
+  // AC: @rel-depends-on ac-1 - Auto-prefix @ on bare references
+  it('should auto-prefix @ on bare slug references in task add', () => {
+    kspec('task add --title "Dep Task" --slug dep-bare', tempDir);
+
+    // Pass bare slug without @ prefix
+    const output = kspec(
+      'task add --title "Main Task" --depends-on dep-bare --slug main-bare',
+      tempDir
+    );
+    expect(output).toContain('Created task');
+
+    const task = kspecJson<{ depends_on: string[] }>(
+      'task get @main-bare',
+      tempDir
+    );
+
+    // Should be stored with @ prefix
+    expect(task.depends_on).toEqual(['@dep-bare']);
+  });
+
+  // AC: @rel-depends-on ac-1 - Auto-prefix @ on bare ULID references
+  it('should auto-prefix @ on bare ULID references in task add', () => {
+    const dep = kspecJson<{ task: { _ulid: string } }>(
+      'task add --title "Dep ULID Bare" --json',
+      tempDir
+    );
+    const shortUlid = dep.task._ulid.slice(0, 8);
+
+    const output = kspec(
+      `task add --title "Main ULID Bare" --depends-on ${shortUlid} --slug main-ulid-bare`,
+      tempDir
+    );
+    expect(output).toContain('Created task');
+
+    const task = kspecJson<{ depends_on: string[] }>(
+      'task get @main-ulid-bare',
+      tempDir
+    );
+
+    // Should be stored with @ prefix
+    expect(task.depends_on).toHaveLength(1);
+    expect(task.depends_on[0]).toBe(`@${shortUlid}`);
+  });
 });

--- a/tests/task-clear-deps.test.ts
+++ b/tests/task-clear-deps.test.ts
@@ -154,4 +154,16 @@ describe('Integration: task set --clear-deps', () => {
       expect(r.data.task.depends_on).toEqual([]);
     }
   });
+
+  // AC: @rel-depends-on ac-1 - Auto-prefix @ on bare references in task set
+  it('should auto-prefix @ on bare slug references in task set --depends-on', () => {
+    kspec('task add --title "Dep Task" --slug set-dep', tempDir);
+    kspec('task add --title "Main Task" --slug set-main', tempDir);
+
+    // Pass bare slug without @ prefix
+    kspec('task set @set-main --depends-on set-dep', tempDir);
+
+    const task = kspecJson<{ depends_on: string[] }>('task get @set-main', tempDir);
+    expect(task.depends_on).toEqual(['@set-dep']);
+  });
 });


### PR DESCRIPTION
## Summary

- **depends_on @ prefix**: `task add`, `task set`, and `derive` now auto-prefix `@` when bare IDs are passed via `--depends-on`. Previously, bare refs (e.g. `01KH7XA9`) were stored without `@`, failing `RefSchema` validation on reload and silently dropping the task from all CLI commands.
- **plan import warning**: `plan import` now emits a validation warning when the `## Specs` section exists but contains no fenced YAML code block, instead of silently returning 0 specs / 0 tasks.

## Test plan

- [x] Existing 32 tests still pass
- [x] New test: bare slug auto-prefixed in `task add --depends-on`
- [x] New test: bare ULID auto-prefixed in `task add --depends-on`
- [x] New test: bare slug auto-prefixed in `task set --depends-on`
- [x] New test: plan import warns on missing YAML block
- [x] New test: no warning when YAML block present
- [x] New test: no warning when no Specs section at all

Task: @01KHAPKT
Task: @01KHAPKY
Task: @01KHAQCC
Spec: @rel-depends-on
Spec: @plan-import

Generated with [Claude Code](https://claude.ai/code)