### PR TITLE
docs: document fenced YAML requirement for plan import

### DIFF
--- a/.claude/skills/spec-plan/SKILL.md
+++ b/.claude/skills/spec-plan/SKILL.md
@@ -77,7 +77,9 @@ Batch runs all commands against an isolated state copy and commits once on succe
 
 ## Plan Document Format
 
-The import path uses structured markdown documents. The parser (`parsePlanDocument()`) extracts specs, tasks, and notes from this format:
+The import path uses structured markdown documents. The parser (`parsePlanDocument()`) extracts specs, tasks, and notes from this format.
+
+**Important:** The `## Specs` section MUST contain a fenced YAML code block (wrapped in triple-backtick yaml markers). Without the fenced block, no specs will be detected and you'll see a warning: "Specs section found but no YAML code block detected — wrap specs in triple-backtick yaml block".
 
 ```markdown
 # Auth Redesign

--- a/src/cli/commands/plan-import.ts
+++ b/src/cli/commands/plan-import.ts
@@ -52,6 +52,18 @@ export function registerPlanImportCommand(planCommand: Command): void {
     .addHelpText(
       "after",
       `
+Format:
+  Plan documents use markdown with a ## Specs section containing a fenced
+  YAML code block. The YAML must be wrapped in triple-backtick yaml markers:
+
+    ## Specs
+    \`\`\`yaml
+    - title: My Feature
+      type: feature
+    \`\`\`
+
+  Without the fenced code block, specs will not be detected.
+
 Examples:
   $ kspec plan import ./plan.md --module @core
   $ kspec plan import ./plan.md --module @api --dry-run


### PR DESCRIPTION
## Summary

- Added Format section to `kspec plan import --help` explaining the fenced YAML code block requirement
- Updated spec-plan skill (`SKILL.md`) with Important callout about the same requirement
- Addresses ac-34 documentation gap: users now know that `## Specs` section must wrap YAML in triple-backtick markers

## Test plan

- [x] Verify `kspec plan import --help` shows Format section with fenced YAML guidance
- [x] All 29 plan import tests pass

Task: @01KHAQCH
Spec: @plan-import

🤖 Generated with [Claude Code](https://claude.ai/code)