### PR TITLE
feat: cache scanTestCoverage() results for daemon performance

### DIFF
--- a/packages/daemon/src/routes/items.ts
+++ b/packages/daemon/src/routes/items.ts
@@ -20,7 +20,7 @@ import {
   loadAllTasks,
   ReferenceIndex,
   AlignmentIndex,
-  scanTestCoverage,
+  getCachedTestCoverage,
   computeACCoverage,
   type LoadedSpecItem,
 } from '../../parser/index.js';
@@ -220,10 +220,11 @@ export function createItemsRoutes(options: ItemsRouteOptions = {}) {
         }
 
         // AC: @web-dashboard ac-15 - Compute test coverage for acceptance criteria
+        // Uses cached coverage scan for performance (avoids re-scanning on every request)
         let acceptanceCriteriaWithCoverage = item.acceptance_criteria;
         if (item.acceptance_criteria && item.acceptance_criteria.length > 0) {
           try {
-            const coveredACs = await scanTestCoverage(projectContext.path);
+            const coveredACs = await getCachedTestCoverage(projectContext.path);
             acceptanceCriteriaWithCoverage = computeACCoverage(item, coveredACs);
           } catch (err) {
             // Coverage scan failed - leave as undefined

--- a/src/parser/coverage-cache.ts
+++ b/src/parser/coverage-cache.ts
@@ -1,0 +1,153 @@
+/**
+ * Test coverage cache for daemon performance optimization.
+ *
+ * Caches scanTestCoverage() results to avoid re-scanning test files
+ * on every API request. The cache is per-project-directory and supports:
+ * - TTL-based expiration (default 60 seconds)
+ * - Explicit invalidation for file watcher integration
+ *
+ * @module coverage-cache
+ */
+
+import { scanTestCoverage } from "./validate.js";
+
+/**
+ * Cached coverage data with metadata
+ */
+interface CacheEntry {
+  /** The actual coverage set */
+  coverage: Set<string>;
+  /** Timestamp when cache was populated */
+  cachedAt: number;
+  /** Promise for in-flight scan (prevents duplicate parallel scans) */
+  pending?: Promise<Set<string>>;
+}
+
+/**
+ * Default TTL in milliseconds (60 seconds)
+ */
+const DEFAULT_TTL_MS = 60_000;
+
+/**
+ * Per-project cache storage
+ * Key: normalized root directory path
+ */
+const cache = new Map<string, CacheEntry>();
+
+/**
+ * Configurable TTL (for testing)
+ */
+let ttlMs = DEFAULT_TTL_MS;
+
+/**
+ * Normalize a directory path for use as cache key.
+ * Removes trailing slashes for consistency.
+ */
+function normalizePath(dir: string): string {
+  return dir.endsWith("/") ? dir.slice(0, -1) : dir;
+}
+
+/**
+ * Check if a cache entry is still valid based on TTL.
+ */
+function isValid(entry: CacheEntry): boolean {
+  return Date.now() - entry.cachedAt < ttlMs;
+}
+
+/**
+ * Get test coverage for a project directory, using cache when available.
+ *
+ * This is the primary API for daemon routes. It:
+ * 1. Returns cached results if valid
+ * 2. Returns in-flight scan result if a scan is already in progress
+ * 3. Otherwise initiates a new scan and caches the result
+ *
+ * @param rootDir - Project root directory containing tests/
+ * @returns Set of covered AC references (e.g., "@spec-ref ac-1")
+ */
+export async function getCachedTestCoverage(
+  rootDir: string
+): Promise<Set<string>> {
+  const key = normalizePath(rootDir);
+  const existing = cache.get(key);
+
+  // Return cached result if valid
+  if (existing && isValid(existing) && !existing.pending) {
+    return existing.coverage;
+  }
+
+  // Return in-flight scan if one exists (prevents duplicate parallel scans)
+  if (existing?.pending) {
+    return existing.pending;
+  }
+
+  // Initiate new scan
+  const scanPromise = scanTestCoverage(rootDir);
+
+  // Store pending promise to prevent parallel scans
+  const entry: CacheEntry = existing || {
+    coverage: new Set(),
+    cachedAt: 0,
+  };
+  entry.pending = scanPromise;
+  cache.set(key, entry);
+
+  try {
+    const coverage = await scanPromise;
+    // Update cache with result
+    entry.coverage = coverage;
+    entry.cachedAt = Date.now();
+    entry.pending = undefined;
+    return coverage;
+  } catch (error) {
+    // Clear pending on error, allow retry
+    entry.pending = undefined;
+    throw error;
+  }
+}
+
+/**
+ * Invalidate the test coverage cache for a specific project or all projects.
+ *
+ * Call this when test files change (via file watcher) to ensure
+ * fresh coverage data on next request.
+ *
+ * @param rootDir - Optional project root directory. If omitted, clears all caches.
+ */
+export function invalidateTestCoverageCache(rootDir?: string): void {
+  if (rootDir) {
+    const key = normalizePath(rootDir);
+    cache.delete(key);
+  } else {
+    cache.clear();
+  }
+}
+
+/**
+ * Set the cache TTL (for testing purposes).
+ *
+ * @param ms - TTL in milliseconds
+ */
+export function setTestCoverageCacheTTL(ms: number): void {
+  ttlMs = ms;
+}
+
+/**
+ * Reset the cache TTL to default (for testing purposes).
+ */
+export function resetTestCoverageCacheTTL(): void {
+  ttlMs = DEFAULT_TTL_MS;
+}
+
+/**
+ * Get current cache statistics (for debugging/monitoring).
+ */
+export function getTestCoverageCacheStats(): {
+  entries: number;
+  ttlMs: number;
+} {
+  return {
+    entries: cache.size,
+    ttlMs,
+  };
+}

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -3,6 +3,7 @@
 export * from "./alignment.js";
 export * from "./assess.js";
 export * from "./convention-validation.js";
+export * from "./coverage-cache.js";
 export * from "./fix.js";
 export * from "./items.js";
 export * from "./meta.js";

--- a/tests/coverage-cache.test.ts
+++ b/tests/coverage-cache.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Test coverage cache tests
+ *
+ * AC Coverage: Task @01KGGTYQ - Cache scanTestCoverage() results for daemon performance
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { createTempDir, cleanupTempDir } from './helpers/cli';
+import {
+  getCachedTestCoverage,
+  invalidateTestCoverageCache,
+  setTestCoverageCacheTTL,
+  resetTestCoverageCacheTTL,
+  getTestCoverageCacheStats,
+} from '../src/parser/coverage-cache';
+
+describe('coverage-cache', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await createTempDir('coverage-cache-');
+    // Create tests directory structure
+    await fs.mkdir(path.join(tempDir, 'tests'), { recursive: true });
+    // Clear cache between tests
+    invalidateTestCoverageCache();
+    resetTestCoverageCacheTTL();
+  });
+
+  afterEach(async () => {
+    await cleanupTempDir(tempDir);
+    invalidateTestCoverageCache();
+    resetTestCoverageCacheTTL();
+  });
+
+  describe('getCachedTestCoverage', () => {
+    it('should return empty set for project with no tests', async () => {
+      const coverage = await getCachedTestCoverage(tempDir);
+      expect(coverage).toBeInstanceOf(Set);
+      expect(coverage.size).toBe(0);
+    });
+
+    it('should return coverage from test files with AC annotations', async () => {
+      // Create a test file with AC annotations
+      const testFile = path.join(tempDir, 'tests', 'example.test.ts');
+      await fs.writeFile(
+        testFile,
+        `
+// AC: @spec-item ac-1
+it('should do something', () => {});
+
+// AC: @spec-item ac-2, ac-3
+it('should do more', () => {});
+`
+      );
+
+      const coverage = await getCachedTestCoverage(tempDir);
+      expect(coverage.has('@spec-item ac-1')).toBe(true);
+      expect(coverage.has('@spec-item ac-2')).toBe(true);
+      expect(coverage.has('@spec-item ac-3')).toBe(true);
+    });
+
+    it('should cache results on second call', async () => {
+      // First call populates cache
+      const coverage1 = await getCachedTestCoverage(tempDir);
+      const stats1 = getTestCoverageCacheStats();
+      expect(stats1.entries).toBe(1);
+
+      // Second call should return cached result
+      const coverage2 = await getCachedTestCoverage(tempDir);
+
+      // Should be the same object (cached)
+      expect(coverage1).toBe(coverage2);
+    });
+
+    it('should handle parallel calls without duplicate scans', async () => {
+      // Create a test file
+      const testFile = path.join(tempDir, 'tests', 'example.test.ts');
+      await fs.writeFile(testFile, '// AC: @spec ac-1\nit("test", () => {});');
+
+      // Start multiple parallel calls
+      const results = await Promise.all([
+        getCachedTestCoverage(tempDir),
+        getCachedTestCoverage(tempDir),
+        getCachedTestCoverage(tempDir),
+      ]);
+
+      // All should return the same cached result
+      expect(results[0]).toBe(results[1]);
+      expect(results[1]).toBe(results[2]);
+
+      // Only one cache entry should exist
+      const stats = getTestCoverageCacheStats();
+      expect(stats.entries).toBe(1);
+    });
+
+    it('should cache separately per project directory', async () => {
+      const tempDir2 = await createTempDir('coverage-cache-2-');
+      await fs.mkdir(path.join(tempDir2, 'tests'), { recursive: true });
+
+      try {
+        // Create different test files in each directory
+        await fs.writeFile(
+          path.join(tempDir, 'tests', 'a.test.ts'),
+          '// AC: @spec-a ac-1\nit("test", () => {});'
+        );
+        await fs.writeFile(
+          path.join(tempDir2, 'tests', 'b.test.ts'),
+          '// AC: @spec-b ac-1\nit("test", () => {});'
+        );
+
+        const coverage1 = await getCachedTestCoverage(tempDir);
+        const coverage2 = await getCachedTestCoverage(tempDir2);
+
+        // Different projects should have different coverage
+        expect(coverage1.has('@spec-a ac-1')).toBe(true);
+        expect(coverage1.has('@spec-b ac-1')).toBe(false);
+
+        expect(coverage2.has('@spec-b ac-1')).toBe(true);
+        expect(coverage2.has('@spec-a ac-1')).toBe(false);
+
+        // Two cache entries should exist
+        const stats = getTestCoverageCacheStats();
+        expect(stats.entries).toBe(2);
+      } finally {
+        await cleanupTempDir(tempDir2);
+      }
+    });
+
+    it('should expire cache after TTL', async () => {
+      // Set a very short TTL
+      setTestCoverageCacheTTL(10); // 10ms
+
+      // Create initial test file
+      const testFile = path.join(tempDir, 'tests', 'example.test.ts');
+      await fs.writeFile(testFile, '// AC: @spec-a ac-1\nit("test", () => {});');
+
+      const coverage1 = await getCachedTestCoverage(tempDir);
+      expect(coverage1.has('@spec-a ac-1')).toBe(true);
+
+      // Update the test file
+      await fs.writeFile(testFile, '// AC: @spec-b ac-1\nit("test", () => {});');
+
+      // Wait for TTL to expire
+      await new Promise((resolve) => setTimeout(resolve, 20));
+
+      // Should re-scan and get new coverage
+      const coverage2 = await getCachedTestCoverage(tempDir);
+      expect(coverage2.has('@spec-b ac-1')).toBe(true);
+      // Old coverage should be gone (new object)
+      expect(coverage2).not.toBe(coverage1);
+    });
+  });
+
+  describe('invalidateTestCoverageCache', () => {
+    it('should clear cache for specific project', async () => {
+      // Populate cache
+      await getCachedTestCoverage(tempDir);
+      expect(getTestCoverageCacheStats().entries).toBe(1);
+
+      // Invalidate
+      invalidateTestCoverageCache(tempDir);
+      expect(getTestCoverageCacheStats().entries).toBe(0);
+    });
+
+    it('should clear all caches when called without argument', async () => {
+      const tempDir2 = await createTempDir('coverage-cache-2-');
+      await fs.mkdir(path.join(tempDir2, 'tests'), { recursive: true });
+
+      try {
+        // Populate caches for multiple projects
+        await getCachedTestCoverage(tempDir);
+        await getCachedTestCoverage(tempDir2);
+        expect(getTestCoverageCacheStats().entries).toBe(2);
+
+        // Invalidate all
+        invalidateTestCoverageCache();
+        expect(getTestCoverageCacheStats().entries).toBe(0);
+      } finally {
+        await cleanupTempDir(tempDir2);
+      }
+    });
+
+    it('should handle path with trailing slash', async () => {
+      // Populate cache with path without trailing slash
+      await getCachedTestCoverage(tempDir);
+      expect(getTestCoverageCacheStats().entries).toBe(1);
+
+      // Invalidate with trailing slash - should still work
+      invalidateTestCoverageCache(tempDir + '/');
+      expect(getTestCoverageCacheStats().entries).toBe(0);
+    });
+  });
+
+  describe('cache configuration', () => {
+    it('should report correct TTL in stats', () => {
+      const defaultStats = getTestCoverageCacheStats();
+      expect(defaultStats.ttlMs).toBe(60_000); // 60 seconds default
+
+      setTestCoverageCacheTTL(30_000);
+      const customStats = getTestCoverageCacheStats();
+      expect(customStats.ttlMs).toBe(30_000);
+    });
+
+    it('should reset TTL to default', () => {
+      setTestCoverageCacheTTL(5_000);
+      expect(getTestCoverageCacheStats().ttlMs).toBe(5_000);
+
+      resetTestCoverageCacheTTL();
+      expect(getTestCoverageCacheStats().ttlMs).toBe(60_000);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add TTL-based caching (60s default) for test coverage scans to avoid re-scanning test files on every `/api/items/:ref` request
- Support explicit cache invalidation for file watcher integration
- Handle concurrent requests without duplicate scans

## Test plan
- [x] Run coverage cache tests: `npm test -- tests/coverage-cache.test.ts`
- [x] Run daemon API items tests to verify integration
- [x] Verify 11 tests cover caching, TTL expiration, invalidation, and multi-project scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)