### PR TITLE
feat: gate reflect phase on meaningful session work during ralph loop

### DIFF
--- a/.claude/skills/reflect/SKILL.md
+++ b/.claude/skills/reflect/SKILL.md
@@ -151,7 +151,37 @@ After reflection, observations can be:
 
 ## Loop Mode
 
-You are running in autonomous loop mode. Start the workflow:
+You are running in autonomous loop mode.
+
+### Gate: Check for Meaningful Session Work
+
+**BEFORE starting reflection, check if there's anything worth reflecting on.**
+
+Use the session introspection data (provided in your prompt context or via `kspec session start --json`) to check:
+
+1. **Tasks completed recently** - Check `recently_completed` array. Are any `completed_at` timestamps from the current session (within the last ~1 hour)?
+
+2. **Code changes** - Check `working_tree`:
+   - Is `clean` false?
+   - Are there any `staged`, `unstaged`, or `untracked` files?
+
+3. **Recent commits** - Check `recent_commits` array. Are any commit timestamps from the current session?
+
+**Skip reflection if ALL of these are true:**
+- No tasks completed in the current session
+- Working tree is clean (no staged/unstaged/untracked files)
+- No commits made in the current session
+
+If skipping, output:
+```
+Reflection skipped: no meaningful session work detected (no tasks completed, no code changes, no commits).
+```
+
+Then **exit immediately** without starting the workflow.
+
+### If There IS Meaningful Work
+
+Start the workflow:
 
 ```bash
 kspec workflow start @session-reflect-loop


### PR DESCRIPTION
## Summary

- Add gating logic to the reflect skill's Loop Mode section
- Before starting the reflection workflow, agent checks session introspection data for meaningful work
- If no meaningful work detected (no tasks completed, no code changes, no commits), agent skips reflection and exits immediately
- Prevents wasted time on empty reflection runs during ralph loops

## Background

Data from task notes showed 19% workflow time wasted on 31 consecutive empty reflection runs. This change addresses the issue at the skill level by instructing the agent to check session state before starting the full reflection workflow.

## Test plan

- [x] Skill file updated with clear gating instructions
- [x] Gate criteria defined: recently_completed tasks, working_tree status, recent_commits
- [x] Skip message format specified for when reflection is skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)