### PR TITLE
fix: plan import --update now updates acceptance criteria on existing specs

### DIFF
--- a/src/cli/commands/plan-import.ts
+++ b/src/cli/commands/plan-import.ts
@@ -19,6 +19,7 @@ import {
   loadPlans,
   savePlan,
   saveTask,
+  updateSpecItem,
   type LoadedSpecItem,
 } from "../../parser/index.js";
 import {
@@ -256,11 +257,30 @@ async function importPlan(
 
       if (exists.ok && options.update) {
         // AC: @plan-import ac-26 - Update existing spec
+        // Updates: description, type, tags, traits, and acceptance_criteria
+        const existingSpec = exists.item as LoadedSpecItem;
+
         if (options.dryRun) {
           info(`Would update spec: ${specRef}`);
           result.updatedSpecs.push(specRef);
         } else {
-          // Update logic would go here - for now, skip
+          // Build updates from plan spec
+          const updates: Partial<SpecItemInput> = {};
+
+          if (spec.description !== undefined) {
+            updates.description = spec.description;
+          }
+          if (spec.type !== undefined) {
+            updates.type = spec.type as SpecItemInput["type"];
+          }
+          if (spec.traits !== undefined) {
+            updates.traits = spec.traits.map(t => t.startsWith('@') ? t : `@${t}`);
+          }
+          if (spec.acceptance_criteria !== undefined) {
+            updates.acceptance_criteria = spec.acceptance_criteria;
+          }
+
+          await updateSpecItem(ctx, existingSpec, updates);
           info(`Updated spec: ${specRef}`);
           result.updatedSpecs.push(specRef);
         }

--- a/tests/cli-plan-import.test.ts
+++ b/tests/cli-plan-import.test.ts
@@ -631,6 +631,103 @@ derive_from_specs: true
     expect(output).toContain("Updated spec: @my-feature");
   });
 
+  // AC: @plan-import ac-26 - Verify acceptance criteria are updated
+  it("should update acceptance criteria on existing specs with --update flag", async () => {
+    // Create initial spec with ACs
+    kspec('item add --under @test-core --title "Feature" --slug ac-feature', tempDir);
+    kspec('item ac add @ac-feature --given "initial" --when "test" --then "pass"', tempDir);
+
+    // Verify initial AC exists
+    const beforeSpec = kspecJson<{
+      acceptance_criteria: Array<{ id: string; given: string; when: string; then: string }>;
+    }>("item get @ac-feature --json", tempDir);
+    expect(beforeSpec.acceptance_criteria).toHaveLength(1);
+    expect(beforeSpec.acceptance_criteria[0].given).toBe("initial");
+
+    const planPath = path.join(tempDir, "update-ac-plan.md");
+    await fs.writeFile(
+      planPath,
+      `# Update AC Plan
+
+## Specs
+
+\`\`\`yaml
+- title: Feature
+  slug: ac-feature
+  description: Updated with new ACs
+  acceptance_criteria:
+    - id: ac-new-1
+      given: A user is logged in
+      when: They click logout
+      then: Session ends
+    - id: ac-new-2
+      given: A user is on the dashboard
+      when: They view stats
+      then: Current data is shown
+\`\`\`
+`,
+    );
+
+    const output = kspec(
+      `plan import "${planPath}" --module @test-core --update`,
+      tempDir,
+    );
+    expect(output).toContain("Updated spec: @ac-feature");
+
+    // Verify ACs were updated
+    const afterSpec = kspecJson<{
+      description: string;
+      acceptance_criteria: Array<{ id: string; given: string; when: string; then: string }>;
+    }>("item get @ac-feature --json", tempDir);
+
+    expect(afterSpec.description).toBe("Updated with new ACs");
+    expect(afterSpec.acceptance_criteria).toHaveLength(2);
+    expect(afterSpec.acceptance_criteria[0].id).toBe("ac-new-1");
+    expect(afterSpec.acceptance_criteria[0].given).toBe("A user is logged in");
+    expect(afterSpec.acceptance_criteria[1].id).toBe("ac-new-2");
+    expect(afterSpec.acceptance_criteria[1].given).toBe("A user is on the dashboard");
+  });
+
+  // AC: @plan-import ac-26 - Verify traits are updated
+  it("should update traits on existing specs with --update flag", async () => {
+    // Create initial spec
+    kspec('item add --under @test-core --title "Feature" --slug trait-feature', tempDir);
+
+    const planPath = path.join(tempDir, "update-traits-plan.md");
+    await fs.writeFile(
+      planPath,
+      `# Update Traits Plan
+
+## Specs
+
+\`\`\`yaml
+- title: Feature
+  slug: trait-feature
+  type: requirement
+  traits:
+    - json-output
+    - cli-command
+\`\`\`
+`,
+    );
+
+    const output = kspec(
+      `plan import "${planPath}" --module @test-core --update`,
+      tempDir,
+    );
+    expect(output).toContain("Updated spec: @trait-feature");
+
+    // Verify traits were updated
+    const afterSpec = kspecJson<{
+      type: string;
+      traits: string[];
+    }>("item get @trait-feature --json", tempDir);
+
+    expect(afterSpec.type).toBe("requirement");
+    expect(afterSpec.traits).toContain("@json-output");
+    expect(afterSpec.traits).toContain("@cli-command");
+  });
+
   // AC: @plan-import ac-27
   it("should create manual tasks from additional_tasks array", async () => {
     const planPath = path.join(tempDir, "test-plan.md");


### PR DESCRIPTION
## Summary

- Implemented actual update logic for `kspec plan import --update` flag
- Previously the code had a placeholder comment "Update logic would go here - for now, skip" with no actual implementation
- Now `updateSpecItem()` is called with updates from the plan spec:
  - `description`
  - `type`
  - `traits` (with auto @ prefixing)
  - `acceptance_criteria`
- Added 2 new tests verifying the fix:
  - AC update test: creates spec with AC, imports plan with different ACs, verifies ACs are replaced
  - Trait update test: verifies type and traits are updated

## Test plan

- [x] All 29 plan import tests pass
- [x] New test verifies AC updates work correctly
- [x] New test verifies trait/type updates work correctly

Task: @01KHAQC8
Spec: @plan-import ac-26

🤖 Generated with [Claude Code](https://claude.ai/code)