### PR TITLE
feat: add workflow complete command for graceful exit distinction

### DIFF
--- a/src/cli/commands/workflow.ts
+++ b/src/cli/commands/workflow.ts
@@ -6,6 +6,7 @@
  * - kspec workflow runs [--active] [--completed] [--workflow @ref] [--json]
  * - kspec workflow show @run [--json]
  * - kspec workflow abort @run [--reason text] [--json]
+ * - kspec workflow complete @run [--result <result>] [--json]
  */
 
 import chalk from "chalk";
@@ -28,7 +29,8 @@ import {
   type Workflow,
 } from "../../parser/index.js";
 import { commitIfShadow } from "../../parser/shadow.js";
-import type { WorkflowRun } from "../../schema/index.js";
+import type { WorkflowRun, WorkflowRunResult } from "../../schema/index.js";
+import { WorkflowRunResultSchema } from "../../schema/index.js";
 import { errors } from "../../strings/errors.js";
 import { EXIT_CODES } from "../exit-codes.js";
 import { error, isJsonMode, output, success } from "../output.js";
@@ -323,6 +325,69 @@ async function workflowAbort(
     if (options.reason) {
       console.log(`  Reason: ${options.reason}`);
     }
+  }
+}
+
+/**
+ * Command: kspec workflow complete @run-id [--result <result>] [--json]
+ * Marks a workflow run as completed with an optional result.
+ * Use this for graceful exits (e.g., no_work_available) instead of aborting.
+ */
+async function workflowComplete(
+  runRef: string,
+  options: { result?: string; json?: boolean },
+) {
+  const ctx = await initContext();
+
+  const run = await findWorkflowRunByRef(ctx, runRef);
+  if (!run) {
+    error(errors.workflowRun.runNotFound(runRef));
+    process.exit(EXIT_CODES.NOT_FOUND);
+  }
+
+  // Cannot complete already finished runs
+  if (run.status === "completed") {
+    error(`Cannot complete run ${shortUlid(run._ulid)}: already completed`);
+    process.exit(EXIT_CODES.VALIDATION_FAILED);
+  }
+
+  if (run.status === "aborted") {
+    error(`Cannot complete run ${shortUlid(run._ulid)}: already aborted`);
+    process.exit(EXIT_CODES.VALIDATION_FAILED);
+  }
+
+  // Validate result if provided
+  let result: WorkflowRunResult | undefined;
+  if (options.result) {
+    const parseResult = WorkflowRunResultSchema.safeParse(options.result);
+    if (!parseResult.success) {
+      const validResults = WorkflowRunResultSchema.options.join(", ");
+      error(`Invalid result: ${options.result}. Must be one of: ${validResults}`);
+      process.exit(EXIT_CODES.VALIDATION_FAILED);
+    }
+    result = parseResult.data;
+  }
+
+  // Update run status
+  run.status = "completed";
+  run.completed_at = new Date().toISOString();
+  if (result) {
+    run.result = result;
+  }
+
+  await updateWorkflowRun(ctx, run);
+  await commitIfShadow(ctx.shadow, "workflow-complete");
+
+  if (isJsonMode()) {
+    output({
+      run_id: run._ulid,
+      status: run.status,
+      result: run.result,
+      completed_at: run.completed_at,
+    });
+  } else {
+    const resultInfo = run.result ? ` (${run.result})` : "";
+    success(`Completed workflow run: ${shortUlid(run._ulid)}${resultInfo}`);
   }
 }
 
@@ -955,6 +1020,16 @@ export function registerWorkflowCommand(program: Command): void {
     .option("--reason <text>", "Reason for aborting")
     .option("--json", "Output JSON")
     .action(workflowAbort);
+
+  markMutating(workflow.command("complete"))
+    .description("Mark workflow run as completed (graceful exit)")
+    .argument("<run-ref>", "Run reference (@ulid or ulid prefix)")
+    .option(
+      "--result <result>",
+      "Completion result (success, no_work_available, early_exit)",
+    )
+    .option("--json", "Output JSON")
+    .action(workflowComplete);
 
   markMutating(workflow.command("next"))
     .description("Advance workflow run to next step")

--- a/src/schema/meta.ts
+++ b/src/schema/meta.ts
@@ -193,6 +193,15 @@ export const WorkflowRunStatusSchema = z.enum([
 ]);
 
 /**
+ * Workflow run result - distinguishes between different completion types
+ */
+export const WorkflowRunResultSchema = z.enum([
+  "success", // Normal completion through all steps
+  "no_work_available", // Graceful exit - no eligible work to process
+  "early_exit", // Intentional exit before all steps (not an error)
+]);
+
+/**
  * Workflow run schema - tracks execution of a workflow
  */
 export const WorkflowRunSchema = z.object({
@@ -208,6 +217,7 @@ export const WorkflowRunSchema = z.object({
   initiated_by: z.string().optional(),
   abort_reason: z.string().optional(),
   task_ref: RefSchema.optional(),
+  result: WorkflowRunResultSchema.optional(), // Only set for completed runs
 });
 
 /**
@@ -249,6 +259,7 @@ export type MetaManifest = z.infer<typeof MetaManifestSchema>;
 export type StepResultStatus = z.infer<typeof StepResultStatusSchema>;
 export type StepResult = z.infer<typeof StepResultSchema>;
 export type WorkflowRunStatus = z.infer<typeof WorkflowRunStatusSchema>;
+export type WorkflowRunResult = z.infer<typeof WorkflowRunResultSchema>;
 export type WorkflowRun = z.infer<typeof WorkflowRunSchema>;
 export type WorkflowRunsFile = z.infer<typeof WorkflowRunsFileSchema>;
 

--- a/tests/workflow-runs.test.ts
+++ b/tests/workflow-runs.test.ts
@@ -1516,3 +1516,147 @@ describe('workflow next with step inputs', () => {
     expect(nextResult.stderr).toContain('Expected format: key=value');
   });
 });
+
+/**
+ * Tests for workflow complete command
+ * Distinguishes graceful exit (no_work_available) from abort (actual failure)
+ */
+describe('workflow complete', () => {
+  let runId: string;
+
+  beforeEach(async () => {
+    const result = kspec('workflow start @test-workflow --json', tempDir);
+    const output = JSON.parse(result.stdout);
+    runId = output.run_id;
+  });
+
+  it('should complete an active run with no result', async () => {
+    const result = kspec(`workflow complete @${runId} --json`, tempDir);
+
+    expect(result.exitCode).toBe(0);
+    const output = JSON.parse(result.stdout);
+
+    expect(output.run_id).toBe(runId);
+    expect(output.status).toBe('completed');
+    expect(output.completed_at).toBeDefined();
+    expect(output.result).toBeUndefined();
+
+    // Verify in file
+    const runsPath = path.join(tempDir, 'kynetic.runs.yaml');
+    const runsContent = await fs.readFile(runsPath, 'utf-8');
+    const doc = parseDocument(runsContent);
+    const runsData = doc.toJS() as { runs: any[] };
+
+    const run = runsData.runs[0];
+    expect(run.status).toBe('completed');
+    expect(run.completed_at).toBeDefined();
+    expect(run.result).toBeUndefined();
+  });
+
+  it('should complete with no_work_available result', async () => {
+    const result = kspec(`workflow complete @${runId} --result no_work_available --json`, tempDir);
+
+    expect(result.exitCode).toBe(0);
+    const output = JSON.parse(result.stdout);
+
+    expect(output.run_id).toBe(runId);
+    expect(output.status).toBe('completed');
+    expect(output.result).toBe('no_work_available');
+
+    // Verify in file
+    const runsPath = path.join(tempDir, 'kynetic.runs.yaml');
+    const runsContent = await fs.readFile(runsPath, 'utf-8');
+    const doc = parseDocument(runsContent);
+    const runsData = doc.toJS() as { runs: any[] };
+
+    const run = runsData.runs[0];
+    expect(run.status).toBe('completed');
+    expect(run.result).toBe('no_work_available');
+  });
+
+  it('should complete with success result', async () => {
+    const result = kspec(`workflow complete @${runId} --result success --json`, tempDir);
+
+    expect(result.exitCode).toBe(0);
+    const output = JSON.parse(result.stdout);
+
+    expect(output.result).toBe('success');
+  });
+
+  it('should complete with early_exit result', async () => {
+    const result = kspec(`workflow complete @${runId} --result early_exit --json`, tempDir);
+
+    expect(result.exitCode).toBe(0);
+    const output = JSON.parse(result.stdout);
+
+    expect(output.result).toBe('early_exit');
+  });
+
+  it('should display human-readable output without --json', async () => {
+    const result = kspec(`workflow complete @${runId} --result no_work_available`, tempDir);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('Completed workflow run:');
+    expect(result.stdout).toContain('(no_work_available)');
+  });
+
+  it('should display human-readable output without result', async () => {
+    const result = kspec(`workflow complete @${runId}`, tempDir);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('Completed workflow run:');
+    expect(result.stdout).not.toContain('(');
+  });
+
+  it('should error if result is invalid', async () => {
+    const result = kspec(`workflow complete @${runId} --result invalid_result`, tempDir, { expectFail: true });
+
+    expect(result.exitCode).toBe(4); // VALIDATION_FAILED
+    expect(result.stderr).toContain('Invalid result: invalid_result');
+    expect(result.stderr).toContain('success');
+    expect(result.stderr).toContain('no_work_available');
+    expect(result.stderr).toContain('early_exit');
+  });
+
+  it('should error if run does not exist', async () => {
+    const result = kspec('workflow complete @nonexistent --result success', tempDir, { expectFail: true });
+
+    expect(result.exitCode).toBe(3); // NOT_FOUND
+    expect(result.stderr).toContain('Workflow run not found');
+  });
+
+  it('should error when completing an already completed run', async () => {
+    // Complete the run first
+    kspec(`workflow complete @${runId} --result success`, tempDir);
+
+    // Try to complete again
+    const result = kspec(`workflow complete @${runId} --result success`, tempDir, { expectFail: true });
+
+    expect(result.exitCode).toBe(4); // VALIDATION_FAILED
+    expect(result.stderr).toContain('already completed');
+  });
+
+  it('should error when completing an aborted run', async () => {
+    // Abort the run first
+    kspec(`workflow abort @${runId}`, tempDir);
+
+    // Try to complete
+    const result = kspec(`workflow complete @${runId} --result success`, tempDir, { expectFail: true });
+
+    expect(result.exitCode).toBe(4); // VALIDATION_FAILED
+    expect(result.stderr).toContain('already aborted');
+  });
+
+  it('should complete a paused run', async () => {
+    // Pause the run first
+    kspec(`workflow pause @${runId}`, tempDir);
+
+    // Complete should work
+    const result = kspec(`workflow complete @${runId} --result early_exit --json`, tempDir);
+
+    expect(result.exitCode).toBe(0);
+    const output = JSON.parse(result.stdout);
+    expect(output.status).toBe('completed');
+    expect(output.result).toBe('early_exit');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `kspec workflow complete` command to mark workflow runs as completed with an optional result field
- Adds `WorkflowRunResultSchema` with values: `success`, `no_work_available`, `early_exit`
- Adds `result` field to `WorkflowRunSchema`

This addresses the 69% false abort rate observed in task-work-loop workflow runs (observation @01KGQY7097). Previously, graceful exits due to no eligible tasks were recorded as "aborted" - now they can be properly categorized as `completed` with `result: no_work_available`.

## Test plan
- [x] Complete active run without result specified
- [x] Complete with `--result no_work_available`
- [x] Complete with `--result success`
- [x] Complete with `--result early_exit`
- [x] Validate invalid result values
- [x] Error on already completed runs
- [x] Error on already aborted runs
- [x] Complete paused runs
- [x] Human-readable output
- [x] JSON output

Task: @01KHAP90

🤖 Generated with [Claude Code](https://claude.ai/code)