### PR TITLE
feat: add observation content search and search scope flags

### DIFF
--- a/src/cli/commands/meta.ts
+++ b/src/cli/commands/meta.ts
@@ -918,6 +918,7 @@ export function registerMetaCommands(program: Command): void {
     );
 
   // AC-obs-2, AC-obs-5: kspec meta observations
+  // AC: @observation-content-search ac-search-flag, ac-regex-support, ac-combined-filters
   meta
     .command("observations")
     .description("List observations (shows unresolved by default)")
@@ -931,6 +932,10 @@ export function registerMetaCommands(program: Command): void {
     .option(
       "--pending-resolution",
       "Show observations with completed tasks awaiting resolution",
+    )
+    .option(
+      "--search <pattern>",
+      "Search observations by regex pattern (matches content)",
     )
     .action(async (options) => {
       try {
@@ -980,6 +985,19 @@ export function registerMetaCommands(program: Command): void {
               "depends_on" in item &&
               item.status === "completed"
             );
+          });
+        }
+
+        // AC: @observation-content-search ac-search-flag, ac-regex-support, ac-combined-filters, ac-search-all-fields
+        // Apply --search filter using regex pattern (consistent with kspec search behavior)
+        if (options.search) {
+          const { grepItem } = await import("../../utils/grep.js");
+          observations = observations.filter((obs) => {
+            const match = grepItem(
+              obs as unknown as Record<string, unknown>,
+              options.search,
+            );
+            return match !== null;
           });
         }
 

--- a/src/cli/commands/search.ts
+++ b/src/cli/commands/search.ts
@@ -152,9 +152,23 @@ export function registerSearchCommand(program: Command): void {
     .option("-s, --status <status>", "Filter by task status")
     .option("--items-only", "Search only spec items")
     .option("--tasks-only", "Search only tasks")
+    .option("--observations-only", "Search only observations")
     .option("--limit <n>", "Limit results", "50")
     .action(async (pattern, options) => {
       try {
+        // AC: @observation-content-search ac-only-flags-exclusive
+        // Check mutual exclusivity of scope-only flags
+        const scopeFlags = [
+          options.itemsOnly && "--items-only",
+          options.tasksOnly && "--tasks-only",
+          options.observationsOnly && "--observations-only",
+        ].filter(Boolean);
+
+        if (scopeFlags.length > 1) {
+          error(`Flags ${scopeFlags.join(", ")} are mutually exclusive. Use only one at a time.`);
+          process.exit(EXIT_CODES.ERROR);
+        }
+
         const ctx = await initContext();
         const { itemIndex, tasks, items, refIndex } = await buildIndexes(ctx);
 
@@ -162,7 +176,8 @@ export function registerSearchCommand(program: Command): void {
         const limit = parseInt(options.limit, 10) || 50;
 
         // Search spec items
-        if (!options.tasksOnly) {
+        // AC: @observation-content-search ac-global-search-filter - skip items when --observations-only
+        if (!options.tasksOnly && !options.observationsOnly) {
           for (const item of items) {
             // Apply type filter
             if (options.type && item.type !== options.type) continue;
@@ -182,7 +197,8 @@ export function registerSearchCommand(program: Command): void {
         }
 
         // Search tasks
-        if (!options.itemsOnly) {
+        // AC: @observation-content-search ac-global-search-filter - skip tasks when --observations-only
+        if (!options.itemsOnly && !options.observationsOnly) {
           for (const task of tasks) {
             // Apply status filter
             if (options.status && task.status !== options.status) continue;
@@ -202,7 +218,8 @@ export function registerSearchCommand(program: Command): void {
         }
 
         // Search inbox items (AC-7)
-        if (!options.itemsOnly && !options.tasksOnly) {
+        // AC: @observation-content-search ac-global-search-filter - skip inbox when --observations-only
+        if (!options.itemsOnly && !options.tasksOnly && !options.observationsOnly) {
           const inboxItems = await loadInboxItems(ctx);
           for (const inboxItem of inboxItems) {
             const match = grepItem(
@@ -220,10 +237,11 @@ export function registerSearchCommand(program: Command): void {
         }
 
         // Search meta entities (AC-7)
+        // AC: @observation-content-search ac-global-search-filter - handle --observations-only
         if (!options.itemsOnly && !options.tasksOnly) {
           const metaCtx = await loadMetaContext(ctx);
 
-          // Search observations
+          // Search observations (always when not --items-only or --tasks-only)
           for (const observation of metaCtx.observations) {
             const match = grepItem(
               observation as unknown as Record<string, unknown>,
@@ -238,48 +256,51 @@ export function registerSearchCommand(program: Command): void {
             }
           }
 
-          // Search agents
-          for (const agent of metaCtx.agents) {
-            const match = grepItem(
-              agent as unknown as Record<string, unknown>,
-              pattern,
-            );
-            if (match) {
-              results.push({
-                type: "agent",
-                item: agent,
-                matchedFields: match.matchedFields,
-              });
+          // Skip other meta entities when --observations-only
+          if (!options.observationsOnly) {
+            // Search agents
+            for (const agent of metaCtx.agents) {
+              const match = grepItem(
+                agent as unknown as Record<string, unknown>,
+                pattern,
+              );
+              if (match) {
+                results.push({
+                  type: "agent",
+                  item: agent,
+                  matchedFields: match.matchedFields,
+                });
+              }
             }
-          }
 
-          // Search workflows
-          for (const workflow of metaCtx.workflows) {
-            const match = grepItem(
-              workflow as unknown as Record<string, unknown>,
-              pattern,
-            );
-            if (match) {
-              results.push({
-                type: "workflow",
-                item: workflow,
-                matchedFields: match.matchedFields,
-              });
+            // Search workflows
+            for (const workflow of metaCtx.workflows) {
+              const match = grepItem(
+                workflow as unknown as Record<string, unknown>,
+                pattern,
+              );
+              if (match) {
+                results.push({
+                  type: "workflow",
+                  item: workflow,
+                  matchedFields: match.matchedFields,
+                });
+              }
             }
-          }
 
-          // Search conventions
-          for (const convention of metaCtx.conventions) {
-            const match = grepItem(
-              convention as unknown as Record<string, unknown>,
-              pattern,
-            );
-            if (match) {
-              results.push({
-                type: "convention",
-                item: convention,
-                matchedFields: match.matchedFields,
-              });
+            // Search conventions
+            for (const convention of metaCtx.conventions) {
+              const match = grepItem(
+                convention as unknown as Record<string, unknown>,
+                pattern,
+              );
+              if (match) {
+                results.push({
+                  type: "convention",
+                  item: convention,
+                  matchedFields: match.matchedFields,
+                });
+              }
             }
           }
         }

--- a/tests/observation-content-search.test.ts
+++ b/tests/observation-content-search.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Tests for observation content search functionality
+ * AC: @observation-content-search
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { kspec, kspecJson, kspecOutput, setupTempFixtures, cleanupTempDir, testUlid } from './helpers/cli';
+
+describe('kspec meta observations --search', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await setupTempFixtures();
+  });
+
+  afterEach(async () => {
+    await cleanupTempDir(tempDir);
+  });
+
+  // AC: @observation-content-search ac-search-flag
+  it('should filter observations by search pattern', async () => {
+    // Fixtures have observations with content like "Test friction observation"
+    const result = kspec('meta observations --search friction --all', tempDir);
+    expect(result.stdout).toContain('friction');
+    expect(result.stdout).not.toContain('success observation');
+    expect(result.stdout).not.toContain('question observation');
+  });
+
+  // AC: @observation-content-search ac-regex-support
+  it('should treat search pattern as regex', async () => {
+    // Search with regex alternation: friction|success
+    const result = kspec('meta observations --search "friction|success" --all', tempDir);
+    expect(result.stdout).toContain('friction');
+    expect(result.stdout).toContain('success');
+    expect(result.stdout).not.toContain('question');
+  });
+
+  // AC: @observation-content-search ac-combined-filters
+  it('should combine --search with --type filter using AND logic', async () => {
+    // Add another friction observation that doesn't match search
+    const metaPath = path.join(tempDir, 'kynetic.meta.yaml');
+    let metaContent = await fs.readFile(metaPath, 'utf-8');
+
+    const newObs = `
+  - _ulid: ${testUlid('0BS', 10)}
+    created_at: "2026-01-25T09:00:00Z"
+    type: friction
+    content: "CLI command test"
+    resolved: false
+`;
+    metaContent = metaContent.replace('observations:', `observations:${newObs}`);
+    await fs.writeFile(metaPath, metaContent);
+
+    // Search for "test" with type friction - should get both friction observations
+    const result1 = kspec('meta observations --search test --type friction --all', tempDir);
+    expect(result1.stdout).toContain('friction');
+
+    // Search for "CLI" with type friction - should get only the new one
+    const result2 = kspecJson<Array<{ content: string }>>('meta observations --search CLI --type friction --all', tempDir);
+    expect(result2).toHaveLength(1);
+    expect(result2[0].content).toContain('CLI');
+  });
+
+  // AC: @observation-content-search ac-search-all-fields
+  it('should search all text fields not just content', async () => {
+    // grepItem searches all text fields recursively, not just the content field
+    // The type field is also searchable - "friction", "success", etc.
+    // This tests that searching for "success" (which is in the type field)
+    // finds the observation even though "success" is also in content
+    interface Observation {
+      _ulid: string;
+      type: string;
+      content: string;
+    }
+
+    // Search for "success" which is both a type value and in content
+    const results = kspecJson<Observation[]>('meta observations --search success --all', tempDir);
+
+    expect(results.length).toBeGreaterThan(0);
+    // Should find the success type observation
+    const hasSuccessType = results.some(obs => obs.type === 'success');
+    expect(hasSuccessType).toBe(true);
+  });
+
+  // AC: @observation-content-search ac-search-json
+  it('should return only matching observations in JSON mode', async () => {
+    interface Observation {
+      _ulid: string;
+      type: string;
+      content: string;
+    }
+
+    // Search for friction
+    const results = kspecJson<Observation[]>('meta observations --search friction --all', tempDir);
+
+    expect(Array.isArray(results)).toBe(true);
+    expect(results.length).toBeGreaterThan(0);
+    // All results should match the search pattern
+    for (const obs of results) {
+      const matchesPattern = obs.content.toLowerCase().includes('friction') ||
+                            obs.type === 'friction';
+      expect(matchesPattern).toBe(true);
+    }
+  });
+
+  it('should show empty result when no observations match search', async () => {
+    const result = kspec('meta observations --search "nonexistent-pattern-xyz" --all', tempDir);
+    expect(result.stdout).toContain('No');
+  });
+
+  it('should be case-insensitive by default', async () => {
+    // Search with different case
+    const result = kspec('meta observations --search FRICTION --all', tempDir);
+    expect(result.stdout).toContain('friction');
+  });
+});
+
+describe('kspec search --observations-only', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await setupTempFixtures();
+  });
+
+  afterEach(async () => {
+    await cleanupTempDir(tempDir);
+  });
+
+  // AC: @observation-content-search ac-global-search-filter
+  it('should return only observation matches when --observations-only is used', async () => {
+    interface SearchResult {
+      pattern: string;
+      results: Array<{ type: string; ulid: string }>;
+      total: number;
+    }
+
+    // Search for "test" which should match observations, tasks, and items
+    const allResults = kspecJson<SearchResult>('search test', tempDir);
+    const observationsOnlyResults = kspecJson<SearchResult>('search test --observations-only', tempDir);
+
+    // observations-only should have fewer results
+    expect(observationsOnlyResults.total).toBeLessThanOrEqual(allResults.total);
+
+    // All results should be observations
+    for (const result of observationsOnlyResults.results) {
+      expect(result.type).toBe('observation');
+    }
+  });
+
+  it('should find observations by content with --observations-only', async () => {
+    interface SearchResult {
+      pattern: string;
+      results: Array<{ type: string; title: string }>;
+      total: number;
+    }
+
+    const results = kspecJson<SearchResult>('search friction --observations-only', tempDir);
+
+    expect(results.total).toBeGreaterThan(0);
+    expect(results.results.every(r => r.type === 'observation')).toBe(true);
+  });
+
+  // AC: @observation-content-search ac-only-flags-exclusive
+  it('should error when --observations-only used with --items-only', async () => {
+    const result = kspec('search test --observations-only --items-only', tempDir, { expectFail: true });
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain('mutually exclusive');
+  });
+
+  it('should error when --observations-only used with --tasks-only', async () => {
+    const result = kspec('search test --observations-only --tasks-only', tempDir, { expectFail: true });
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain('mutually exclusive');
+  });
+
+  it('should error when all three scope flags are used', async () => {
+    const result = kspec('search test --observations-only --items-only --tasks-only', tempDir, { expectFail: true });
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain('mutually exclusive');
+  });
+
+  it('should work normally with only --items-only', async () => {
+    interface SearchResult {
+      results: Array<{ type: string }>;
+      total: number;
+    }
+
+    const results = kspecJson<SearchResult>('search test --items-only', tempDir);
+
+    // All results should be items
+    for (const result of results.results) {
+      expect(result.type).toBe('item');
+    }
+  });
+
+  it('should work normally with only --tasks-only', async () => {
+    interface SearchResult {
+      results: Array<{ type: string }>;
+      total: number;
+    }
+
+    const results = kspecJson<SearchResult>('search test --tasks-only', tempDir);
+
+    // All results should be tasks
+    for (const result of results.results) {
+      expect(result.type).toBe('task');
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Add `--search` flag to `kspec meta observations` for regex pattern filtering
- Add `--observations-only` flag to `kspec search` command for scoping search results
- Add mutual exclusivity validation for scope flags (`--items-only`, `--tasks-only`, `--observations-only`)

## Changes

**src/cli/commands/meta.ts:**
- Added `--search <pattern>` option to observations subcommand
- Uses `grepItem` from utils/grep.ts for consistent regex matching (case-insensitive by default)
- Search is applied after other filters (type, workflow, promoted, etc.) using AND logic

**src/cli/commands/search.ts:**
- Added `--observations-only` flag to limit search to observations only
- Added validation to prevent combining mutually exclusive scope flags
- Updated search logic to respect the new flag

## Test plan

- [ ] 14 new tests in `tests/observation-content-search.test.ts` covering all 7 ACs
- [ ] Verify `kspec meta observations --search pattern` filters correctly
- [ ] Verify `kspec search pattern --observations-only` returns only observations
- [ ] Verify error when using multiple scope flags together

Task: @implement-observation-content-search
Spec: @observation-content-search

🤖 Generated with [Claude Code](https://claude.com/claude-code)