### PR TITLE
feat: filter superseded notes from default task display

### DIFF
--- a/src/cli/commands/session.ts
+++ b/src/cli/commands/session.ts
@@ -61,7 +61,7 @@ import {
   parseTimeSpec,
 } from "../../utils/index.js";
 import { EXIT_CODES } from "../exit-codes.js";
-import { error, isJsonMode, output } from "../output.js";
+import { error, isJsonMode, isNoteSuperseded, output } from "../output.js";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -310,6 +310,11 @@ function collectRecentNotes(
 
       // Filter by since date if provided
       if (options.since && noteDate < options.since) {
+        continue;
+      }
+
+      // Filter out superseded notes
+      if (isNoteSuperseded(note, task.notes)) {
         continue;
       }
 

--- a/src/cli/commands/task.ts
+++ b/src/cli/commands/task.ts
@@ -30,6 +30,7 @@ import { executeBatchOperation, formatBatchOutput } from "../batch.js";
 import { EXIT_CODES } from "../exit-codes.js";
 import { parseTagsArray } from "../parse-utils.js";
 import {
+  annotateNotesWithSuperseded,
   error,
   formatTaskDetails,
   info,
@@ -477,7 +478,8 @@ export function registerTaskCommands(program: Command): void {
   task
     .command("get <ref>")
     .description("Get task details")
-    .action(async (ref: string) => {
+    .option("--all", "Show all notes including superseded ones")
+    .action(async (ref: string, options: { all?: boolean }) => {
       try {
         const ctx = await initContext();
         const tasks = await loadAllTasks(ctx);
@@ -535,8 +537,10 @@ export function registerTaskCommands(program: Command): void {
         }
 
         // Build JSON output with inherited traits (AC: @trait-display ac-2)
+        // Always include all notes in JSON output with superseded computed field
         const jsonOutput = {
           ...foundTask,
+          notes: annotateNotesWithSuperseded(foundTask.notes),
           ...(inheritedTraits.length > 0 && {
             inherited_traits: inheritedTraits.map(({ trait, acs }) => ({
               ref: `@${trait.slug}`,
@@ -547,7 +551,7 @@ export function registerTaskCommands(program: Command): void {
         };
 
         output(jsonOutput, () => {
-          formatTaskDetails(foundTask, index);
+          formatTaskDetails(foundTask, index, { showAllNotes: options.all });
 
           // AC: @trait-display ac-3, ac-4, ac-5 - Show inherited AC per trait in labeled sections
           if (inheritedTraits.length > 0) {

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -1,8 +1,37 @@
 import chalk from "chalk";
 import type { ReferenceIndex } from "../parser/index.js";
-import type { Task, TaskStatus } from "../schema/index.js";
+import type { Note, Task, TaskStatus } from "../schema/index.js";
 import { fieldLabels, sectionHeaders, summaries } from "../strings/labels.js";
 import { formatMatchedFields, grepItem } from "../utils/grep.js";
+
+/**
+ * Check if a note has been superseded by another note.
+ * A note is superseded if its ULID appears in any other note's `supersedes` field.
+ */
+export function isNoteSuperseded(note: Note, allNotes: Note[]): boolean {
+  return allNotes.some((n) => n.supersedes === note._ulid);
+}
+
+/**
+ * Filter notes to exclude superseded ones.
+ * Returns only notes that have not been superseded.
+ */
+export function filterSupersededNotes(notes: Note[]): Note[] {
+  return notes.filter((note) => !isNoteSuperseded(note, notes));
+}
+
+/**
+ * Annotate notes with superseded status for JSON output.
+ * Adds a computed `superseded` field to each note.
+ */
+export function annotateNotesWithSuperseded(
+  notes: Note[],
+): Array<Note & { superseded: boolean }> {
+  return notes.map((note) => ({
+    ...note,
+    superseded: isNoteSuperseded(note, notes),
+  }));
+}
 
 /**
  * Output options
@@ -409,10 +438,19 @@ export function formatTaskList(
   console.log(summaries.taskCount(tasks.length));
 }
 
+export interface FormatTaskDetailsOptions {
+  /** Show all notes including superseded ones (default: false) */
+  showAllNotes?: boolean;
+}
+
 /**
  * Format task details
  */
-export function formatTaskDetails(task: Task, index?: ReferenceIndex): void {
+export function formatTaskDetails(
+  task: Task,
+  index?: ReferenceIndex,
+  options: FormatTaskDetailsOptions = {},
+): void {
   console.log(chalk.bold(task.title));
   console.log(chalk.gray("─".repeat(40)));
   console.log(`${fieldLabels.ulid}      ${task._ulid}`);
@@ -614,11 +652,24 @@ export function formatTaskDetails(task: Task, index?: ReferenceIndex): void {
   }
 
   if (task.notes.length > 0) {
+    // Filter superseded notes unless showAllNotes is true
+    const notesToShow = options.showAllNotes
+      ? task.notes
+      : filterSupersededNotes(task.notes);
+    const hiddenCount = task.notes.length - notesToShow.length;
+
     console.log(`\n${sectionHeaders.notes}`);
-    for (const note of task.notes) {
+    for (const note of notesToShow) {
       const author = note.author || "unknown";
-      console.log(chalk.gray(`[${note.created_at}] ${author}:`));
+      // Mark if this note supersedes another
+      const supersededLabel = note.supersedes ? chalk.gray(" (supersedes earlier note)") : "";
+      console.log(chalk.gray(`[${note.created_at}] ${author}:`) + supersededLabel);
       console.log(note.content);
+    }
+
+    // Show count of hidden notes if any
+    if (hiddenCount > 0) {
+      console.log(chalk.gray(`\n(${hiddenCount} superseded note${hiddenCount > 1 ? "s" : ""} hidden - use --all to show)`));
     }
   }
 

--- a/tests/note-supersession-filter.test.ts
+++ b/tests/note-supersession-filter.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Tests for note supersession filtering
+ * Verifies that superseded notes are hidden from default display but shown with --all flag
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  kspecOutput as kspec,
+  kspecJson,
+  setupTempFixtures,
+  cleanupTempDir,
+  initGitRepo,
+} from './helpers/cli';
+import type { Note } from '../src/schema/index.js';
+
+describe('Note supersession filtering', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await setupTempFixtures();
+    initGitRepo(tempDir);
+  });
+
+  afterEach(async () => {
+    await cleanupTempDir(tempDir);
+  });
+
+  describe('task get', () => {
+    it('should hide superseded notes by default', () => {
+      // Add initial note
+      kspec('task note @test-task-pending "Initial implementation"', tempDir);
+
+      // Get the first note's ULID
+      const taskWithOneNote = kspecJson<{ notes: Array<Note & { superseded?: boolean }> }>(
+        'task get @test-task-pending',
+        tempDir
+      );
+      expect(taskWithOneNote.notes.length).toBe(1);
+      const firstNoteUlid = taskWithOneNote.notes[0]._ulid;
+
+      // Add superseding note
+      kspec(`task note @test-task-pending "Updated implementation" --supersedes ${firstNoteUlid}`, tempDir);
+
+      // Get task - text output should hide superseded note
+      const textOutput = kspec('task get @test-task-pending', tempDir);
+      expect(textOutput).toContain('Updated implementation');
+      expect(textOutput).not.toContain('Initial implementation');
+      expect(textOutput).toContain('1 superseded note hidden');
+    });
+
+    it('should show all notes with --all flag', () => {
+      // Add initial note
+      kspec('task note @test-task-pending "Initial implementation"', tempDir);
+
+      // Get the first note's ULID
+      const taskWithOneNote = kspecJson<{ notes: Array<Note & { superseded?: boolean }> }>(
+        'task get @test-task-pending',
+        tempDir
+      );
+      const firstNoteUlid = taskWithOneNote.notes[0]._ulid;
+
+      // Add superseding note
+      kspec(`task note @test-task-pending "Updated implementation" --supersedes ${firstNoteUlid}`, tempDir);
+
+      // Get task with --all - should show both notes
+      const textOutput = kspec('task get @test-task-pending --all', tempDir);
+      expect(textOutput).toContain('Updated implementation');
+      expect(textOutput).toContain('Initial implementation');
+      expect(textOutput).not.toContain('superseded note hidden');
+    });
+
+    it('should include superseded field in JSON output', () => {
+      // Add initial note
+      kspec('task note @test-task-pending "Initial implementation"', tempDir);
+
+      // Get the first note's ULID
+      const taskWithOneNote = kspecJson<{ notes: Array<Note & { superseded?: boolean }> }>(
+        'task get @test-task-pending',
+        tempDir
+      );
+      const firstNoteUlid = taskWithOneNote.notes[0]._ulid;
+
+      // Add superseding note
+      kspec(`task note @test-task-pending "Updated implementation" --supersedes ${firstNoteUlid}`, tempDir);
+
+      // JSON output should always include all notes with superseded field
+      const jsonOutput = kspecJson<{ notes: Array<Note & { superseded: boolean }> }>(
+        'task get @test-task-pending',
+        tempDir
+      );
+
+      expect(jsonOutput.notes.length).toBe(2);
+
+      // Find the notes by content
+      const initialNote = jsonOutput.notes.find(n => n.content === 'Initial implementation');
+      const updatedNote = jsonOutput.notes.find(n => n.content === 'Updated implementation');
+
+      expect(initialNote).toBeDefined();
+      expect(updatedNote).toBeDefined();
+      expect(initialNote?.superseded).toBe(true);
+      expect(updatedNote?.superseded).toBe(false);
+    });
+
+    it('should show notes without supersession normally', () => {
+      // Add multiple non-superseding notes
+      kspec('task note @test-task-pending "First note"', tempDir);
+      kspec('task note @test-task-pending "Second note"', tempDir);
+      kspec('task note @test-task-pending "Third note"', tempDir);
+
+      // All notes should be visible
+      const textOutput = kspec('task get @test-task-pending', tempDir);
+      expect(textOutput).toContain('First note');
+      expect(textOutput).toContain('Second note');
+      expect(textOutput).toContain('Third note');
+      expect(textOutput).not.toContain('superseded note hidden');
+    });
+
+    it('should mark superseding notes with indicator', () => {
+      // Add initial note
+      kspec('task note @test-task-pending "Initial implementation"', tempDir);
+
+      // Get the first note's ULID
+      const taskWithOneNote = kspecJson<{ notes: Array<Note & { superseded?: boolean }> }>(
+        'task get @test-task-pending',
+        tempDir
+      );
+      const firstNoteUlid = taskWithOneNote.notes[0]._ulid;
+
+      // Add superseding note
+      kspec(`task note @test-task-pending "Updated implementation" --supersedes ${firstNoteUlid}`, tempDir);
+
+      // The superseding note should indicate it supersedes another
+      const textOutput = kspec('task get @test-task-pending', tempDir);
+      expect(textOutput).toContain('supersedes earlier note');
+    });
+
+    it('should handle multiple superseded notes', () => {
+      // Add first note
+      kspec('task note @test-task-pending "Version 1"', tempDir);
+      const v1 = kspecJson<{ notes: Array<Note> }>('task get @test-task-pending', tempDir);
+      const v1Ulid = v1.notes[0]._ulid;
+
+      // Add second note superseding first
+      kspec(`task note @test-task-pending "Version 2" --supersedes ${v1Ulid}`, tempDir);
+      const v2Task = kspecJson<{ notes: Array<Note & { superseded: boolean }> }>('task get @test-task-pending', tempDir);
+      const v2Note = v2Task.notes.find(n => n.content === 'Version 2');
+      const v2Ulid = v2Note?._ulid;
+
+      // Add third note superseding second
+      kspec(`task note @test-task-pending "Version 3" --supersedes ${v2Ulid}`, tempDir);
+
+      // Default view should only show latest note
+      const textOutput = kspec('task get @test-task-pending', tempDir);
+      expect(textOutput).toContain('Version 3');
+      expect(textOutput).not.toContain('Version 1');
+      expect(textOutput).not.toContain('Version 2');
+      expect(textOutput).toContain('2 superseded notes hidden');
+
+      // JSON should show all with superseded flags
+      const jsonOutput = kspecJson<{ notes: Array<Note & { superseded: boolean }> }>(
+        'task get @test-task-pending',
+        tempDir
+      );
+      expect(jsonOutput.notes.length).toBe(3);
+
+      const v1Note = jsonOutput.notes.find(n => n.content === 'Version 1');
+      const v2NoteJson = jsonOutput.notes.find(n => n.content === 'Version 2');
+      const v3Note = jsonOutput.notes.find(n => n.content === 'Version 3');
+
+      expect(v1Note?.superseded).toBe(true);
+      expect(v2NoteJson?.superseded).toBe(true);
+      expect(v3Note?.superseded).toBe(false);
+    });
+  });
+
+  describe('session start', () => {
+    it('should filter superseded notes from recent_notes', () => {
+      // Start a task and add notes
+      kspec('task start @test-task-pending', tempDir);
+      kspec('task note @test-task-pending "Initial work"', tempDir);
+
+      // Get the first note's ULID
+      const taskWithOneNote = kspecJson<{ notes: Array<Note> }>(
+        'task get @test-task-pending',
+        tempDir
+      );
+      const firstNoteUlid = taskWithOneNote.notes[0]._ulid;
+
+      // Add superseding note
+      kspec(`task note @test-task-pending "Updated work" --supersedes ${firstNoteUlid}`, tempDir);
+
+      // Session start should only show the non-superseded note
+      const session = kspecJson<{ recent_notes: Array<{ content: string }> }>(
+        'session start',
+        tempDir
+      );
+
+      // Only the superseding note should appear
+      const noteContents = session.recent_notes.map(n => n.content);
+      expect(noteContents).toContain('Updated work');
+      expect(noteContents).not.toContain('Initial work');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Added note supersession filtering to reduce noise in task display
- Superseded notes are hidden from default `task get` output
- Added `--all` flag to show full note history
- JSON output includes computed `superseded` field for all notes
- Session start `recent_notes` also filters superseded notes

## Test plan
- [x] Run `npm test -- tests/note-supersession-filter.test.ts`
- [x] Verify `task get` hides superseded notes by default
- [x] Verify `task get --all` shows all notes
- [x] Verify JSON output includes `superseded` field
- [x] Verify session start filters superseded notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)