### PR TITLE
feat: add --tasks flag to ralph for explicit task scoping

### DIFF
--- a/src/cli/commands/ralph.ts
+++ b/src/cli/commands/ralph.ts
@@ -284,6 +284,110 @@ function extractBashCommand(update: SessionUpdate): string | null {
   return command;
 }
 
+// ─── Explicit Task Scope ─────────────────────────────────────────────────────
+
+/**
+ * Parsed explicit task scope for --tasks flag.
+ * AC: @cli-ralph ac-21
+ */
+interface ExplicitTaskScope {
+  /** Original refs as provided by user */
+  refs: string[];
+  /** Resolved ULIDs for the tasks */
+  ulids: string[];
+}
+
+/**
+ * Parse and validate --tasks flag value.
+ * Returns resolved ULIDs for the specified task refs.
+ * AC: @cli-ralph ac-21
+ *
+ * @throws Error if any ref cannot be resolved or is not a task
+ */
+async function parseExplicitTasks(
+  ctx: KspecContext,
+  tasksArg: string,
+): Promise<ExplicitTaskScope> {
+  const refs = tasksArg.split(",").map((r) => r.trim()).filter(Boolean);
+
+  if (refs.length === 0) {
+    throw new Error("--tasks requires at least one task reference");
+  }
+
+  // Load tasks and items for resolution
+  const tasks = await loadAllTasks(ctx);
+  const items = await loadAllItems(ctx);
+  const index = new ReferenceIndex(tasks, items);
+
+  const ulids: string[] = [];
+
+  for (const ref of refs) {
+    const result = index.resolve(ref);
+    if (!result.ok) {
+      throw new Error(`Cannot resolve task reference: ${ref}`);
+    }
+
+    // Verify it's a task (not a spec item)
+    const task = tasks.find((t) => t._ulid === result.ulid);
+    if (!task) {
+      throw new Error(`Reference ${ref} is not a task`);
+    }
+
+    ulids.push(result.ulid);
+  }
+
+  return { refs, ulids };
+}
+
+/**
+ * Filter session context to only include tasks from explicit scope.
+ * AC: @cli-ralph ac-21
+ */
+function filterByExplicitTasks(
+  ctx: SessionContext,
+  scope: ExplicitTaskScope,
+): SessionContext {
+  // Task refs in context are short ULIDs (variable length from shortUlid())
+  // Check if the context ref is a prefix of any explicit ULID
+  const matchesScope = (taskRef: string) => {
+    return scope.ulids.some((ulid) => ulid.startsWith(taskRef));
+  };
+
+  return {
+    ...ctx,
+    active_tasks: ctx.active_tasks.filter((t) => matchesScope(t.ref)),
+    pending_review_tasks: ctx.pending_review_tasks.filter((t) => matchesScope(t.ref)),
+    ready_tasks: ctx.ready_tasks.filter((t) => matchesScope(t.ref)),
+  };
+}
+
+/**
+ * Check if all explicit tasks are completed or blocked.
+ * AC: @cli-ralph ac-21
+ */
+async function allExplicitTasksDone(
+  ctx: KspecContext,
+  scope: ExplicitTaskScope,
+): Promise<{ done: boolean; statuses: Map<string, string> }> {
+  const tasks = await loadAllTasks(ctx);
+  const statuses = new Map<string, string>();
+
+  for (const ulid of scope.ulids) {
+    const task = tasks.find((t) => t._ulid === ulid);
+    if (task) {
+      statuses.set(ulid.slice(0, 8), task.status);
+    }
+  }
+
+  // Check if all are completed or blocked
+  const done = scope.ulids.every((ulid) => {
+    const status = statuses.get(ulid.slice(0, 8));
+    return status === "completed" || status === "blocked";
+  });
+
+  return { done, statuses };
+}
+
 // ─── Prompt Template ─────────────────────────────────────────────────────────
 
 // AC: @ralph-skill-delegation ac-1, ac-2, ac-3
@@ -293,6 +397,7 @@ function buildTaskWorkPrompt(
   maxLoops: number,
   sessionId: string,
   focus?: string,
+  explicitTaskScope?: ExplicitTaskScope,
 ): string {
   const focusSection = focus
     ? `
@@ -304,12 +409,27 @@ Keep this focus in mind throughout your work. It takes priority over default tas
 `
     : "";
 
+  // AC: @cli-ralph ac-21 - Explicit task scope indicator in prompt
+  const taskScopeSection = explicitTaskScope
+    ? `
+## Explicit Task Scope
+
+This session is scoped to specific tasks: ${explicitTaskScope.refs.join(", ")}
+
+**Only work on these tasks.** The loop will exit when all listed tasks are completed or blocked.
+`
+    : "";
+
+  const modeDescription = explicitTaskScope
+    ? "Loop mode means: no confirmations, auto-resolve decisions, explicit task scope (only the listed tasks)."
+    : "Loop mode means: no confirmations, auto-resolve decisions, automation-eligible tasks only.";
+
   return `# Kspec Automation Session - Task Work
 
 **Session ID:** \`${sessionId}\`
 **Iteration:** ${iteration} of ${maxLoops}
 **Mode:** Automated (no human in the loop)
-${focusSection}
+${focusSection}${taskScopeSection}
 
 ## Current State
 \`\`\`json
@@ -324,7 +444,7 @@ Run the task-work skill in loop mode:
 /task-work loop
 \`\`\`
 
-Loop mode means: no confirmations, auto-resolve decisions, automation-eligible tasks only.
+${modeDescription}
 
 **Normal flow:** Work on a task, create a PR, then stop responding. Ralph continues automatically —
 it checks for remaining eligible tasks at the start of each iteration and exits the loop itself when none remain.
@@ -926,6 +1046,10 @@ export function registerRalphCommand(program: Command): void {
       "Max tasks per iteration (0 = unlimited)",
       "1",
     )
+    .option(
+      "--tasks <refs>",
+      "Explicit task scope: only work on these tasks (comma-separated refs, e.g., @task1,@task2)",
+    )
     .action(async (args: string[], options) => {
       // Check for unknown subcommands that fell through to default
       // Only check args that look like subcommand names (alphanumeric with hyphens, no quotes)
@@ -1018,15 +1142,31 @@ export function registerRalphCommand(program: Command): void {
           restartEvery > 0 ? `, restart every ${restartEvery}` : "";
         const maxTasksInfo =
           maxTasks === 0 ? "unlimited" : `${maxTasks}`;
+
+        // Initialize kspec context early to validate --tasks
+        const ctx = await initContext();
+
+        // AC: @cli-ralph ac-21 - Parse explicit task scope
+        let explicitTaskScope: ExplicitTaskScope | undefined;
+        if (options.tasks) {
+          try {
+            explicitTaskScope = await parseExplicitTasks(ctx, options.tasks);
+            info(`Explicit task scope: ${explicitTaskScope.refs.join(", ")}`);
+          } catch (err) {
+            error(`Invalid --tasks argument: ${(err as Error).message}`);
+            process.exit(EXIT_CODES.VALIDATION_FAILED);
+          }
+        }
+
+        const taskScopeInfo = explicitTaskScope
+          ? `, tasks=${explicitTaskScope.refs.join(",")}`
+          : "";
         info(
-          `Starting ralph loop (adapter=${options.adapter}, max ${maxLoops} iterations, ${maxRetries} retries, ${maxFailures} max failures${restartInfo}, max-tasks=${maxTasksInfo})`,
+          `Starting ralph loop (adapter=${options.adapter}, max ${maxLoops} iterations, ${maxRetries} retries, ${maxFailures} max failures${restartInfo}, max-tasks=${maxTasksInfo}${taskScopeInfo})`,
         );
         if (options.focus) {
           info(`Focus: ${options.focus}`);
         }
-
-        // Initialize kspec context
-        const ctx = await initContext();
         const specDir = ctx.specDir;
 
         // Create session for event tracking
@@ -1049,6 +1189,7 @@ export function registerRalphCommand(program: Command): void {
             maxTasks,
             yolo: options.yolo,
             focus: options.focus,
+            explicitTasks: explicitTaskScope?.refs,
           },
         });
 
@@ -1114,12 +1255,18 @@ export function registerRalphCommand(program: Command): void {
             }
             await clearEndLoopMarker(ctx.rootDir);
 
-            // Gather fresh context each iteration (only automation-eligible tasks)
-            // AC: @cli-ralph ac-16
-            const sessionCtx = await gatherSessionContext(ctx, {
+            // Gather fresh context each iteration
+            // AC: @cli-ralph ac-16 - Only automation-eligible tasks (unless explicit scope)
+            // AC: @cli-ralph ac-21 - With explicit task scope, ignore automation eligibility
+            let sessionCtx = await gatherSessionContext(ctx, {
               limit: "10",
-              eligible: true,
+              eligible: !explicitTaskScope, // Skip eligibility filter if explicit scope
             });
+
+            // AC: @cli-ralph ac-21 - Filter to explicit tasks if scope is set
+            if (explicitTaskScope) {
+              sessionCtx = filterByExplicitTasks(sessionCtx, explicitTaskScope);
+            }
 
             // AC: @ralph-subagent-spawning ac-8 - Process pending_review tasks BEFORE main iteration
             // This wraps consecutiveFailures in an object so it can be mutated by the helper
@@ -1149,8 +1296,23 @@ export function registerRalphCommand(program: Command): void {
             if (sessionCtx.pending_review_tasks.length > 0) {
               currentCtx = await gatherSessionContext(ctx, {
                 limit: "10",
-                eligible: true,
+                eligible: !explicitTaskScope,
               });
+              if (explicitTaskScope) {
+                currentCtx = filterByExplicitTasks(currentCtx, explicitTaskScope);
+              }
+            }
+
+            // AC: @cli-ralph ac-21 - Check explicit task completion
+            if (explicitTaskScope) {
+              const { done, statuses } = await allExplicitTasksDone(ctx, explicitTaskScope);
+              if (done) {
+                const statusList = Array.from(statuses.entries())
+                  .map(([ref, status]) => `${ref}: ${status}`)
+                  .join(", ");
+                info(`All explicit tasks completed or blocked (${statusList}). Exiting loop.`);
+                break;
+              }
             }
 
             // Check for automation-eligible tasks (ready or in_progress)
@@ -1159,7 +1321,11 @@ export function registerRalphCommand(program: Command): void {
             const hasReadyTasks = currentCtx.ready_tasks.length > 0;
 
             if (!hasActiveTasks && !hasReadyTasks) {
-              info("No automation-eligible tasks (ready or in_progress). Exiting loop.");
+              if (explicitTaskScope) {
+                info("No explicit tasks available (ready or in_progress). Exiting loop.");
+              } else {
+                info("No automation-eligible tasks (ready or in_progress). Exiting loop.");
+              }
               break;
             }
 
@@ -1168,12 +1334,14 @@ export function registerRalphCommand(program: Command): void {
             const iterationStartTime = new Date();
 
             // Build prompts - task-work first, then reflect
+            // AC: @cli-ralph ac-21 - Include explicit task scope in prompt
             const taskWorkPrompt = buildTaskWorkPrompt(
               currentCtx,
               iteration,
               maxLoops,
               sessionId,
               options.focus,
+              explicitTaskScope,
             );
             const reflectPrompt = buildReflectPrompt(
               iteration,
@@ -1181,7 +1349,7 @@ export function registerRalphCommand(program: Command): void {
               sessionId,
             );
 
-            // AC: @ralph-task-limit ac-dryrun
+            // AC: @ralph-task-limit ac-dryrun, @cli-ralph ac-21
             if (options.dryRun) {
               console.log(
                 chalk.yellow("=== DRY RUN - Configuration ===\n"),
@@ -1191,6 +1359,9 @@ export function registerRalphCommand(program: Command): void {
               console.log(`  max-retries: ${maxRetries}`);
               console.log(`  max-failures: ${maxFailures}`);
               console.log(`  restart-every: ${restartEvery === 0 ? "never" : restartEvery}`);
+              if (explicitTaskScope) {
+                console.log(`  explicit-tasks: ${explicitTaskScope.refs.join(", ")}`);
+              }
               console.log(
                 chalk.yellow("\n=== Task Work Prompt ===\n"),
               );

--- a/tests/ralph.test.ts
+++ b/tests/ralph.test.ts
@@ -1386,4 +1386,176 @@ describe('subagent module', () => {
       expect(typeof renderer.render).toBe('function');
     });
   });
+
+  // ─── Explicit Task Scope Tests ──────────────────────────────────────────────
+  // AC: @cli-ralph ac-21
+
+  describe('--tasks flag (explicit task scope)', () => {
+    let tempDir: string;
+
+    beforeEach(async () => {
+      tempDir = await setupTempFixtures();
+    });
+
+    afterEach(async () => {
+      await cleanupTempDir(tempDir);
+    });
+
+    // AC: @cli-ralph ac-21 - Basic explicit task scope
+    it('accepts --tasks flag with task references', async () => {
+      const result = runRalph('--dry-run --tasks @test-task-pending', tempDir);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('explicit-tasks: @test-task-pending');
+      expect(result.stdout).toContain('Explicit Task Scope');
+    });
+
+    // AC: @cli-ralph ac-21 - Multiple tasks
+    it('accepts comma-separated task refs', async () => {
+      const result = runRalph('--dry-run --tasks @test-task-pending,@test-task-secondary', tempDir);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('explicit-tasks: @test-task-pending, @test-task-secondary');
+    });
+
+    // AC: @cli-ralph ac-21 - ULID format
+    it('accepts ULID format task refs', async () => {
+      const result = runRalph('--dry-run --tasks @01KF1645CA45ZT43W2T6HJMVA1', tempDir);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Explicit Task Scope');
+    });
+
+    // AC: @cli-ralph ac-21 - Short ULID format
+    it('accepts short ULID format task refs', async () => {
+      // Use 01KF1645CA which uniquely identifies test-task-pending
+      const result = runRalph('--dry-run --tasks @01KF1645CA', tempDir);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Explicit Task Scope');
+    });
+
+    // AC: @cli-ralph ac-21 - Invalid task ref
+    it('errors on invalid task reference', async () => {
+      const result = runRalph('--dry-run --tasks @nonexistent-task', tempDir);
+
+      expect(result.exitCode).not.toBe(0);
+      expect(result.output).toContain('Cannot resolve task reference');
+    });
+
+    // AC: @cli-ralph ac-21 - Prompt includes scope indicator
+    it('includes explicit task scope in prompt', async () => {
+      const result = runRalph('--dry-run --tasks @test-task-pending', tempDir);
+
+      expect(result.stdout).toContain('Explicit Task Scope');
+      expect(result.stdout).toContain('This session is scoped to specific tasks');
+      expect(result.stdout).toContain('@test-task-pending');
+    });
+
+    // AC: @cli-ralph ac-21 - Mode description updated
+    it('updates mode description for explicit scope', async () => {
+      const result = runRalph('--dry-run --tasks @test-task-pending', tempDir);
+
+      // Should mention explicit task scope, not automation-eligible
+      expect(result.stdout).toContain('explicit task scope');
+    });
+
+    // AC: @cli-ralph ac-21 - Session start event includes explicit tasks
+    it('logs explicit tasks in session start event', async () => {
+      const result = runRalph('--max-loops 1 --tasks @test-task-pending', tempDir, {
+        MOCK_ACP_EXIT_CODE: '0',
+      });
+
+      // Check events file
+      const sessionsDir = path.join(tempDir, 'sessions');
+      const sessions = await fs.readdir(sessionsDir).catch(() => []);
+
+      if (sessions.length > 0) {
+        const eventsPath = path.join(sessionsDir, sessions[0], 'events.jsonl');
+        const events = await fs.readFile(eventsPath, 'utf-8');
+
+        expect(events).toContain('explicitTasks');
+        expect(events).toContain('@test-task-pending');
+      }
+    });
+
+    // AC: @cli-ralph ac-21 - Ignores automation eligibility with explicit scope
+    it('includes manual_only tasks when explicitly specified', async () => {
+      // test-task-secondary is automation: manual_only
+      const result = runRalph('--dry-run --tasks @test-task-secondary', tempDir);
+
+      expect(result.exitCode).toBe(0);
+      // Should not fail even though task is manual_only
+      expect(result.stdout).toContain('Explicit Task Scope');
+      expect(result.stdout).toContain('@test-task-secondary');
+    });
+
+    // AC: @cli-ralph ac-21 - Only shows explicitly listed tasks in context
+    it('filters context to only include explicit tasks', async () => {
+      const result = runRalph('--dry-run --tasks @test-task-pending', tempDir);
+
+      // Context should only show the explicitly listed task
+      // The ready_tasks should not include test-task-secondary (even though it's pending)
+      expect(result.stdout).toContain('test-task-pending');
+
+      // Parse the JSON context from output to verify filtering
+      const contextMatch = result.stdout.match(/## Current State\s+```json\s+([\s\S]*?)\s+```/);
+      if (contextMatch) {
+        const context = JSON.parse(contextMatch[1]);
+        // Ready tasks should only include the explicit task
+        const readyRefs = context.ready_tasks.map((t: { ref: string }) => t.ref);
+        expect(readyRefs.length).toBeLessThanOrEqual(1);
+        // Should not include test-task-secondary
+        expect(readyRefs).not.toContain('01KF1645C'); // Short ULID prefix for secondary
+      }
+    });
+
+    // AC: @cli-ralph ac-21 - Exit when all explicit tasks completed
+    it('exits when all explicit tasks are completed', async () => {
+      // test-task-completed is already completed
+      const result = runRalph('--max-loops 5 --tasks @test-task-completed', tempDir, {
+        MOCK_ACP_EXIT_CODE: '0',
+      });
+
+      expect(result.output).toContain('All explicit tasks completed or blocked');
+      // Should not run multiple iterations
+      expect(result.output).not.toContain('Iteration 2/5');
+    });
+
+    // AC: @cli-ralph ac-21 - Exit when all explicit tasks blocked
+    it('exits when all explicit tasks are blocked', async () => {
+      // Modify test-task-pending to be blocked
+      const tasksPath = path.join(tempDir, 'project.tasks.yaml');
+      const content = await fs.readFile(tasksPath, 'utf-8');
+      const modified = content.replace(
+        /title: Test pending task\n    type: task\n    status: pending/,
+        'title: Test pending task\n    type: task\n    status: blocked'
+      );
+      await fs.writeFile(tasksPath, modified);
+
+      const result = runRalph('--max-loops 5 --tasks @test-task-pending', tempDir, {
+        MOCK_ACP_EXIT_CODE: '0',
+      });
+
+      expect(result.output).toContain('All explicit tasks completed or blocked');
+    });
+
+    // AC: @cli-ralph ac-21 - Empty --tasks value
+    it('errors on empty --tasks value', async () => {
+      const result = runRalph('--dry-run --tasks ""', tempDir);
+
+      // Should error or show warning
+      expect(result.exitCode).not.toBe(0);
+    });
+
+    // AC: @cli-ralph ac-21 - Reference to spec item (not task) should error
+    it('errors when --tasks references a spec item instead of task', async () => {
+      // Try to use a spec item ref (if any exist in fixtures)
+      const result = runRalph('--dry-run --tasks @some-spec-item', tempDir);
+
+      expect(result.exitCode).not.toBe(0);
+      // Should mention it's not a task or cannot be resolved
+      expect(result.output).toMatch(/cannot resolve|not a task/i);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Add `--tasks <refs>` flag to `kspec ralph` command for explicit task scoping
- Accept comma-separated task refs (e.g., `--tasks @task1,@task2`)
- Bypass automation eligibility filtering when explicit tasks are specified
- Filter session context to only include the listed tasks
- Exit loop when all explicit tasks are completed or blocked
- Include explicit task scope indicator in prompt for agent awareness

## Test plan

- [x] Run `npm test -- tests/ralph.test.ts -t "tasks flag"` - 14 tests passing
- [x] Verify flag acceptance with slug, ULID, and short ULID formats
- [x] Verify error handling for invalid/non-task refs
- [x] Verify prompt includes explicit scope section
- [x] Verify loop exits when all explicit tasks done

Task: @01KHAP9E
Spec: @cli-ralph

🤖 Generated with [Claude Code](https://claude.ai/code)