### PR TITLE
feat: add AC schema field validation to detect drift

### DIFF
--- a/src/cli/commands/validate.ts
+++ b/src/cli/commands/validate.ts
@@ -5,6 +5,7 @@ import type { LoadedSpecItem, LoadedTask } from "../../parser/index.js";
 import {
   AlignmentIndex,
   type AlignmentWarning,
+  checkACSchemaReferences,
   type CompletenessWarning,
   type ConventionValidationResult,
   expandIncludePattern,
@@ -263,6 +264,65 @@ function formatStalenessWarnings(
         chalk.gray(`    ... and ${automationBlocking.length - 3} more`),
       );
     }
+  }
+}
+
+/**
+ * AC schema drift warning type
+ */
+interface ACDriftWarning {
+  type: "ac_schema_field_mismatch";
+  itemRef: string;
+  itemTitle: string;
+  message: string;
+  details?: string;
+}
+
+/**
+ * Format AC schema drift warnings for display
+ */
+function formatDriftWarnings(
+  warnings: CompletenessWarning[],
+  verbose: boolean,
+): void {
+  // Filter to only drift warnings
+  const driftWarnings = warnings.filter(
+    (w) => w.type === "ac_schema_field_mismatch",
+  ) as ACDriftWarning[];
+
+  if (driftWarnings.length === 0) {
+    console.log(chalk.green("AC Schema Drift: OK"));
+    return;
+  }
+
+  console.log(chalk.yellow(`\nAC Schema Drift warnings: ${driftWarnings.length}`));
+
+  // Group by item
+  const byItem = new Map<string, ACDriftWarning[]>();
+  for (const w of driftWarnings) {
+    const existing = byItem.get(w.itemRef) || [];
+    existing.push(w);
+    byItem.set(w.itemRef, existing);
+  }
+
+  const itemEntries = [...byItem.entries()];
+  const shown = verbose ? itemEntries : itemEntries.slice(0, 5);
+
+  for (const [itemRef, itemWarnings] of shown) {
+    const firstWarning = itemWarnings[0];
+    console.log(chalk.yellow(`  ${itemRef} - ${firstWarning.itemTitle}`));
+    for (const w of itemWarnings) {
+      console.log(chalk.yellow(`    ! ${w.message}`));
+      if (w.details) {
+        console.log(chalk.gray(`      ${w.details}`));
+      }
+    }
+  }
+
+  if (!verbose && itemEntries.length > 5) {
+    console.log(
+      chalk.gray(`  ... and ${itemEntries.length - 5} more items with drift`),
+    );
   }
 }
 
@@ -736,6 +796,10 @@ export function registerValidateCommand(program: Command): void {
     )
     .option("--skills", "Validate skill files (.claude/skills/*/SKILL.md)")
     .option(
+      "--drift",
+      "Check AC field references against actual schema (catches spec prose drift)",
+    )
+    .option(
       "--fix",
       "Auto-fix issues where possible (invalid ULIDs, missing timestamps)",
     )
@@ -894,16 +958,31 @@ export function registerValidateCommand(program: Command): void {
           }
         }
 
+        // Run AC schema drift checks if requested
+        let driftWarningCount = 0;
+        if (options.drift) {
+          const items = await loadAllItems(ctx);
+          const driftWarnings = checkACSchemaReferences(items);
+          formatDriftWarnings(driftWarnings, options.verbose);
+          driftWarningCount = driftWarnings.length;
+
+          // With --strict, drift warnings cause validation failure
+          if (options.strict && driftWarnings.length > 0) {
+            result.valid = false;
+          }
+        }
+
         // Determine exit code based on errors vs warnings
         // Errors: schema, refs, trait cycles, conventions, skills (result.valid = false)
-        // Warnings: orphans, alignment, completeness, staleness, ref warnings
+        // Warnings: orphans, alignment, completeness, staleness, drift, ref warnings
         const hasErrors = !result.valid;
         const hasWarnings =
           result.orphans.length > 0 ||
           result.refWarnings.length > 0 ||
           result.completenessWarnings.length > 0 ||
           additionalWarningCount > 0 ||
-          stalenessWarningCount > 0;
+          stalenessWarningCount > 0 ||
+          driftWarningCount > 0;
 
         if (hasErrors) {
           process.exit(EXIT_CODES.VALIDATION_FAILED);

--- a/src/parser/validate.ts
+++ b/src/parser/validate.ts
@@ -68,7 +68,8 @@ export type CompletenessWarningType =
   | "missing_description"
   | "status_inconsistency"
   | "missing_test_coverage"
-  | "automation_eligible_no_spec";
+  | "automation_eligible_no_spec"
+  | "ac_schema_field_mismatch";
 
 /**
  * Trait cycle error
@@ -994,6 +995,235 @@ async function checkCompleteness(
           details:
             "Retrospective specs with verified_at/verified_by should have implementation status set to 'implemented' or 'verified'",
         });
+      }
+    }
+  }
+
+  return warnings;
+}
+
+// ============================================================
+// AC SCHEMA DRIFT DETECTION
+// ============================================================
+
+/**
+ * Known schema fields for SpecItem
+ * These are the actual fields defined in SpecItemSchema
+ */
+const SPEC_ITEM_FIELDS = new Set([
+  "_ulid",
+  "slugs",
+  "title",
+  "type",
+  "status",
+  "maturity",
+  "implementation",
+  "priority",
+  "tags",
+  "description",
+  "acceptance_criteria",
+  "depends_on",
+  "implements",
+  "relates_to",
+  "tests",
+  "traits",
+  "supersedes",
+  "traceability",
+  "created",
+  "created_by",
+  "deprecated_in",
+  "superseded_by",
+  "verified_at",
+  "verified_by",
+  "notes",
+]);
+
+/**
+ * Known schema fields for Task
+ * These are the actual fields defined in TaskSchema
+ */
+const TASK_FIELDS = new Set([
+  "_ulid",
+  "slugs",
+  "title",
+  "type",
+  "description",
+  "spec_ref",
+  "derivation",
+  "meta_ref",
+  "plan_ref",
+  "origin",
+  "status",
+  "blocked_by",
+  "closed_reason",
+  "depends_on",
+  "context",
+  "priority",
+  "complexity",
+  "tags",
+  "assignee",
+  "vcs_refs",
+  "created_at",
+  "started_at",
+  "completed_at",
+  "notes",
+  "todos",
+  "automation",
+]);
+
+/**
+ * Known fields that are referenced but are parse-time or conceptual only
+ * These are common pseudo-fields that ACs reference but don't exist in schema
+ */
+const CONCEPTUAL_FIELDS = new Set([
+  "children", // Hierarchy is parse-time only
+  "parent", // Parent references are derived, not stored
+  "modules", // These are container structures in YAML, not item fields
+  "features",
+  "requirements",
+  "constraints",
+  "decisions",
+  "epics",
+  "themes",
+  "capabilities",
+]);
+
+/**
+ * Extract field reference patterns from AC text
+ * Looks for patterns like:
+ * - item.field
+ * - spec.field
+ * - task.field
+ * - status.field
+ * - spec_ref.field
+ * - the field
+ * - their field
+ * - item's field
+ */
+/**
+ * File extensions to exclude from field matching
+ * These are common file extensions that would otherwise match our patterns
+ */
+const FILE_EXTENSIONS = new Set([
+  "yaml",
+  "yml",
+  "json",
+  "js",
+  "ts",
+  "md",
+  "txt",
+  "html",
+  "css",
+  "log",
+]);
+
+function extractFieldReferences(text: string): Array<{ context: string; field: string }> {
+  const references: Array<{ context: string; field: string }> = [];
+
+  // Pattern: context.field (e.g., item.status, spec_ref.children)
+  // This matches entity.property patterns in prose
+  const dotPattern = /\b(item|spec|task|status|spec_ref|task_ref|meta_ref|plan_ref)\.(\w+)/gi;
+  let match: RegExpExecArray | null;
+  while ((match = dotPattern.exec(text)) !== null) {
+    const field = match[2].toLowerCase();
+    // Skip file extensions (e.g., spec.yaml, task.json)
+    if (FILE_EXTENSIONS.has(field)) {
+      continue;
+    }
+    references.push({ context: match[1].toLowerCase(), field });
+  }
+
+  // Pattern: "the <field>" when discussing items/tasks (common in ACs)
+  // Only match known schema-like words to avoid false positives
+  const thePattern = /\bthe\s+(status|children|parent|spec_ref|depends_on|traits|tags|notes|todos|acceptance_criteria)\b/gi;
+  while ((match = thePattern.exec(text)) !== null) {
+    references.push({ context: "item", field: match[1].toLowerCase() });
+  }
+
+  return references;
+}
+
+/**
+ * Check if a field exists in the appropriate schema
+ */
+function isValidSchemaField(context: string, field: string): { valid: boolean; reason?: string } {
+  // If it's a known conceptual field, it's technically invalid but we can give a specific message
+  if (CONCEPTUAL_FIELDS.has(field)) {
+    return { valid: false, reason: `'${field}' is a parse-time/conceptual field, not stored in schema` };
+  }
+
+  // Check based on context
+  switch (context) {
+    case "spec":
+    case "item":
+      if (SPEC_ITEM_FIELDS.has(field)) {
+        return { valid: true };
+      }
+      break;
+
+    case "task":
+      if (TASK_FIELDS.has(field)) {
+        return { valid: true };
+      }
+      break;
+
+    case "status":
+      // status.maturity, status.implementation are valid for specs
+      if (field === "maturity" || field === "implementation") {
+        return { valid: true };
+      }
+      break;
+
+    case "spec_ref":
+    case "task_ref":
+    case "meta_ref":
+    case "plan_ref":
+      // These are string references, not objects with fields
+      return { valid: false, reason: `'${context}' is a reference string, not an object with fields` };
+  }
+
+  // Check if field exists in either schema (might be ambiguous context)
+  if (SPEC_ITEM_FIELDS.has(field) || TASK_FIELDS.has(field)) {
+    return { valid: true };
+  }
+
+  return { valid: false, reason: `'${field}' is not a known schema field` };
+}
+
+/**
+ * Check acceptance criteria for field references that don't exist in schema
+ * Catches drift between spec prose and implementation reality.
+ */
+export function checkACSchemaReferences(
+  items: LoadedSpecItem[],
+): CompletenessWarning[] {
+  const warnings: CompletenessWarning[] = [];
+
+  for (const item of items) {
+    if (!item.acceptance_criteria || item.acceptance_criteria.length === 0) {
+      continue;
+    }
+
+    const itemRef = item.slugs?.[0]
+      ? `@${item.slugs[0]}`
+      : `@${item._ulid.slice(0, 8)}`;
+
+    for (const ac of item.acceptance_criteria) {
+      // Check all three parts of the AC for field references
+      const textToCheck = `${ac.given} ${ac.when} ${ac.then}`;
+      const fieldRefs = extractFieldReferences(textToCheck);
+
+      for (const { context, field } of fieldRefs) {
+        const result = isValidSchemaField(context, field);
+        if (!result.valid) {
+          warnings.push({
+            type: "ac_schema_field_mismatch",
+            itemRef,
+            itemTitle: item.title,
+            message: `AC ${ac.id} references '${context}.${field}' which doesn't exist in schema`,
+            details: result.reason,
+          });
+        }
       }
     }
   }

--- a/tests/ac-schema-drift.test.ts
+++ b/tests/ac-schema-drift.test.ts
@@ -1,0 +1,356 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  cleanupTempDir,
+  createTempDir,
+  initGitRepo,
+  kspecOutput as kspec,
+  kspecWithStatus,
+} from "./helpers/cli";
+
+/**
+ * Tests for AC schema field drift detection
+ * Task: @01KGGZKQ
+ *
+ * Validates that acceptance criteria don't reference schema fields that don't exist.
+ */
+describe("AC Schema Drift detection", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await createTempDir("kspec-drift-test-");
+    initGitRepo(tmpDir);
+  });
+
+  afterEach(async () => {
+    if (tmpDir) {
+      await cleanupTempDir(tmpDir);
+    }
+  });
+
+  it("should warn when AC references non-existent field like item.children", async () => {
+    const specDir = path.join(tmpDir, "spec");
+    await fs.mkdir(specDir);
+
+    // Create manifest
+    await fs.writeFile(
+      path.join(tmpDir, "kynetic.yaml"),
+      `kynetic: "1.0"
+project:
+  name: test-project
+  version: 0.1.0
+includes:
+  - "spec/module.yaml"
+`,
+    );
+
+    // Create spec with AC that references children field (doesn't exist in schema)
+    await fs.writeFile(
+      path.join(specDir, "module.yaml"),
+      `- _ulid: 01JHNKAB01SPEC0000000000A1
+  slugs:
+    - test-spec
+  title: Test Spec with drift
+  type: feature
+  acceptance_criteria:
+    - id: ac-1
+      given: a parent item with children
+      when: the item.children are modified
+      then: all item.children should be updated
+`,
+    );
+
+    // Run validate --drift
+    const result = kspec("validate --drift", tmpDir);
+
+    expect(result).toContain("AC Schema Drift warnings");
+    expect(result).toContain("item.children");
+    expect(result).toContain("parse-time/conceptual field");
+  });
+
+  it("should warn when AC references spec_ref.field (spec_ref is a string, not object)", async () => {
+    const specDir = path.join(tmpDir, "spec");
+    await fs.mkdir(specDir);
+
+    // Create manifest
+    await fs.writeFile(
+      path.join(tmpDir, "kynetic.yaml"),
+      `kynetic: "1.0"
+project:
+  name: test-project
+  version: 0.1.0
+includes:
+  - "spec/module.yaml"
+`,
+    );
+
+    // Create spec with AC that references spec_ref.children
+    await fs.writeFile(
+      path.join(specDir, "module.yaml"),
+      `- _ulid: 01JHNKAB01SPEC0000000000A1
+  slugs:
+    - test-spec
+  title: Test Spec with ref drift
+  type: feature
+  acceptance_criteria:
+    - id: ac-1
+      given: a task with a spec_ref
+      when: the spec_ref.status changes
+      then: the task should reflect spec_ref.children state
+`,
+    );
+
+    // Run validate --drift
+    const result = kspec("validate --drift", tmpDir);
+
+    expect(result).toContain("AC Schema Drift warnings");
+    expect(result).toContain("spec_ref");
+    expect(result).toContain("reference string, not an object");
+  });
+
+  it("should NOT warn when AC references valid schema fields", async () => {
+    const specDir = path.join(tmpDir, "spec");
+    await fs.mkdir(specDir);
+
+    // Create manifest
+    await fs.writeFile(
+      path.join(tmpDir, "kynetic.yaml"),
+      `kynetic: "1.0"
+project:
+  name: test-project
+  version: 0.1.0
+includes:
+  - "spec/module.yaml"
+`,
+    );
+
+    // Create spec with AC that references valid fields
+    await fs.writeFile(
+      path.join(specDir, "module.yaml"),
+      `- _ulid: 01JHNKAB01SPEC0000000000A1
+  slugs:
+    - test-spec
+  title: Test Spec with valid refs
+  type: feature
+  acceptance_criteria:
+    - id: ac-1
+      given: a spec item
+      when: the item.status is updated
+      then: the item.tags should reflect the change
+`,
+    );
+
+    // Run validate --drift
+    const result = kspec("validate --drift", tmpDir);
+
+    expect(result).toContain("AC Schema Drift: OK");
+    expect(result).not.toContain("AC Schema Drift warnings");
+  });
+
+  it("should warn when AC references task fields that don't exist", async () => {
+    const specDir = path.join(tmpDir, "spec");
+    await fs.mkdir(specDir);
+
+    // Create manifest
+    await fs.writeFile(
+      path.join(tmpDir, "kynetic.yaml"),
+      `kynetic: "1.0"
+project:
+  name: test-project
+  version: 0.1.0
+includes:
+  - "spec/module.yaml"
+`,
+    );
+
+    // Create spec with AC that references unknown task field
+    await fs.writeFile(
+      path.join(specDir, "module.yaml"),
+      `- _ulid: 01JHNKAB01SPEC0000000000A1
+  slugs:
+    - test-spec
+  title: Test Spec with task drift
+  type: feature
+  acceptance_criteria:
+    - id: ac-1
+      given: a task
+      when: the task.foobar changes
+      then: task.baz should be updated
+`,
+    );
+
+    // Run validate --drift
+    const result = kspec("validate --drift", tmpDir);
+
+    expect(result).toContain("AC Schema Drift warnings");
+    expect(result).toContain("task.foobar");
+    expect(result).toContain("not a known schema field");
+  });
+
+  it("should accept valid status.maturity and status.implementation references", async () => {
+    const specDir = path.join(tmpDir, "spec");
+    await fs.mkdir(specDir);
+
+    // Create manifest
+    await fs.writeFile(
+      path.join(tmpDir, "kynetic.yaml"),
+      `kynetic: "1.0"
+project:
+  name: test-project
+  version: 0.1.0
+includes:
+  - "spec/module.yaml"
+`,
+    );
+
+    // Create spec with AC that references status fields
+    await fs.writeFile(
+      path.join(specDir, "module.yaml"),
+      `- _ulid: 01JHNKAB01SPEC0000000000A1
+  slugs:
+    - test-spec
+  title: Test Spec with status refs
+  type: feature
+  acceptance_criteria:
+    - id: ac-1
+      given: a spec item
+      when: status.maturity is updated
+      then: status.implementation should be validated
+`,
+    );
+
+    // Run validate --drift
+    const result = kspec("validate --drift", tmpDir);
+
+    expect(result).toContain("AC Schema Drift: OK");
+  });
+
+  it("should only run drift checks when --drift flag is provided", async () => {
+    const specDir = path.join(tmpDir, "spec");
+    await fs.mkdir(specDir);
+
+    // Create manifest
+    await fs.writeFile(
+      path.join(tmpDir, "kynetic.yaml"),
+      `kynetic: "1.0"
+project:
+  name: test-project
+  version: 0.1.0
+includes:
+  - "spec/module.yaml"
+`,
+    );
+
+    // Create spec with AC that references children field
+    await fs.writeFile(
+      path.join(specDir, "module.yaml"),
+      `- _ulid: 01JHNKAB01SPEC0000000000A1
+  slugs:
+    - test-spec
+  title: Test Spec with drift
+  type: feature
+  acceptance_criteria:
+    - id: ac-1
+      given: a parent item
+      when: item.children are modified
+      then: item.children should be updated
+`,
+    );
+
+    // Run validate WITHOUT --drift flag
+    const resultWithoutFlag = kspec("validate", tmpDir);
+
+    // Should NOT contain drift warnings
+    expect(resultWithoutFlag).not.toContain("AC Schema Drift");
+
+    // Run validate WITH --drift flag
+    const resultWithFlag = kspec("validate --drift", tmpDir);
+
+    // Should contain drift warnings
+    expect(resultWithFlag).toContain("AC Schema Drift");
+  });
+
+  it("should exit with code 6 for warnings, code 4 with --strict", async () => {
+    const specDir = path.join(tmpDir, "spec");
+    await fs.mkdir(specDir);
+
+    // Create manifest
+    await fs.writeFile(
+      path.join(tmpDir, "kynetic.yaml"),
+      `kynetic: "1.0"
+project:
+  name: test-project
+  version: 0.1.0
+includes:
+  - "spec/module.yaml"
+`,
+    );
+
+    // Create spec with AC drift issue
+    await fs.writeFile(
+      path.join(specDir, "module.yaml"),
+      `- _ulid: 01JHNKAB01SPEC0000000000A1
+  slugs:
+    - test-spec
+  title: Test Spec with drift
+  type: feature
+  acceptance_criteria:
+    - id: ac-1
+      given: a parent item
+      when: item.children are modified
+      then: item.children should be updated
+`,
+    );
+
+    // Run validate --drift (without --strict) - should exit 6 (warnings present)
+    const resultNoStrict = kspecWithStatus("validate --drift", tmpDir);
+    expect(resultNoStrict.exitCode).toBe(6); // VALIDATION_WARNINGS
+
+    // Run validate --drift --strict - should exit 4 (warnings treated as errors)
+    const resultStrict = kspecWithStatus("validate --drift --strict", tmpDir);
+    expect(resultStrict.exitCode).toBe(4); // VALIDATION_FAILED
+  });
+
+  it("should report multiple drift issues in the same AC", async () => {
+    const specDir = path.join(tmpDir, "spec");
+    await fs.mkdir(specDir);
+
+    // Create manifest
+    await fs.writeFile(
+      path.join(tmpDir, "kynetic.yaml"),
+      `kynetic: "1.0"
+project:
+  name: test-project
+  version: 0.1.0
+includes:
+  - "spec/module.yaml"
+`,
+    );
+
+    // Create spec with multiple drift issues
+    await fs.writeFile(
+      path.join(specDir, "module.yaml"),
+      `- _ulid: 01JHNKAB01SPEC0000000000A1
+  slugs:
+    - test-spec
+  title: Test Spec with multiple drift
+  type: feature
+  acceptance_criteria:
+    - id: ac-1
+      given: an item with item.children and spec_ref.status
+      when: item.parent changes
+      then: spec_ref.children should cascade to item.children
+`,
+    );
+
+    // Run validate --drift
+    const result = kspec("validate --drift", tmpDir);
+
+    expect(result).toContain("AC Schema Drift warnings");
+    // Should catch multiple issues
+    expect(result).toContain("children");
+    expect(result).toContain("parent");
+    expect(result).toContain("spec_ref");
+  });
+});


### PR DESCRIPTION
## Summary
- Add `--drift` flag to `kspec validate` command that checks acceptance criteria for field references that don't exist in the actual schema
- Implements `checkACSchemaReferences()` function that extracts field patterns from AC given/when/then clauses (e.g., `item.status`, `spec_ref.children`)
- Validates against actual SpecItemSchema and TaskSchema fields
- Detects conceptual fields (`children`, `parent`) that exist at parse-time only but aren't stored in schema
- Detects ref strings (`spec_ref`, `task_ref`) incorrectly treated as objects with fields
- Filters file extensions (spec.yaml, task.json) to avoid false positives

## Test plan
- [x] Tests for invalid field detection (item.children)
- [x] Tests for ref string detection (spec_ref.field)
- [x] Tests for valid field acceptance
- [x] Tests for status.maturity/implementation acceptance
- [x] Tests for flag presence check
- [x] Tests for exit codes (6 for warnings, 4 with --strict)
- [x] Tests for multiple drift issues

Task: @01KGGZKQ

Generated with [Claude Code](https://claude.ai/code)