### PR TITLE
feat: add kspec refs command for unified cross-reference lookup

### DIFF
--- a/src/cli/commands/index.ts
+++ b/src/cli/commands/index.ts
@@ -15,6 +15,7 @@ export { registerMetaCommands } from "./meta.js";
 export { registerModuleCommands } from "./module.js";
 export { registerPlanCommands } from "./plan.js";
 export { registerRalphCommand } from "./ralph.js";
+export { registerRefsCommand } from "./refs.js";
 export { registerSearchCommand } from "./search.js";
 export { registerServeCommands } from "./serve.js";
 export { registerSessionCommands } from "./session.js";

--- a/src/cli/commands/refs.ts
+++ b/src/cli/commands/refs.ts
@@ -1,0 +1,410 @@
+/**
+ * Unified cross-reference lookup command.
+ *
+ * Shows all inbound references to a given entity across all entity types.
+ * AC: @unified-cross-reference-lookup
+ */
+
+import chalk from "chalk";
+import type { Command } from "commander";
+import {
+  buildIndexes,
+  initContext,
+  loadMetaContext,
+} from "../../parser/index.js";
+import type {
+  LoadedMetaItem,
+  LoadedWorkflow,
+} from "../../parser/meta.js";
+import { ReferenceIndex } from "../../parser/refs.js";
+import type {
+  AnyLoadedItem,
+  LoadedSpecItem,
+  LoadedTask,
+} from "../../parser/yaml.js";
+import { errors } from "../../strings/index.js";
+import { EXIT_CODES } from "../exit-codes.js";
+import { error, output } from "../output.js";
+
+/**
+ * Reference types we scan for
+ */
+const REFERENCE_FIELDS = {
+  // Task reference fields
+  task: ["spec_ref", "depends_on", "meta_ref", "plan_ref", "blocked_by"],
+  // Spec item reference fields
+  spec: [
+    "depends_on",
+    "implements",
+    "relates_to",
+    "supersedes",
+    "traits",
+    "tests",
+  ],
+} as const;
+
+/**
+ * A single reference found
+ */
+interface FoundReference {
+  /** The ULID of the referencing entity */
+  ulid: string;
+  /** Slug or short ULID for display */
+  ref: string;
+  /** Title/name of the referencing entity */
+  title: string;
+  /** Entity type (task, feature, requirement, etc.) */
+  type: string;
+  /** The field that contains the reference */
+  field: string;
+}
+
+/**
+ * Grouped references by relationship type
+ */
+interface GroupedReferences {
+  /** Tasks with spec_ref pointing to target */
+  "tasks_spec_ref": FoundReference[];
+  /** Tasks with depends_on including target */
+  "tasks_depends_on": FoundReference[];
+  /** Tasks with meta_ref pointing to target */
+  "tasks_meta_ref": FoundReference[];
+  /** Tasks with plan_ref pointing to target */
+  "tasks_plan_ref": FoundReference[];
+  /** Tasks with blocked_by including target */
+  "tasks_blocked_by": FoundReference[];
+  /** Specs with depends_on including target */
+  "specs_depends_on": FoundReference[];
+  /** Specs with implements including target */
+  "specs_implements": FoundReference[];
+  /** Specs with relates_to including target */
+  "specs_relates_to": FoundReference[];
+  /** Specs with supersedes including target */
+  "specs_supersedes": FoundReference[];
+  /** Specs with traits including target */
+  "specs_traits": FoundReference[];
+  /** Specs with tests including target */
+  "specs_tests": FoundReference[];
+}
+
+/**
+ * Check if a reference field value contains the target
+ */
+function containsRef(
+  value: unknown,
+  targetUlid: string,
+  refIndex: ReferenceIndex,
+): boolean {
+  if (!value) return false;
+
+  if (typeof value === "string") {
+    // Resolve the reference and compare ULIDs
+    const resolved = refIndex.resolve(value);
+    return resolved.ok && resolved.ulid === targetUlid;
+  }
+
+  if (Array.isArray(value)) {
+    return value.some((v) => containsRef(v, targetUlid, refIndex));
+  }
+
+  return false;
+}
+
+/**
+ * Get display reference for an entity
+ */
+function getDisplayRef(
+  entity: AnyLoadedItem | LoadedMetaItem,
+  refIndex: ReferenceIndex,
+): string {
+  // Prefer slug
+  if ("slugs" in entity && entity.slugs.length > 0) {
+    return `@${entity.slugs[0]}`;
+  }
+  // For meta items, use id
+  if ("id" in entity && entity.id) {
+    return `@${entity.id}`;
+  }
+  // Fall back to short ULID
+  return refIndex.shortUlid(entity._ulid);
+}
+
+/**
+ * Get title/name from an entity
+ */
+function getTitle(entity: AnyLoadedItem | LoadedMetaItem): string {
+  if ("title" in entity) return entity.title;
+  if ("name" in entity) return entity.name;
+  if ("id" in entity) return entity.id;
+  return "(unknown)";
+}
+
+/**
+ * Get entity type
+ */
+function getType(entity: AnyLoadedItem | LoadedMetaItem): string {
+  if ("type" in entity && entity.type) return entity.type;
+  return "unknown";
+}
+
+/**
+ * Check if entity is a task (has string status)
+ */
+function isTask(entity: AnyLoadedItem): entity is LoadedTask {
+  return "status" in entity && typeof entity.status === "string";
+}
+
+/**
+ * Scan all entities for references to target
+ * AC: @unified-cross-reference-lookup ac-task-spec-ref through ac-supersedes
+ */
+function findAllReferences(
+  targetUlid: string,
+  tasks: LoadedTask[],
+  items: LoadedSpecItem[],
+  workflows: LoadedWorkflow[],
+  refIndex: ReferenceIndex,
+): GroupedReferences {
+  const groups: GroupedReferences = {
+    tasks_spec_ref: [],
+    tasks_depends_on: [],
+    tasks_meta_ref: [],
+    tasks_plan_ref: [],
+    tasks_blocked_by: [],
+    specs_depends_on: [],
+    specs_implements: [],
+    specs_relates_to: [],
+    specs_supersedes: [],
+    specs_traits: [],
+    specs_tests: [],
+  };
+
+  // Scan tasks
+  // AC: @unified-cross-reference-lookup ac-task-spec-ref, ac-task-depends-on, ac-meta-ref
+  for (const task of tasks) {
+    const taskObj = task as unknown as Record<string, unknown>;
+
+    for (const field of REFERENCE_FIELDS.task) {
+      if (containsRef(taskObj[field], targetUlid, refIndex)) {
+        const ref: FoundReference = {
+          ulid: task._ulid,
+          ref: getDisplayRef(task, refIndex),
+          title: task.title,
+          type: "task",
+          field,
+        };
+
+        const key = `tasks_${field}` as keyof GroupedReferences;
+        if (key in groups) {
+          groups[key].push(ref);
+        }
+      }
+    }
+  }
+
+  // Scan spec items
+  // AC: @unified-cross-reference-lookup ac-spec-depends-on through ac-trait-references
+  for (const item of items) {
+    const itemObj = item as unknown as Record<string, unknown>;
+
+    for (const field of REFERENCE_FIELDS.spec) {
+      if (containsRef(itemObj[field], targetUlid, refIndex)) {
+        const ref: FoundReference = {
+          ulid: item._ulid,
+          ref: getDisplayRef(item, refIndex),
+          title: item.title,
+          type: item.type || "spec",
+          field,
+        };
+
+        const key = `specs_${field}` as keyof GroupedReferences;
+        if (key in groups) {
+          groups[key].push(ref);
+        }
+      }
+    }
+  }
+
+  return groups;
+}
+
+/**
+ * Format section header for human output
+ * AC: @unified-cross-reference-lookup ac-grouped-output
+ */
+function formatSectionHeader(
+  entityType: string,
+  field: string,
+): string {
+  const fieldLabel = field.replace(/_/g, " ");
+  return `${entityType} (${fieldLabel})`;
+}
+
+/**
+ * Count total references across all groups
+ */
+function countTotalReferences(groups: GroupedReferences): number {
+  return Object.values(groups).reduce((sum, arr) => sum + arr.length, 0);
+}
+
+/**
+ * Format human-readable output
+ * AC: @unified-cross-reference-lookup ac-grouped-output, ac-no-refs
+ */
+function formatHumanOutput(
+  targetRef: string,
+  groups: GroupedReferences,
+): void {
+  const total = countTotalReferences(groups);
+
+  if (total === 0) {
+    // AC: @unified-cross-reference-lookup ac-no-refs
+    console.log(chalk.gray(`No references found for ${targetRef}`));
+    return;
+  }
+
+  console.log(chalk.bold(`References to ${targetRef}`));
+  console.log(chalk.gray("─".repeat(40)));
+
+  // Define display order
+  const sections: Array<{
+    key: keyof GroupedReferences;
+    entityType: string;
+    field: string;
+  }> = [
+    { key: "tasks_spec_ref", entityType: "Tasks", field: "spec_ref" },
+    { key: "tasks_depends_on", entityType: "Tasks", field: "depends_on" },
+    { key: "tasks_meta_ref", entityType: "Tasks", field: "meta_ref" },
+    { key: "tasks_plan_ref", entityType: "Tasks", field: "plan_ref" },
+    { key: "tasks_blocked_by", entityType: "Tasks", field: "blocked_by" },
+    { key: "specs_depends_on", entityType: "Specs", field: "depends_on" },
+    { key: "specs_implements", entityType: "Specs", field: "implements" },
+    { key: "specs_relates_to", entityType: "Specs", field: "relates_to" },
+    { key: "specs_supersedes", entityType: "Specs", field: "supersedes" },
+    { key: "specs_traits", entityType: "Specs", field: "traits" },
+    { key: "specs_tests", entityType: "Specs", field: "tests" },
+  ];
+
+  for (const section of sections) {
+    const refs = groups[section.key];
+    if (refs.length === 0) continue;
+
+    console.log(
+      `\n${chalk.cyan(formatSectionHeader(section.entityType, section.field))}`,
+    );
+
+    for (const ref of refs) {
+      const typeLabel = chalk.gray(`[${ref.type}]`);
+      console.log(`  ${chalk.yellow(ref.ref)} ${typeLabel} ${ref.title}`);
+    }
+  }
+
+  console.log(chalk.gray(`\n${total} reference(s) found`));
+}
+
+/**
+ * Build JSON output structure
+ * AC: @unified-cross-reference-lookup ac-json-structured
+ */
+function buildJsonOutput(
+  targetRef: string,
+  targetUlid: string,
+  groups: GroupedReferences,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {
+    target: targetRef,
+    target_ulid: targetUlid,
+  };
+
+  // Add non-empty groups
+  for (const [key, refs] of Object.entries(groups)) {
+    if (refs.length > 0) {
+      result[key] = (refs as FoundReference[]).map((r) => ({
+        ref: r.ref,
+        ulid: r.ulid,
+        title: r.title,
+        type: r.type,
+      }));
+    }
+  }
+
+  result.total = countTotalReferences(groups);
+
+  return result;
+}
+
+/**
+ * Register the refs command
+ * AC: @unified-cross-reference-lookup
+ */
+export function registerRefsCommand(program: Command): void {
+  program
+    .command("refs <ref>")
+    .description(
+      "Show all inbound references to an entity (reverse lookup)",
+    )
+    .action(async (ref: string) => {
+      try {
+        const ctx = await initContext();
+        const { tasks, items } = await buildIndexes(ctx);
+
+        // Load meta context for workflows
+        const metaCtx = await loadMetaContext(ctx);
+
+        // Build reference index with meta items included
+        // This allows resolving references to workflows, agents, etc.
+        const allMetaItems: LoadedMetaItem[] = [
+          ...metaCtx.agents,
+          ...metaCtx.workflows,
+          ...metaCtx.conventions,
+          ...metaCtx.observations,
+        ];
+        const refIndex = new ReferenceIndex(tasks, items, allMetaItems);
+
+        // AC: @unified-cross-reference-lookup ac-ref-resolution
+        // Resolve target reference
+        const resolved = refIndex.resolve(ref);
+        if (!resolved.ok) {
+          if (resolved.error === "not_found") {
+            error(
+              errors.reference.itemNotFound(ref),
+              "Try: kspec search <pattern>",
+            );
+            process.exit(EXIT_CODES.NOT_FOUND);
+          } else if (resolved.error === "ambiguous") {
+            error(errors.reference.ambiguous(ref));
+            for (const candidate of resolved.candidates) {
+              console.error(`  ${candidate}`);
+            }
+            process.exit(EXIT_CODES.USAGE_ERROR);
+          } else {
+            error(errors.reference.slugMapsToMultiple(ref));
+            for (const candidate of resolved.candidates) {
+              console.error(`  ${candidate}`);
+            }
+            process.exit(EXIT_CODES.USAGE_ERROR);
+          }
+        }
+
+        const targetUlid = resolved.ulid;
+        const targetRef = getDisplayRef(resolved.item, refIndex);
+
+        // Find all references
+        const groups = findAllReferences(
+          targetUlid,
+          tasks,
+          items,
+          metaCtx.workflows,
+          refIndex,
+        );
+
+        // Output
+        output(buildJsonOutput(targetRef, targetUlid, groups), () => {
+          formatHumanOutput(targetRef, groups);
+        });
+      } catch (err) {
+        error("Failed to find references", err);
+        process.exit(EXIT_CODES.ERROR);
+      }
+    });
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -30,6 +30,7 @@ import {
   registerModuleCommands,
   registerPlanCommands,
   registerRalphCommand,
+  registerRefsCommand,
   registerSearchCommand,
   registerServeCommands,
   registerSessionCommands,
@@ -198,6 +199,7 @@ registerInboxCommands(program);
 registerShadowCommands(program);
 registerLogCommand(program);
 registerSearchCommand(program);
+registerRefsCommand(program);
 registerServeCommands(program);
 registerRalphCommand(program);
 registerMetaCommands(program);

--- a/tests/refs.test.ts
+++ b/tests/refs.test.ts
@@ -1,0 +1,483 @@
+/**
+ * Tests for kspec refs (unified cross-reference lookup)
+ * AC: @unified-cross-reference-lookup
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import {
+  kspec,
+  kspecJson,
+  setupTempFixtures,
+  cleanupTempDir,
+  testUlid,
+} from './helpers/cli';
+
+describe('kspec refs', () => {
+  let tempDir: string;
+
+  // Test ULIDs - using valid Crockford base32
+  const specAUlid = testUlid('SPCA', 1);
+  const specBUlid = testUlid('SPCB', 1);
+  const specCUlid = testUlid('SPCC', 1);
+  const specDUlid = testUlid('SPCD', 1);
+  const specEUlid = testUlid('SPCE', 1);
+  const oldSpecUlid = testUlid('0KDS', 1);
+  const isolatedUlid = testUlid('JS0K', 1);
+  const traitUlid = testUlid('TRAT', 1);
+  const specXUlid = testUlid('SPCX', 1);
+  const specYUlid = testUlid('SPCY', 1);
+  const specZUlid = testUlid('SPCZ', 1);
+  const workflowUlid = testUlid('WRKF', 1);
+  const taskWithMetaUlid = testUlid('TMRF', 1);
+
+  beforeAll(async () => {
+    tempDir = await setupTempFixtures();
+
+    // Add additional fixtures needed for refs tests
+
+    // Spec A - will be referenced by others
+    const specA = `_ulid: ${specAUlid}
+slugs:
+  - spec-a
+title: Spec A (Target)
+type: feature
+status:
+  maturity: draft
+  implementation: not_started
+`;
+
+    // Spec B - depends_on spec-a
+    const specB = `_ulid: ${specBUlid}
+slugs:
+  - spec-b
+title: Spec B (depends on A)
+type: feature
+status:
+  maturity: draft
+  implementation: not_started
+depends_on:
+  - "@spec-a"
+`;
+
+    // Spec C - implements spec-a
+    const specC = `_ulid: ${specCUlid}
+slugs:
+  - spec-c
+title: Spec C (implements A)
+type: feature
+status:
+  maturity: draft
+  implementation: not_started
+implements:
+  - "@spec-a"
+`;
+
+    // Spec D - relates_to spec-a
+    const specD = `_ulid: ${specDUlid}
+slugs:
+  - spec-d
+title: Spec D (relates to A)
+type: feature
+status:
+  maturity: draft
+  implementation: not_started
+relates_to:
+  - "@spec-a"
+`;
+
+    // Old spec - will be superseded
+    const oldSpec = `_ulid: ${oldSpecUlid}
+slugs:
+  - old-spec
+title: Old Spec (deprecated)
+type: feature
+status:
+  maturity: deprecated
+  implementation: not_started
+`;
+
+    // Spec E - supersedes old-spec (supersedes is a single ref, not array)
+    const specE = `_ulid: ${specEUlid}
+slugs:
+  - spec-e
+title: Spec E (supersedes old)
+type: feature
+status:
+  maturity: draft
+  implementation: not_started
+supersedes: "@old-spec"
+`;
+
+    // Isolated item with no references to it
+    const isolatedSpec = `_ulid: ${isolatedUlid}
+slugs:
+  - isolated-item
+title: Isolated Item
+type: feature
+status:
+  maturity: draft
+  implementation: not_started
+`;
+
+    // Trait for trait references
+    const trait = `_ulid: ${traitUlid}
+slugs:
+  - my-trait
+title: My Trait
+type: trait
+status:
+  maturity: draft
+  implementation: not_started
+`;
+
+    // Specs that use the trait (X, Y, Z)
+    const specsWithTrait = `_ulid: ${specXUlid}
+slugs:
+  - spec-x
+title: Spec X (uses trait)
+type: feature
+status:
+  maturity: draft
+  implementation: not_started
+traits:
+  - "@my-trait"
+---
+_ulid: ${specYUlid}
+slugs:
+  - spec-y
+title: Spec Y (uses trait)
+type: feature
+status:
+  maturity: draft
+  implementation: not_started
+traits:
+  - "@my-trait"
+---
+_ulid: ${specZUlid}
+slugs:
+  - spec-z
+title: Spec Z (uses trait)
+type: feature
+status:
+  maturity: draft
+  implementation: not_started
+traits:
+  - "@my-trait"
+`;
+
+    const modulesDir = path.join(tempDir, 'modules');
+    await fs.writeFile(path.join(modulesDir, 'spec-a.yaml'), specA);
+    await fs.writeFile(path.join(modulesDir, 'spec-b.yaml'), specB);
+    await fs.writeFile(path.join(modulesDir, 'spec-c.yaml'), specC);
+    await fs.writeFile(path.join(modulesDir, 'spec-d.yaml'), specD);
+    await fs.writeFile(path.join(modulesDir, 'old-spec.yaml'), oldSpec);
+    await fs.writeFile(path.join(modulesDir, 'spec-e.yaml'), specE);
+    await fs.writeFile(path.join(modulesDir, 'isolated.yaml'), isolatedSpec);
+    await fs.writeFile(path.join(modulesDir, 'trait.yaml'), trait);
+    await fs.writeFile(path.join(modulesDir, 'trait-users.yaml'), specsWithTrait);
+
+    // Update manifest to include the new modules
+    const manifest = `kynetic: "1.0"
+
+project:
+  name: "Test Project"
+  version: "0.1.0"
+  status: draft
+  description: A minimal test project for integration testing
+
+includes:
+  - modules/*.yaml
+
+tasks_file: project.tasks.yaml
+meta_file: kynetic.meta.yaml
+`;
+    await fs.writeFile(path.join(tempDir, 'kynetic.yaml'), manifest);
+
+    // Add tasks that reference specs
+    // Read existing tasks and add spec_ref to them
+    const existingTasks = await fs.readFile(path.join(tempDir, 'project.tasks.yaml'), 'utf-8');
+    const updatedTasks = existingTasks.replace(
+      'spec_ref: "@test-core"',
+      'spec_ref: "@test-core"'
+    );
+
+    // Add new tasks with spec_ref pointing to test-core
+    const additionalTasks = `
+  - _ulid: ${testUlid('TSK1', 1)}
+    slugs:
+      - task-for-core-1
+    title: Task 1 (for test-core)
+    type: task
+    status: pending
+    priority: 2
+    spec_ref: "@test-core"
+    depends_on: []
+    notes: []
+    todos: []
+    created_at: "2026-01-01T00:00:00Z"
+
+  - _ulid: ${testUlid('TSK2', 1)}
+    slugs:
+      - task-for-core-2
+    title: Task 2 (for test-core)
+    type: task
+    status: pending
+    priority: 2
+    spec_ref: "@test-core"
+    depends_on: []
+    notes: []
+    todos: []
+    created_at: "2026-01-01T00:00:00Z"
+
+  - _ulid: ${testUlid('TSK3', 1)}
+    slugs:
+      - task-with-dep
+    title: Task 3 (depends on task-1)
+    type: task
+    status: pending
+    priority: 2
+    depends_on:
+      - "@task-for-core-1"
+    notes: []
+    todos: []
+    created_at: "2026-01-01T00:00:00Z"
+
+  - _ulid: ${taskWithMetaUlid}
+    slugs:
+      - task-with-meta-ref
+    title: Task with meta_ref
+    type: task
+    status: pending
+    priority: 2
+    meta_ref: "@workflow-1"
+    depends_on: []
+    notes: []
+    todos: []
+    created_at: "2026-01-01T00:00:00Z"
+`;
+
+    // Append to tasks file
+    const newTasksContent = updatedTasks.trim() + '\n' + additionalTasks;
+    await fs.writeFile(path.join(tempDir, 'project.tasks.yaml'), newTasksContent);
+
+    // Update meta manifest to include workflow
+    const metaManifest = `kynetic_meta: "1.0"
+
+agents:
+  - _ulid: 01KF1645CB01TASKAGENT00001
+    id: test-agent
+    name: Test Agent
+    role: developer
+    capabilities:
+      - code
+    conventions:
+      - "@testing-conventions"
+
+workflows:
+  - _ulid: ${workflowUlid}
+    id: workflow-1
+    trigger: Before doing task work
+    description: A test workflow
+    steps:
+      - type: action
+        content: Do the first thing
+
+conventions:
+  - _ulid: 01KF1645CB01CONVENTION0001
+    domain: testing-conventions
+    rules:
+      - Write tests for all features
+
+observations: []
+`;
+    await fs.writeFile(path.join(tempDir, 'kynetic.meta.yaml'), metaManifest);
+  });
+
+  afterAll(async () => {
+    await cleanupTempDir(tempDir);
+  });
+
+  // AC: @unified-cross-reference-lookup ac-task-spec-ref
+  it('should show tasks with spec_ref pointing to target', async () => {
+    const result = kspecJson<{ tasks_spec_ref?: { ref: string; title: string }[]; total: number }>(
+      'refs @test-core',
+      tempDir
+    );
+
+    expect(result.tasks_spec_ref).toBeDefined();
+    expect(result.tasks_spec_ref!.length).toBeGreaterThanOrEqual(2);
+    const titles = result.tasks_spec_ref!.map(r => r.title);
+    expect(titles).toContain('Task 1 (for test-core)');
+    expect(titles).toContain('Task 2 (for test-core)');
+  });
+
+  // AC: @unified-cross-reference-lookup ac-task-depends-on
+  it('should show tasks with depends_on including target', async () => {
+    const result = kspecJson<{ tasks_depends_on?: { ref: string; title: string }[]; total: number }>(
+      'refs @task-for-core-1',
+      tempDir
+    );
+
+    expect(result.tasks_depends_on).toBeDefined();
+    expect(result.tasks_depends_on).toHaveLength(1);
+    expect(result.tasks_depends_on![0].title).toBe('Task 3 (depends on task-1)');
+  });
+
+  // AC: @unified-cross-reference-lookup ac-spec-depends-on
+  it('should show specs with depends_on including target', async () => {
+    const result = kspecJson<{ specs_depends_on?: { ref: string; title: string }[]; total: number }>(
+      'refs @spec-a',
+      tempDir
+    );
+
+    expect(result.specs_depends_on).toBeDefined();
+    expect(result.specs_depends_on).toHaveLength(1);
+    expect(result.specs_depends_on![0].title).toBe('Spec B (depends on A)');
+  });
+
+  // AC: @unified-cross-reference-lookup ac-spec-implements
+  it('should show specs with implements including target', async () => {
+    const result = kspecJson<{ specs_implements?: { ref: string; title: string }[]; total: number }>(
+      'refs @spec-a',
+      tempDir
+    );
+
+    expect(result.specs_implements).toBeDefined();
+    expect(result.specs_implements).toHaveLength(1);
+    expect(result.specs_implements![0].title).toBe('Spec C (implements A)');
+  });
+
+  // AC: @unified-cross-reference-lookup ac-spec-relates-to
+  it('should show specs with relates_to including target', async () => {
+    const result = kspecJson<{ specs_relates_to?: { ref: string; title: string }[]; total: number }>(
+      'refs @spec-a',
+      tempDir
+    );
+
+    expect(result.specs_relates_to).toBeDefined();
+    expect(result.specs_relates_to).toHaveLength(1);
+    expect(result.specs_relates_to![0].title).toBe('Spec D (relates to A)');
+  });
+
+  // AC: @unified-cross-reference-lookup ac-trait-references
+  it('should show specs with traits including target', async () => {
+    const result = kspecJson<{ specs_traits?: { ref: string; title: string }[]; total: number }>(
+      'refs @my-trait',
+      tempDir
+    );
+
+    expect(result.specs_traits).toBeDefined();
+    expect(result.specs_traits).toHaveLength(3);
+    const titles = result.specs_traits!.map(r => r.title);
+    expect(titles).toContain('Spec X (uses trait)');
+    expect(titles).toContain('Spec Y (uses trait)');
+    expect(titles).toContain('Spec Z (uses trait)');
+  });
+
+  // AC: @unified-cross-reference-lookup ac-meta-ref
+  it('should show tasks with meta_ref pointing to target', async () => {
+    const result = kspecJson<{ tasks_meta_ref?: { ref: string; title: string }[]; total: number }>(
+      'refs @workflow-1',
+      tempDir
+    );
+
+    expect(result.tasks_meta_ref).toBeDefined();
+    expect(result.tasks_meta_ref).toHaveLength(1);
+    expect(result.tasks_meta_ref![0].title).toBe('Task with meta_ref');
+  });
+
+  // AC: @unified-cross-reference-lookup ac-supersedes
+  it('should show specs with supersedes including target', async () => {
+    const result = kspecJson<{ specs_supersedes?: { ref: string; title: string }[]; total: number }>(
+      'refs @old-spec',
+      tempDir
+    );
+
+    expect(result.specs_supersedes).toBeDefined();
+    expect(result.specs_supersedes).toHaveLength(1);
+    expect(result.specs_supersedes![0].title).toBe('Spec E (supersedes old)');
+  });
+
+  // AC: @unified-cross-reference-lookup ac-grouped-output
+  it('should group output by relationship type with clear section headers', async () => {
+    // Use human-readable output (no --json)
+    const result = kspec('refs @spec-a', tempDir);
+
+    // Should have section headers (field names have underscores replaced with spaces)
+    expect(result.stdout).toContain('Specs (depends on)');
+    expect(result.stdout).toContain('Specs (implements)');
+    expect(result.stdout).toContain('Specs (relates to)');
+
+    // Should include the items
+    expect(result.stdout).toContain('Spec B');
+    expect(result.stdout).toContain('Spec C');
+    expect(result.stdout).toContain('Spec D');
+  });
+
+  // AC: @unified-cross-reference-lookup ac-json-structured
+  it('should return JSON object with keys per reference type', async () => {
+    const result = kspecJson<Record<string, unknown>>(
+      'refs @spec-a',
+      tempDir
+    );
+
+    // Should have structured keys
+    expect(result).toHaveProperty('target');
+    expect(result).toHaveProperty('target_ulid');
+    expect(result).toHaveProperty('total');
+
+    // Each array should have proper structure
+    if (result.specs_depends_on) {
+      const deps = result.specs_depends_on as { ref: string; ulid: string; title: string; type: string }[];
+      expect(deps[0]).toHaveProperty('ref');
+      expect(deps[0]).toHaveProperty('ulid');
+      expect(deps[0]).toHaveProperty('title');
+      expect(deps[0]).toHaveProperty('type');
+    }
+  });
+
+  // AC: @unified-cross-reference-lookup ac-no-refs
+  it('should show "No references found" message for isolated items', async () => {
+    const result = kspec('refs @isolated-item', tempDir);
+
+    expect(result.stdout).toContain('No references found');
+    expect(result.stdout).toContain('@isolated-item');
+    expect(result.exitCode).toBe(0);
+  });
+
+  // AC: @unified-cross-reference-lookup ac-ref-resolution
+  it('should support ULID, slug, and short ULID reference formats', async () => {
+    // Test with slug
+    const bySlug = kspecJson<{ total: number }>('refs @spec-a', tempDir);
+    expect(bySlug.total).toBeGreaterThan(0);
+
+    // Test with full ULID
+    const byUlid = kspecJson<{ total: number }>(`refs ${specAUlid}`, tempDir);
+    expect(byUlid.total).toBeGreaterThan(0);
+
+    // Test with short ULID (first 8 chars)
+    const byShortUlid = kspecJson<{ total: number }>(`refs ${specAUlid.slice(0, 8)}`, tempDir);
+    expect(byShortUlid.total).toBeGreaterThan(0);
+  });
+
+  // Error handling: invalid reference
+  it('should show error for invalid reference with suggestion', async () => {
+    const result = kspec('refs @nonexistent', tempDir, { expectFail: true });
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain('not found');
+    expect(result.stderr).toContain('search');
+  });
+
+  // Test total count
+  it('should show correct total count in JSON output', async () => {
+    const result = kspecJson<{ total: number }>(
+      'refs @spec-a',
+      tempDir
+    );
+
+    // spec-a is referenced by: spec-b (depends), spec-c (implements), spec-d (relates)
+    expect(result.total).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary

- Add new `kspec refs <ref>` command for unified cross-reference lookup
- Scans all tasks and spec items to find inbound references to a target entity
- Eliminates need for agents to grep YAML files to find relationships
- Supports all reference field types: spec_ref, depends_on, implements, relates_to, supersedes, traits, tests, meta_ref, plan_ref, blocked_by

## Features

- Groups output by relationship type (e.g., "Tasks (spec_ref)", "Specs (depends_on)")
- JSON output with structured keys per reference type
- Includes meta items (workflows, agents) in reference resolution
- Supports ULID, slug, and short ULID reference formats
- Shows "No references found" message for isolated items (exit code 0)

## Test Plan

- [x] 14 tests covering all 12 acceptance criteria
- [x] Tests pass: `npm test -- --run tests/refs.test.ts`
- [x] Full test suite passes

Task: @implement-unified-cross-reference-lookup
Spec: @unified-cross-reference-lookup

🤖 Generated with [Claude Code](https://claude.ai/code)