### PR TITLE
fix: ralph noise stripping handles split-chunk boundaries

### DIFF
--- a/src/ralph/events.ts
+++ b/src/ralph/events.ts
@@ -341,6 +341,63 @@ const NOISE_PATTERNS = [
 ];
 
 /**
+ * Full noise pattern strings (without tool ID suffix).
+ * Used to check if a suffix could be a prefix of a noise pattern.
+ */
+const NOISE_PATTERN_STRINGS = [
+  "No onPostToolUseHook found for tool use ID: toolu_",
+  "No onPreToolUseHook found for tool use ID: toolu_",
+  "No onPostToolUseHook found for tool use",
+  "No onPreToolUseHook found for tool use",
+  "No onPostToolUseHook found",
+  "No onPreToolUseHook found",
+];
+
+// Maximum length to check for potential partial match
+const MAX_NOISE_PATTERN_LEN =
+  Math.max(...NOISE_PATTERN_STRINGS.map((p) => p.length)) + 24; // +24 for tool ID
+
+/**
+ * Check if the content ends with a potential partial noise pattern.
+ * Returns the partial match length if found, 0 otherwise.
+ *
+ * A partial match occurs when:
+ * 1. The content ends with something that is a PREFIX of a noise pattern
+ *    (e.g., "No on" or "No onPostToolUseHook found"), OR
+ * 2. The content ends with a complete noise pattern prefix followed by
+ *    a partial tool ID (< 24 chars)
+ */
+function getPartialNoiseLength(content: string): number {
+  // Check suffixes of decreasing length (longer matches first)
+  const maxCheck = Math.min(content.length, MAX_NOISE_PATTERN_LEN);
+
+  for (let len = maxCheck; len > 0; len--) {
+    const suffix = content.slice(-len);
+
+    for (const pattern of NOISE_PATTERN_STRINGS) {
+      // Case 1: suffix is a prefix of a pattern (suffix is shorter than pattern)
+      // e.g., suffix="No onPost" is a prefix of pattern="No onPostToolUseHook found..."
+      if (suffix.length <= pattern.length && pattern.startsWith(suffix)) {
+        return len;
+      }
+
+      // Case 2: suffix starts with a complete toolu_ pattern and has partial tool ID
+      // e.g., suffix="No onPostToolUseHook found for tool use ID: toolu_ABC123"
+      // where the tool ID is < 24 chars
+      if (pattern.endsWith("toolu_") && suffix.startsWith(pattern)) {
+        const afterToolu = suffix.slice(pattern.length);
+        // If tool ID is incomplete (< 24 chars) and valid chars, it's a partial match
+        if (afterToolu.length < 24 && /^[A-Za-z0-9]*$/.test(afterToolu)) {
+          return len;
+        }
+      }
+    }
+  }
+
+  return 0;
+}
+
+/**
  * Strip noise patterns from content.
  * Returns the cleaned content, or null if nothing remains after stripping.
  * Preserves whitespace-only chunks that aren't noise to maintain streaming formatting.
@@ -374,6 +431,12 @@ interface TranslatorState {
     string,
     { tool: string; input: unknown; startTime: number }
   >;
+  /**
+   * Buffer for potential partial noise at chunk boundaries.
+   * When a chunk ends with what might be the start of a noise pattern,
+   * we hold it here until the next chunk arrives.
+   */
+  noiseBuffer: string;
 }
 
 export function createTranslator(): RalphTranslator {
@@ -381,10 +444,63 @@ export function createTranslator(): RalphTranslator {
     sessionStart: Date.now(),
     activeMessage: null,
     pendingTools: new Map(),
+    noiseBuffer: "",
   };
 
   function getTimestamp(): number {
     return Date.now() - state.sessionStart;
+  }
+
+  /**
+   * Process a text chunk with boundary-aware noise stripping.
+   * Returns the safe content to emit, and updates the noise buffer.
+   * Returns null if the entire chunk should be suppressed.
+   *
+   * The key insight is that we need to check for partial noise patterns
+   * BEFORE stripping, because partial patterns won't match the full regex
+   * and could leave fragments behind.
+   */
+  function processChunkWithBuffer(text: string): string | null {
+    // Combine buffer with new text
+    const combined = state.noiseBuffer + text;
+    state.noiseBuffer = "";
+
+    // First, check if the combined content ends with a partial noise pattern
+    // This must happen BEFORE stripping, because partial patterns at the end
+    // won't match the regex and could leave fragments
+    const partialLen = getPartialNoiseLength(combined);
+    if (partialLen > 0) {
+      // Buffer the potential partial match
+      state.noiseBuffer = combined.slice(-partialLen);
+      const safeContent = combined.slice(0, -partialLen);
+
+      // Strip complete noise patterns from the safe content
+      const cleaned = stripNoise(safeContent);
+      if (cleaned === null || cleaned.length === 0) {
+        return null;
+      }
+      return cleaned;
+    }
+
+    // No partial match at the end - strip complete patterns
+    const cleaned = stripNoise(combined);
+    if (cleaned === null) {
+      return null;
+    }
+
+    return cleaned;
+  }
+
+  /**
+   * Flush any remaining buffer content at finalization.
+   * Strips any complete noise patterns from the buffer.
+   */
+  function flushBuffer(): string {
+    const buffered = state.noiseBuffer;
+    state.noiseBuffer = "";
+    // Strip any complete noise from the buffer
+    const cleaned = stripNoise(buffered);
+    return cleaned ?? "";
   }
 
   function translate(update: SessionUpdate): RalphEvent | null {
@@ -401,10 +517,12 @@ export function createTranslator(): RalphTranslator {
           // Empty string signals finalization
           if (content.text === "") {
             if (state.activeMessage?.type === "agent_message") {
-              // Strip noise from accumulated content to handle split-chunk noise
-              const finalContent = stripNoise(state.activeMessage.content);
+              // Flush buffer and strip noise from accumulated content
+              const buffered = flushBuffer();
+              const combined = state.activeMessage.content + buffered;
+              const finalContent = stripNoise(combined);
               state.activeMessage = null;
-              if (finalContent === null) {
+              if (finalContent === null || finalContent.trim() === "") {
                 return null;
               }
               return {
@@ -420,8 +538,8 @@ export function createTranslator(): RalphTranslator {
             return null;
           }
 
-          // Strip noise patterns from content
-          const cleanedText = stripNoise(content.text);
+          // Process chunk with boundary-aware noise stripping
+          const cleanedText = processChunkWithBuffer(content.text);
           if (cleanedText === null) {
             return null;
           }
@@ -456,10 +574,12 @@ export function createTranslator(): RalphTranslator {
         if (content?.type === "text" && typeof content.text === "string") {
           if (content.text === "") {
             if (state.activeMessage?.type === "agent_thought") {
-              // Strip noise from accumulated content to handle split-chunk noise
-              const finalContent = stripNoise(state.activeMessage.content);
+              // Flush buffer and strip noise from accumulated content
+              const buffered = flushBuffer();
+              const combined = state.activeMessage.content + buffered;
+              const finalContent = stripNoise(combined);
               state.activeMessage = null;
-              if (finalContent === null) {
+              if (finalContent === null || finalContent.trim() === "") {
                 return null;
               }
               return {
@@ -475,8 +595,8 @@ export function createTranslator(): RalphTranslator {
             return null;
           }
 
-          // Strip noise patterns from content
-          const cleanedText = stripNoise(content.text);
+          // Process chunk with boundary-aware noise stripping
+          const cleanedText = processChunkWithBuffer(content.text);
           if (cleanedText === null) {
             return null;
           }
@@ -628,11 +748,13 @@ export function createTranslator(): RalphTranslator {
 
   function finalize(): RalphEvent | null {
     if (state.activeMessage) {
-      // Strip noise from accumulated content to handle split-chunk noise
-      const finalContent = stripNoise(state.activeMessage.content);
+      // Flush buffer and strip noise from accumulated content
+      const buffered = flushBuffer();
+      const combined = state.activeMessage.content + buffered;
+      const finalContent = stripNoise(combined);
       const type = state.activeMessage.type;
       state.activeMessage = null;
-      if (finalContent === null) {
+      if (finalContent === null || finalContent.trim() === "") {
         return null;
       }
       return {

--- a/tests/ralph.test.ts
+++ b/tests/ralph.test.ts
@@ -734,6 +734,167 @@ describe('ralph event translator', () => {
       expect(final).not.toBeNull();
       expect((final!.data as { content: string }).content).toBe('Hello World');
     });
+
+    // ─── Split-Chunk Boundary Tests ─────────────────────────────────────────────
+    // AC: @01KHASR8 - noise patterns split across chunk boundaries
+
+    it('buffers and suppresses noise split at "No onPostToolUse" / "Hook found..."', () => {
+      const translator = createTranslator();
+
+      // First chunk: real content followed by partial noise
+      const event1 = translator.translate(
+        makeChunk('agent_message_chunk', 'Real content. No onPostToolUse')
+      );
+
+      // Should emit real content, buffer the partial noise
+      expect(event1).not.toBeNull();
+      expect((event1!.data as { content: string }).content).toBe('Real content. ');
+
+      // Second chunk: rest of noise pattern
+      const event2 = translator.translate(
+        makeChunk('agent_message_chunk', 'Hook found for tool use ID: toolu_01ABC2345678901234567890')
+      );
+
+      // Should suppress - the combined content matches full noise pattern
+      expect(event2).toBeNull();
+
+      // Finalize - should return accumulated content without noise
+      const final = translator.translate(makeChunk('agent_message_chunk', ''));
+      expect(final).not.toBeNull();
+      expect((final!.data as { content: string }).content).toBe('Real content. ');
+    });
+
+    it('buffers and suppresses noise split at "No on" / "PostToolUseHook found..."', () => {
+      const translator = createTranslator();
+
+      // First chunk: partial noise start
+      const event1 = translator.translate(
+        makeChunk('agent_message_chunk', 'No on')
+      );
+
+      // Should buffer, not emit (could be noise)
+      expect(event1).toBeNull();
+
+      // Second chunk: rest of noise
+      const event2 = translator.translate(
+        makeChunk('agent_message_chunk', 'PostToolUseHook found')
+      );
+
+      // Should suppress
+      expect(event2).toBeNull();
+
+      // Finalize - nothing should remain
+      const final = translator.translate(makeChunk('agent_message_chunk', ''));
+      expect(final).toBeNull();
+    });
+
+    it('buffers and suppresses noise split at tool ID boundary', () => {
+      const translator = createTranslator();
+
+      // Full noise up to partial tool ID
+      const event1 = translator.translate(
+        makeChunk('agent_message_chunk', 'No onPostToolUseHook found for tool use ID: toolu_01ABC234567890')
+      );
+
+      // Should buffer - tool ID is incomplete (only 14 chars, need 24)
+      expect(event1).toBeNull();
+
+      // Rest of tool ID
+      const event2 = translator.translate(
+        makeChunk('agent_message_chunk', '1234567890')
+      );
+
+      // Should suppress
+      expect(event2).toBeNull();
+
+      // Finalize
+      const final = translator.translate(makeChunk('agent_message_chunk', ''));
+      expect(final).toBeNull();
+    });
+
+    it('emits buffered content when next chunk proves it is not noise', () => {
+      const translator = createTranslator();
+
+      // Chunk that could be noise start but isn't
+      const event1 = translator.translate(
+        makeChunk('agent_message_chunk', 'No on')
+      );
+
+      // Should buffer
+      expect(event1).toBeNull();
+
+      // Next chunk proves it's not noise (doesn't continue pattern)
+      const event2 = translator.translate(
+        makeChunk('agent_message_chunk', 'e can deny this.')
+      );
+
+      // Should emit combined content
+      expect(event2).not.toBeNull();
+      expect((event2!.data as { content: string }).content).toBe('No one can deny this.');
+    });
+
+    it('handles split noise in thought chunks', () => {
+      const translator = createTranslator();
+
+      // First chunk: partial noise
+      const event1 = translator.translate(
+        makeChunk('agent_thought_chunk', 'Thinking... No onPreToolUseHook')
+      );
+
+      expect(event1).not.toBeNull();
+      expect((event1!.data as { content: string }).content).toBe('Thinking... ');
+
+      // Second chunk: rest of noise
+      const event2 = translator.translate(
+        makeChunk('agent_thought_chunk', ' found')
+      );
+
+      expect(event2).toBeNull();
+
+      // Finalize
+      const final = translator.translate(makeChunk('agent_thought_chunk', ''));
+      expect(final).not.toBeNull();
+      expect((final!.data as { content: string }).content).toBe('Thinking... ');
+    });
+
+    it('handles multiple split noise patterns in sequence', () => {
+      const translator = createTranslator();
+
+      // Real content
+      translator.translate(makeChunk('agent_message_chunk', 'Start. '));
+
+      // First noise split
+      translator.translate(makeChunk('agent_message_chunk', 'No onPostToolUseHook'));
+      translator.translate(makeChunk('agent_message_chunk', ' found'));
+
+      // More content
+      translator.translate(makeChunk('agent_message_chunk', ' Middle. '));
+
+      // Second noise split
+      translator.translate(makeChunk('agent_message_chunk', 'No onPreToolUseHook found for tool use ID: toolu_'));
+      translator.translate(makeChunk('agent_message_chunk', '01ABC2345678901234567890'));
+
+      // End content
+      translator.translate(makeChunk('agent_message_chunk', ' End.'));
+
+      // Finalize
+      const final = translator.translate(makeChunk('agent_message_chunk', ''));
+
+      expect(final).not.toBeNull();
+      expect((final!.data as { content: string }).content).toBe('Start.  Middle.  End.');
+    });
+
+    it('returns null for finalization when only whitespace remains after stripping split noise', () => {
+      const translator = createTranslator();
+
+      // Only noise content, split across chunks
+      translator.translate(makeChunk('agent_message_chunk', '  No onPostToolUseHook'));
+      translator.translate(makeChunk('agent_message_chunk', ' found  '));
+
+      // Finalize - should return null since only whitespace remains
+      const final = translator.translate(makeChunk('agent_message_chunk', ''));
+      expect(final).toBeNull();
+    });
   });
 
   describe('tool_call events', () => {


### PR DESCRIPTION
## Summary
- Implements boundary-aware buffering in `createTranslator` to handle noise patterns split across streaming chunks
- Adds `noiseBuffer` to TranslatorState for holding potential partial matches
- Creates `processChunkWithBuffer()` to detect partial patterns BEFORE stripping (prevents fragments)
- Adds `getPartialNoiseLength()` to detect content ending with noise pattern prefix or incomplete tool ID

## Problem
Noise phrases like "No onPostToolUseHook found for tool use ID: toolu_..." arriving split across chunk boundaries (e.g., "No onPostToolUse" + "Hook found...") would both emit to the stream instead of being suppressed. This was identified in PR #345 Codex review.

## Solution
Check for partial noise patterns at the end of combined (buffer + chunk) content BEFORE running the stripNoise regex. If found, buffer that portion until the next chunk arrives, which either completes the pattern (suppressed) or proves it's not noise (emitted).

## Test plan
- [x] 7 new tests covering split-chunk scenarios
- [x] Split at "No onPostToolUse" / "Hook found..."
- [x] Split at "No on" / "PostToolUseHook found..."
- [x] Partial tool ID boundary (< 24 chars)
- [x] False-positive detection (buffered content proves not noise)
- [x] Thought chunks handled same as message chunks
- [x] Multi-split sequences
- [x] Whitespace-only results after stripping
- [x] All 70 ralph tests pass

Task: @01KHASR8

Generated with [Claude Code](https://claude.ai/code)