### PR TITLE
feat: add --under flag for module-scoped item listing

### DIFF
--- a/src/cli/commands/item.ts
+++ b/src/cli/commands/item.ts
@@ -11,6 +11,7 @@ import {
   createSpecItem,
   deleteSpecItem,
   findChildItems,
+  findDescendantItems,
   findTraitImplementors,
   initContext,
   type LoadedSpecItem,
@@ -300,12 +301,13 @@ export function registerItemCommands(program: Command): void {
     .option("-g, --grep <pattern>", "Search content with regex pattern")
     .option("-v, --verbose", "Show more details")
     .option("--tree", "Show parent/child hierarchy")
+    .option("--under <ref>", "Scope to descendants of a module or parent item")
     .option("--limit <n>", "Limit results", "50")
     .option("--count", "Show only the count of matching items")
     .action(async (options) => {
       try {
         const ctx = await initContext();
-        const { itemIndex, items } = await buildIndexes(ctx);
+        const { itemIndex, items, refIndex } = await buildIndexes(ctx);
 
         // Build filter from options
         const filter: ItemFilter = {
@@ -350,19 +352,63 @@ export function registerItemCommands(program: Command): void {
           filter.grepSearch = options.grep;
         }
 
+        // AC: @module-scoped-item-listing ac-under-filter, ac-under-invalid-ref
+        // Handle --under: scope to descendants of a module or parent item
+        let underRoot: LoadedSpecItem | undefined;
+        let underDescendantUlids: Set<string> | undefined;
+        if (options.under) {
+          const underResult = refIndex.resolve(options.under);
+          if (!underResult.ok) {
+            // AC: @module-scoped-item-listing ac-under-invalid-ref
+            error(`Reference not found: ${options.under}. Check with: kspec item get ${options.under}`);
+            process.exit(EXIT_CODES.NOT_FOUND);
+          }
+          underRoot = underResult.item as LoadedSpecItem;
+          // Check it's not a task
+          if ("status" in underRoot && typeof underRoot.status === "string") {
+            error(`Reference ${options.under} is a task, not a spec item`);
+            process.exit(EXIT_CODES.USAGE_ERROR);
+          }
+          // AC: @module-scoped-item-listing ac-nested-descendants
+          // Find all descendants based on _path and _sourceFile
+          const descendants = findDescendantItems(underRoot, items);
+          underDescendantUlids = new Set([underRoot._ulid, ...descendants.map(d => d._ulid)]);
+        }
+
         const limit = parseInt(options.limit, 10) || 50;
-        const result = itemIndex.queryPaginated(filter, 0, limit);
 
-        // Filter to only LoadedSpecItem (not tasks)
-        const specItems = result.items.filter(
-          (item): item is LoadedSpecItem =>
-            !("status" in item && typeof item.status === "string"),
-        );
+        // When --under is used, we need to get all items first, then filter by scope,
+        // because pagination before scoping could miss items
+        let specItems: LoadedSpecItem[];
+        let effectiveTotal: number;
 
+        if (underDescendantUlids) {
+          // AC: @module-scoped-item-listing ac-under-filter, ac-under-with-other-filters
+          // Get all items matching filters, then scope to descendants
+          const allResults = itemIndex.query(filter);
+          const allSpecItems = allResults.filter(
+            (item): item is LoadedSpecItem =>
+              !("status" in item && typeof item.status === "string"),
+          );
+          // Apply --under filtering (AND logic with other filters)
+          const scopedItems = allSpecItems.filter(item => underDescendantUlids!.has(item._ulid));
+          effectiveTotal = scopedItems.length;
+          specItems = scopedItems.slice(0, limit);
+        } else {
+          const result = itemIndex.queryPaginated(filter, 0, limit);
+          // Filter to only LoadedSpecItem (not tasks)
+          specItems = result.items.filter(
+            (item): item is LoadedSpecItem =>
+              !("status" in item && typeof item.status === "string"),
+          );
+          effectiveTotal = result.total;
+        }
+
+        // AC: @module-scoped-item-listing ac-count-with-under
         // AC: @trait-filterable-list ac-8
         if (options.count) {
-          output({ count: result.total }, () => {
-            console.log(result.total);
+          output({ count: effectiveTotal }, () => {
+            console.log(effectiveTotal);
           });
           return;
         }
@@ -370,13 +416,15 @@ export function registerItemCommands(program: Command): void {
         output(
           {
             items: specItems,
-            total: result.total,
+            total: effectiveTotal,
             showing: specItems.length,
             grepPattern: options.grep,
             tree: options.tree,
+            under: options.under,
           },
           () => {
             if (options.tree) {
+              // AC: @module-scoped-item-listing ac-under-with-tree
               formatItemTree(specItems, options.verbose, options.grep);
             } else {
               formatItemList(specItems, options.verbose, options.grep);

--- a/src/parser/items.ts
+++ b/src/parser/items.ts
@@ -419,6 +419,34 @@ function getNestedField(obj: Record<string, unknown>, path: string): unknown {
 }
 
 /**
+ * Find all descendant items of a parent item based on _path and _sourceFile.
+ * Descendants are items in the same source file whose _path starts with the parent's _path.
+ * AC: @module-scoped-item-listing ac-nested-descendants
+ */
+export function findDescendantItems(
+  parent: LoadedSpecItem,
+  allItems: LoadedSpecItem[],
+): LoadedSpecItem[] {
+  const parentPath = parent._path || "";
+  const parentSourceFile = parent._sourceFile;
+
+  return allItems.filter((item) => {
+    if (item._ulid === parent._ulid) return false; // Skip self
+    if (item._sourceFile !== parentSourceFile) return false; // Must be same source file
+
+    // If parent is at root (empty path), all items from same source file are descendants
+    if (parentPath === "") {
+      return true;
+    }
+
+    // Item's path must start with parent's path followed by a dot
+    // e.g., parent "features[0]" matches child "features[0].requirements[1]"
+    if (!item._path) return false;
+    return item._path.startsWith(`${parentPath}.`);
+  });
+}
+
+/**
  * Find direct child items of a parent item based on _path
  * Children have paths like "parent_path.field[N]"
  */

--- a/tests/item-list-under.test.ts
+++ b/tests/item-list-under.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Tests for kspec item list --under (module-scoped item listing)
+ * AC: @module-scoped-item-listing
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import {
+  kspec,
+  kspecJson,
+  setupTempFixtures,
+  cleanupTempDir,
+  testUlid,
+} from './helpers/cli';
+
+describe('kspec item list --under', () => {
+  let tempDir: string;
+
+  beforeAll(async () => {
+    tempDir = await setupTempFixtures();
+  });
+
+  afterAll(async () => {
+    await cleanupTempDir(tempDir);
+  });
+
+  // AC: @module-scoped-item-listing ac-under-filter
+  it('should list only items structurally nested under specified parent', async () => {
+    // The fixtures have: test-core (module) > test-feature > test-requirement
+    const result = kspecJson<{ items: unknown[]; total: number }>(
+      'item list --under @test-core',
+      tempDir
+    );
+
+    // Should include the root (test-core), test-feature, and test-requirement
+    expect(result.total).toBe(3);
+    expect(result.items).toHaveLength(3);
+  });
+
+  // AC: @module-scoped-item-listing ac-under-root-included
+  it('should include the specified item as root node in output', async () => {
+    const result = kspecJson<{ items: { slugs: string[] }[] }>(
+      'item list --under @test-core',
+      tempDir
+    );
+
+    const slugs = result.items.flatMap(item => item.slugs || []);
+    expect(slugs).toContain('test-core');
+  });
+
+  // AC: @module-scoped-item-listing ac-nested-descendants
+  it('should include all transitive descendants at multiple depth levels', async () => {
+    const result = kspecJson<{ items: { slugs: string[] }[] }>(
+      'item list --under @test-core',
+      tempDir
+    );
+
+    const slugs = result.items.flatMap(item => item.slugs || []);
+    // Should have module, feature, and requirement (3 levels)
+    expect(slugs).toContain('test-core'); // level 1: module
+    expect(slugs).toContain('test-feature'); // level 2: feature
+    expect(slugs).toContain('test-requirement'); // level 3: requirement
+  });
+
+  // AC: @module-scoped-item-listing ac-under-with-tree
+  it('should show hierarchical tree display with --tree flag', async () => {
+    const result = kspec('item list --under @test-core --tree', tempDir);
+
+    // Tree output should contain tree characters and all items
+    expect(result.stdout).toContain('test-core');
+    expect(result.stdout).toContain('test-feature');
+    expect(result.stdout).toContain('test-requirement');
+    // Tree formatting
+    expect(result.stdout).toMatch(/[└├].*[──]/);
+  });
+
+  // AC: @module-scoped-item-listing ac-under-with-other-filters
+  it('should apply other filters within the scoped subtree (AND logic)', async () => {
+    // Filter by type within the scoped tree
+    const result = kspecJson<{ items: { type: string }[]; total: number }>(
+      'item list --under @test-core --type feature',
+      tempDir
+    );
+
+    // Should only show the feature, not the module or requirement
+    expect(result.total).toBe(1);
+    expect(result.items[0].type).toBe('feature');
+  });
+
+  // AC: @module-scoped-item-listing ac-under-json
+  it('should output JSON array with full item data when --json is used', async () => {
+    const result = kspecJson<{ items: { _ulid: string; title: string; type: string }[] }>(
+      'item list --under @test-feature',
+      tempDir
+    );
+
+    // Each item should have full data
+    for (const item of result.items) {
+      expect(item).toHaveProperty('_ulid');
+      expect(item).toHaveProperty('title');
+      expect(item).toHaveProperty('type');
+    }
+  });
+
+  // AC: @module-scoped-item-listing ac-under-invalid-ref
+  it('should show error for invalid reference with suggestion', async () => {
+    const result = kspec('item list --under @nonexistent', tempDir, { expectFail: true });
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain('not found');
+    expect(result.stderr).toContain('kspec item get');
+  });
+
+  // AC: @module-scoped-item-listing ac-count-with-under
+  it('should count only items in scoped subtree with --count', async () => {
+    const result = kspec('item list --under @test-core --count', tempDir);
+
+    // Should count 3 items: module + feature + requirement
+    expect(result.stdout.trim()).toBe('3');
+  });
+
+  // Test that --under errors on task reference
+  it('should reject task references with --under', async () => {
+    // The fixtures have test-task-pending
+    const result = kspec('item list --under @test-task-pending', tempDir, { expectFail: true });
+
+    // Should error because tasks are not spec items
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain('task');
+  });
+
+  // Test scoping to a leaf node (no children)
+  it('should work for leaf items with no descendants', async () => {
+    const result = kspecJson<{ items: unknown[]; total: number }>(
+      'item list --under @test-requirement',
+      tempDir
+    );
+
+    // Leaf item has no children, so only itself
+    expect(result.total).toBe(1);
+  });
+
+  // Test scoping to a mid-level item
+  it('should work for mid-level items (feature level)', async () => {
+    const result = kspecJson<{ items: { slugs: string[] }[]; total: number }>(
+      'item list --under @test-feature',
+      tempDir
+    );
+
+    // Feature + requirement (2 items)
+    expect(result.total).toBe(2);
+    const slugs = result.items.flatMap(item => item.slugs || []);
+    expect(slugs).toContain('test-feature');
+    expect(slugs).toContain('test-requirement');
+    expect(slugs).not.toContain('test-core'); // Parent should not be included
+  });
+});
+
+describe('findDescendantItems', () => {
+  let tempDir: string;
+
+  beforeAll(async () => {
+    tempDir = await setupTempFixtures();
+
+    // Add a second module file to test cross-file isolation
+    const secondModule = `
+_ulid: ${testUlid('M0D2')}
+slugs:
+  - other-module
+title: Other Module
+type: module
+status:
+  maturity: draft
+  implementation: not_started
+features:
+  - _ulid: ${testUlid('FEAT2')}
+    slugs:
+      - other-feature
+    title: Other Feature
+    type: feature
+    status:
+      maturity: draft
+      implementation: not_started
+`;
+    const modulesDir = path.join(tempDir, 'modules');
+    await fs.writeFile(path.join(modulesDir, 'other.yaml'), secondModule);
+  });
+
+  afterAll(async () => {
+    await cleanupTempDir(tempDir);
+  });
+
+  it('should not include items from different source files', async () => {
+    // When scoping to test-core, should not include items from other.yaml
+    const result = kspecJson<{ items: { slugs: string[] }[]; total: number }>(
+      'item list --under @test-core',
+      tempDir
+    );
+
+    const slugs = result.items.flatMap(item => item.slugs || []);
+    expect(slugs).toContain('test-core');
+    expect(slugs).not.toContain('other-module');
+    expect(slugs).not.toContain('other-feature');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `--under <ref>` flag to `kspec item list` command to scope output to descendants of a specified module or parent item
- Implements `findDescendantItems()` function in parser/items.ts that finds all items sharing the same `_sourceFile` with matching `_path` prefix
- Works with existing flags: `--tree` for hierarchical display, `--count` for scoped subtree count, and other filters using AND logic
- Error handling for invalid references and task references (which are not spec items)
- This addresses the primary reason agents bypass the CLI to read .kspec/ YAML directly

## Test plan
- [x] `kspec item list --under @cli` - scopes to CLI module descendants only
- [x] `kspec item list --under @cli --tree` - shows hierarchical tree scoped to module
- [x] `kspec item list --under @cli --count` - counts only items in subtree
- [x] `kspec item list --under @cli --type feature` - AND logic with other filters
- [x] `kspec item list --under @nonexistent` - error with helpful message
- [x] 12 tests covering all 8 acceptance criteria

Task: @implement-module-scoped-item-listing
Spec: @module-scoped-item-listing

🤖 Generated with [Claude Code](https://claude.ai/code)