### PR TITLE
feat: add ralph wrap-up agent on loop exit

### DIFF
--- a/src/cli/commands/ralph.ts
+++ b/src/cli/commands/ralph.ts
@@ -39,13 +39,18 @@ import {
   ReferenceIndex,
 } from "../../parser/index.js";
 import {
+  buildWrapUpContext,
   createCliRenderer,
   createTranslator,
   DEFAULT_SUBAGENT_PREFIX,
   DEFAULT_SUBAGENT_TIMEOUT,
+  DEFAULT_WRAPUP_TIMEOUT,
+  type ExitReason,
   RALPH_PROMPT_TIMEOUT,
   runSubagent,
+  runWrapUpAgent,
   type SubagentContext,
+  WRAPUP_AGENT_PREFIX,
 } from "../../ralph/index.js";
 import {
   appendEvent,
@@ -1233,6 +1238,12 @@ export function registerRalphCommand(program: Command): void {
         // AC: @ralph-end-loop ac-detect, ac-graceful
         let endLoopRequested = false;
 
+        // AC: @ralph-wrap-up-agent-on-loop-exit ac-1 - Track exit reason for wrap-up
+        let exitReason: ExitReason | null = null;
+        let lastIterationCtx: SessionContext | null = null;
+        let lastErrorMessage: string | undefined;
+        const recentTaskRefs: string[] = [];
+
         try {
           for (let iteration = 1; iteration <= maxLoops; iteration++) {
             renderer.newSection?.(`Iteration ${iteration}/${maxLoops}`);
@@ -1286,6 +1297,8 @@ export function registerRalphCommand(program: Command): void {
             consecutiveFailures = failureTracker.count;
 
             if (!continueLoop) {
+              exitReason = "max_failures";
+              lastIterationCtx = sessionCtx;
               break;
             }
 
@@ -1311,6 +1324,8 @@ export function registerRalphCommand(program: Command): void {
                   .map(([ref, status]) => `${ref}: ${status}`)
                   .join(", ");
                 info(`All explicit tasks completed or blocked (${statusList}). Exiting loop.`);
+                exitReason = "explicit_tasks_done";
+                lastIterationCtx = currentCtx;
                 break;
               }
             }
@@ -1326,6 +1341,8 @@ export function registerRalphCommand(program: Command): void {
               } else {
                 info("No automation-eligible tasks (ready or in_progress). Exiting loop.");
               }
+              exitReason = "no_tasks";
+              lastIterationCtx = currentCtx;
               break;
             }
 
@@ -1616,9 +1633,18 @@ export function registerRalphCommand(program: Command): void {
               success(`Completed iteration ${iteration}`);
               consecutiveFailures = 0;
 
+              // Track task refs from this iteration for wrap-up context
+              for (const t of sessionCtx.active_tasks) {
+                if (!recentTaskRefs.includes(t.ref)) {
+                  recentTaskRefs.push(t.ref);
+                }
+              }
+              lastIterationCtx = sessionCtx;
+
               // AC: @ralph-end-loop ac-graceful - Check for end-loop signal
               if (endLoopRequested) {
                 info("Agent requested end of loop. Exiting gracefully.");
+                exitReason = "end_loop_signal";
                 break;
               }
 
@@ -1663,11 +1689,19 @@ export function registerRalphCommand(program: Command): void {
 
               if (consecutiveFailures >= maxFailures) {
                 error(errors.failures.reachedMaxFailures(maxFailures));
+                exitReason = "max_failures";
+                lastErrorMessage = lastError?.message;
+                lastIterationCtx = sessionCtx;
                 break;
               }
 
               info("Continuing to next iteration...");
             }
+          }
+
+          // If loop completed all iterations without breaking
+          if (exitReason === null) {
+            exitReason = "max_iterations";
           }
         } finally {
           // Remove signal handlers to avoid double cleanup
@@ -1677,6 +1711,7 @@ export function registerRalphCommand(program: Command): void {
           // Clean up agent
           if (agent) {
             agent.kill();
+            agent = null;
           }
 
           // AC: @ralph-task-limit ac-reset - Clear marker file when session ends
@@ -1684,6 +1719,72 @@ export function registerRalphCommand(program: Command): void {
 
           // AC: @ralph-end-loop ac-cleanup - Clear end-loop marker when session ends
           await clearEndLoopMarker(ctx.rootDir);
+
+          // AC: @ralph-wrap-up-agent-on-loop-exit ac-1, ac-2, ac-3, ac-4, ac-5
+          // Spawn wrap-up agent if not dry-run and we have an exit reason
+          if (!options.dryRun && exitReason) {
+            console.log("");
+            console.log(chalk.cyan(`${"═".repeat(60)}`));
+            console.log(chalk.cyan.bold(`${WRAPUP_AGENT_PREFIX} Starting Wrap-Up`));
+            console.log(chalk.cyan(`${"═".repeat(60)}`));
+            console.log("");
+
+            const inProgressTasks = lastIterationCtx?.active_tasks || [];
+            const pendingReviewTasks = lastIterationCtx?.pending_review_tasks || [];
+
+            const wrapUpCtx = buildWrapUpContext(
+              exitReason,
+              sessionId,
+              maxLoops, // Use maxLoops as iteration (we're at the end)
+              maxLoops,
+              inProgressTasks,
+              pendingReviewTasks,
+              recentTaskRefs,
+              process.cwd(),
+              lastErrorMessage,
+            );
+
+            info(`Exit reason: ${exitReason}`);
+            info(`Working tree: ${wrapUpCtx.workingTree.clean ? "clean" : "has uncommitted changes"}`);
+
+            const wrapUpResult = await runWrapUpAgent(
+              adapter,
+              wrapUpCtx,
+              {
+                yolo: options.yolo,
+                cwd: process.cwd(),
+                handleRequest: (client, reqId, method, params) =>
+                  handleRequest(client, reqId, method, params, options.yolo),
+              },
+              DEFAULT_WRAPUP_TIMEOUT,
+            );
+
+            // Log wrap-up result
+            await appendEvent(specDir, {
+              session_id: sessionId,
+              type: "session.wrapup",
+              data: {
+                exitReason,
+                result: wrapUpResult,
+              },
+            });
+
+            if (wrapUpResult.skipped) {
+              info(`${WRAPUP_AGENT_PREFIX} Skipped: ${wrapUpResult.skipReason}`);
+            } else if (wrapUpResult.timedOut) {
+              warn(`${WRAPUP_AGENT_PREFIX} Timed out after ${DEFAULT_WRAPUP_TIMEOUT / 1000}s`);
+            } else if (!wrapUpResult.success) {
+              warn(`${WRAPUP_AGENT_PREFIX} Failed: ${wrapUpResult.error}`);
+            } else {
+              success(`${WRAPUP_AGENT_PREFIX} Completed`);
+            }
+
+            console.log("");
+            console.log(chalk.cyan(`${"═".repeat(60)}`));
+            console.log(chalk.cyan.bold(`${WRAPUP_AGENT_PREFIX} Wrap-Up Complete`));
+            console.log(chalk.cyan(`${"═".repeat(60)}`));
+            console.log("");
+          }
 
           // Log session end
           const status =
@@ -1694,6 +1795,7 @@ export function registerRalphCommand(program: Command): void {
             data: {
               status,
               consecutiveFailures,
+              exitReason,
             },
           });
           await updateSessionStatus(specDir, sessionId, status);

--- a/src/ralph/index.ts
+++ b/src/ralph/index.ts
@@ -47,3 +47,16 @@ export {
   shouldEscalate,
   type TaskFailureResult,
 } from "./loop-errors.js";
+// Wrap-up agent
+export {
+  buildWrapUpContext,
+  buildWrapUpPrompt,
+  DEFAULT_WRAPUP_TIMEOUT,
+  type ExitReason,
+  isWrapUpNeeded,
+  runWrapUpAgent,
+  WRAPUP_AGENT_PREFIX,
+  type WrapUpContext,
+  type WrapUpOptions,
+  type WrapUpResult,
+} from "./wrap-up.js";

--- a/src/ralph/wrap-up.ts
+++ b/src/ralph/wrap-up.ts
@@ -1,0 +1,395 @@
+/**
+ * Ralph Wrap-Up Agent Module
+ *
+ * Handles spawning a wrap-up subagent when the ralph loop exits.
+ * The wrap-up agent ensures the workspace is in a clean state:
+ * - Identifies uncommitted changes and reports what they relate to
+ * - Commits, stashes, or flags changes for human review
+ * - Produces a brief exit summary
+ *
+ * AC: @ralph-wrap-up-agent-on-loop-exit
+ */
+
+import type { AgentAdapter } from "../agents/adapters.js";
+import { spawnAndInitialize, type SpawnedAgent } from "../agents/spawner.js";
+import type { SessionUpdate } from "../acp/index.js";
+import type { LoadedTask } from "../parser/index.js";
+import { getWorkingTreeStatus, type GitWorkingTree } from "../utils/git.js";
+import { createTranslator } from "./events.js";
+import { createPrefixedRenderer } from "./cli-renderer.js";
+import { RALPH_PROMPT_TIMEOUT } from "./subagent.js";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/**
+ * Exit reason for ralph loop.
+ * AC: @ralph-wrap-up-agent-on-loop-exit ac-1
+ */
+export type ExitReason =
+  | "no_tasks"
+  | "end_loop_signal"
+  | "max_iterations"
+  | "error"
+  | "max_failures"
+  | "explicit_tasks_done";
+
+/**
+ * Context provided to the wrap-up agent.
+ * AC: @ralph-wrap-up-agent-on-loop-exit ac-2
+ */
+export interface WrapUpContext {
+  /** Why the loop is exiting */
+  exitReason: ExitReason;
+  /** Session ID for reference */
+  sessionId: string;
+  /** Current iteration number */
+  iteration: number;
+  /** Max iterations configured */
+  maxIterations: number;
+  /** Working tree status from git */
+  workingTree: GitWorkingTree;
+  /** Tasks that were in progress when loop ended */
+  inProgressTasks: Array<{ ref: string; title: string }>;
+  /** Tasks that were pending review when loop ended */
+  pendingReviewTasks: Array<{ ref: string; title: string }>;
+  /** Recent task refs worked on this session (for relating changes) */
+  recentTaskRefs: string[];
+  /** Error message if exit was due to error */
+  errorMessage?: string;
+}
+
+/**
+ * Result of running the wrap-up agent.
+ * AC: @ralph-wrap-up-agent-on-loop-exit ac-4, ac-5
+ */
+export interface WrapUpResult {
+  /** Whether wrap-up completed successfully */
+  success: boolean;
+  /** Whether the wrap-up agent timed out */
+  timedOut: boolean;
+  /** Error message if failed */
+  error?: string;
+  /** Whether wrap-up was skipped (e.g., clean working tree, nothing to do) */
+  skipped: boolean;
+  /** Reason for skipping if skipped */
+  skipReason?: string;
+}
+
+/**
+ * Options for running the wrap-up agent.
+ */
+export interface WrapUpOptions {
+  /** Whether to auto-approve tool requests */
+  yolo: boolean;
+  /** Working directory */
+  cwd: string;
+  /** Tool request handler */
+  handleRequest: (
+    client: SpawnedAgent["client"],
+    reqId: string | number,
+    method: string,
+    params: unknown,
+  ) => Promise<void>;
+}
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/**
+ * Default wrap-up agent timeout: 2 minutes.
+ * AC: @ralph-wrap-up-agent-on-loop-exit ac-5
+ */
+export const DEFAULT_WRAPUP_TIMEOUT = 2 * 60 * 1000;
+
+/** Output prefix for wrap-up agent */
+export const WRAPUP_AGENT_PREFIX = "[WRAP-UP]";
+
+// ============================================================================
+// Context Builder
+// ============================================================================
+
+/**
+ * Build wrap-up context from current state.
+ * AC: @ralph-wrap-up-agent-on-loop-exit ac-2
+ */
+export function buildWrapUpContext(
+  exitReason: ExitReason,
+  sessionId: string,
+  iteration: number,
+  maxIterations: number,
+  inProgressTasks: Array<{ ref: string; title: string }>,
+  pendingReviewTasks: Array<{ ref: string; title: string }>,
+  recentTaskRefs: string[],
+  cwd?: string,
+  errorMessage?: string,
+): WrapUpContext {
+  const workingTree = getWorkingTreeStatus(cwd);
+
+  return {
+    exitReason,
+    sessionId,
+    iteration,
+    maxIterations,
+    workingTree,
+    inProgressTasks,
+    pendingReviewTasks,
+    recentTaskRefs,
+    errorMessage,
+  };
+}
+
+/**
+ * Check if wrap-up is needed.
+ * Wrap-up is skipped if working tree is clean and no in-progress tasks.
+ *
+ * Key insight: wrap-up's job is to handle uncommitted changes and summarize
+ * task state. If the working tree is clean and no tasks are in progress,
+ * there's nothing for wrap-up to do regardless of exit reason.
+ */
+export function isWrapUpNeeded(context: WrapUpContext): {
+  needed: boolean;
+  reason?: string;
+} {
+  // Always need wrap-up if there are uncommitted changes
+  if (!context.workingTree.clean) {
+    return { needed: true };
+  }
+
+  // Need wrap-up if there are tasks still in progress
+  if (context.inProgressTasks.length > 0) {
+    return { needed: true };
+  }
+
+  // Clean tree, no in-progress tasks - nothing to clean up
+  // This applies even for error exits - if there's nothing to clean,
+  // spawning a wrap-up agent just adds latency without benefit
+  return {
+    needed: false,
+    reason: "Working tree is clean and no tasks in progress",
+  };
+}
+
+// ============================================================================
+// Prompt Builder
+// ============================================================================
+
+/**
+ * Build the prompt for the wrap-up agent.
+ * AC: @ralph-wrap-up-agent-on-loop-exit ac-2, ac-3, ac-4
+ */
+export function buildWrapUpPrompt(context: WrapUpContext): string {
+  const exitReasonDescriptions: Record<ExitReason, string> = {
+    no_tasks: "No automation-eligible tasks available",
+    end_loop_signal: "Agent explicitly requested end of loop",
+    max_iterations: `Reached maximum iterations (${context.maxIterations})`,
+    error: `Error occurred: ${context.errorMessage || "Unknown error"}`,
+    max_failures: "Reached maximum consecutive failures",
+    explicit_tasks_done: "All explicitly scoped tasks completed or blocked",
+  };
+
+  const workingTreeSection = context.workingTree.clean
+    ? "**Working tree is clean.** No uncommitted changes."
+    : `**Uncommitted changes detected:**
+
+Staged (${context.workingTree.staged.length}):
+${context.workingTree.staged.length > 0 ? context.workingTree.staged.map((f) => `  - ${f.path} (${f.status})`).join("\n") : "  (none)"}
+
+Unstaged (${context.workingTree.unstaged.length}):
+${context.workingTree.unstaged.length > 0 ? context.workingTree.unstaged.map((f) => `  - ${f.path} (${f.status})`).join("\n") : "  (none)"}
+
+Untracked (${context.workingTree.untracked.length}):
+${context.workingTree.untracked.length > 0 ? context.workingTree.untracked.map((f) => `  - ${f}`).join("\n") : "  (none)"}`;
+
+  const taskStateSection = `
+**In-progress tasks (${context.inProgressTasks.length}):**
+${context.inProgressTasks.length > 0 ? context.inProgressTasks.map((t) => `  - ${t.ref}: ${t.title}`).join("\n") : "  (none)"}
+
+**Pending review tasks (${context.pendingReviewTasks.length}):**
+${context.pendingReviewTasks.length > 0 ? context.pendingReviewTasks.map((t) => `  - ${t.ref}: ${t.title}`).join("\n") : "  (none)"}
+
+**Recent task refs worked this session:**
+${context.recentTaskRefs.length > 0 ? context.recentTaskRefs.map((r) => `  - ${r}`).join("\n") : "  (none)"}`;
+
+  return `# Ralph Wrap-Up Agent
+
+You are a wrap-up agent spawned at the end of a ralph automation session.
+Your job is to ensure the workspace is in a clean state before the process terminates.
+
+## Exit Information
+
+**Session ID:** \`${context.sessionId}\`
+**Iteration:** ${context.iteration} of ${context.maxIterations}
+**Exit Reason:** ${exitReasonDescriptions[context.exitReason]}
+
+## Working Tree Status
+
+${workingTreeSection}
+
+## Task State
+${taskStateSection}
+
+## Instructions
+
+Your responsibilities are:
+
+### 1. Handle Uncommitted Changes (if any)
+
+For each uncommitted change, determine what to do:
+
+- **If changes relate to a known task** (match file patterns to recent task refs):
+  - Commit them with an appropriate message including the task ref
+  - Example: \`git commit -m "wip: partial work on @task-ref\\n\\nRalph session ended before completion."\`
+
+- **If changes are test files, build artifacts, or generated code:**
+  - Commit them if they look intentional
+  - Or add to .gitignore if they shouldn't be tracked
+
+- **If changes are unclear or potentially destructive:**
+  - Stash them with a descriptive message: \`git stash push -m "ralph-wrapup: [description]"\`
+  - Or flag them for human review by leaving uncommitted but documenting
+
+**CRITICAL:** Do NOT discard any work. Every change must be preserved somehow (commit, stash, or documented).
+
+### 2. Produce Exit Summary
+
+After handling any changes, output a brief summary:
+
+\`\`\`
+=== RALPH SESSION EXIT SUMMARY ===
+Session: ${context.sessionId}
+Exit reason: [reason]
+Changes handled: [what was committed/stashed/flagged]
+Tasks in progress: [list or "none"]
+Tasks pending review: [list or "none"]
+Human attention needed: [yes/no - if yes, explain what needs attention]
+\`\`\`
+
+### 3. Exit
+
+Once cleanup is complete and summary is output, stop. Do not start new work.
+
+## Timeout Warning
+
+You have 2 minutes to complete wrap-up. If you cannot complete in time, prioritize:
+1. Preserving uncommitted changes (stash if can't commit quickly)
+2. Outputting a minimal summary
+
+Do not let wrap-up block shutdown indefinitely.
+`;
+}
+
+// ============================================================================
+// Wrap-Up Runner
+// ============================================================================
+
+/**
+ * Run the wrap-up agent.
+ *
+ * AC: @ralph-wrap-up-agent-on-loop-exit ac-1 (spawn), ac-2 (inspect),
+ *     ac-3 (handle changes), ac-4 (summary), ac-5 (timeout)
+ *
+ * @param adapter - Agent adapter to use for spawning
+ * @param context - Wrap-up context
+ * @param options - Runtime options
+ * @param timeout - Timeout in ms (default: 2 minutes)
+ * @returns Result indicating success/failure/timeout/skipped
+ */
+export async function runWrapUpAgent(
+  adapter: AgentAdapter,
+  context: WrapUpContext,
+  options: WrapUpOptions,
+  timeout: number = DEFAULT_WRAPUP_TIMEOUT,
+): Promise<WrapUpResult> {
+  // Check if wrap-up is needed
+  const { needed, reason } = isWrapUpNeeded(context);
+  if (!needed) {
+    return {
+      success: true,
+      timedOut: false,
+      skipped: true,
+      skipReason: reason,
+    };
+  }
+
+  const prompt = buildWrapUpPrompt(context);
+  let agent: SpawnedAgent | null = null;
+
+  try {
+    // AC: @ralph-wrap-up-agent-on-loop-exit ac-1 - Spawn wrap-up agent
+    agent = await spawnAndInitialize(adapter, {
+      cwd: options.cwd,
+      clientOptions: {
+        clientInfo: {
+          name: "kspec-ralph-wrapup",
+          version: "1.0.0",
+        },
+        methodTimeouts: {
+          "session/prompt": RALPH_PROMPT_TIMEOUT,
+          "session/resume": RALPH_PROMPT_TIMEOUT,
+        },
+      },
+    });
+
+    // Set up streaming output with prefix
+    const translator = createTranslator();
+    const renderer = createPrefixedRenderer(WRAPUP_AGENT_PREFIX);
+
+    agent.client.on("update", (_sid: string, update: SessionUpdate) => {
+      const event = translator.translate(update);
+      if (event) {
+        renderer.render(event);
+      }
+    });
+
+    // Set up tool request handler
+    agent.client.on(
+      "request",
+      (reqId: string | number, method: string, params: unknown) => {
+        options
+          .handleRequest(agent!.client, reqId, method, params)
+          .catch((err) => {
+            agent!.client.respondError(reqId, -32000, err.message);
+          });
+      },
+    );
+
+    // Create ACP session
+    const acpSessionId = await agent.client.newSession({
+      cwd: options.cwd,
+      mcpServers: [],
+    });
+
+    // AC: @ralph-wrap-up-agent-on-loop-exit ac-5 - Timeout handling
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      setTimeout(() => reject(new Error("WRAPUP_TIMEOUT")), timeout);
+    });
+
+    // Send prompt and wait for completion
+    const promptPromise = agent.client.prompt({
+      sessionId: acpSessionId,
+      prompt: [{ type: "text", text: prompt }],
+    });
+
+    // Race between completion and timeout
+    await Promise.race([promptPromise, timeoutPromise]);
+
+    return { success: true, timedOut: false, skipped: false };
+  } catch (err) {
+    const error = err as Error;
+
+    // AC: @ralph-wrap-up-agent-on-loop-exit ac-5 - Timeout detection
+    if (error.message === "WRAPUP_TIMEOUT") {
+      return { success: false, timedOut: true, skipped: false };
+    }
+
+    return { success: false, timedOut: false, skipped: false, error: error.message };
+  } finally {
+    // Always clean up the agent process
+    if (agent) {
+      agent.kill();
+    }
+  }
+}

--- a/src/sessions/types.ts
+++ b/src/sessions/types.ts
@@ -71,6 +71,7 @@ export const EventTypeSchema = z.enum([
   "session.start",
   "session.update",
   "session.end",
+  "session.wrapup",
   "prompt.sent",
   "tool.call",
   "tool.result",

--- a/tests/ralph-wrap-up.test.ts
+++ b/tests/ralph-wrap-up.test.ts
@@ -1,0 +1,474 @@
+/**
+ * Tests for ralph wrap-up agent module.
+ *
+ * AC: @ralph-wrap-up-agent-on-loop-exit
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  buildWrapUpContext,
+  buildWrapUpPrompt,
+  DEFAULT_WRAPUP_TIMEOUT,
+  isWrapUpNeeded,
+  WRAPUP_AGENT_PREFIX,
+  type ExitReason,
+  type WrapUpContext,
+} from '../src/ralph/wrap-up.js';
+import type { GitWorkingTree } from '../src/utils/git.js';
+
+// ─── Helper Functions ─────────────────────────────────────────────────────────
+
+function createCleanWorkingTree(): GitWorkingTree {
+  return {
+    clean: true,
+    staged: [],
+    unstaged: [],
+    untracked: [],
+  };
+}
+
+function createDirtyWorkingTree(): GitWorkingTree {
+  return {
+    clean: false,
+    staged: [{ path: 'src/feature.ts', status: 'modified', staged: true }],
+    unstaged: [{ path: 'tests/feature.test.ts', status: 'modified', staged: false }],
+    untracked: ['temp.log', 'debug.txt'],
+  };
+}
+
+function createWrapUpContext(overrides: Partial<WrapUpContext> = {}): WrapUpContext {
+  return {
+    exitReason: 'no_tasks',
+    sessionId: '01TEST00000000000000000000',
+    iteration: 5,
+    maxIterations: 10,
+    workingTree: createCleanWorkingTree(),
+    inProgressTasks: [],
+    pendingReviewTasks: [],
+    recentTaskRefs: [],
+    ...overrides,
+  };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('wrap-up agent module', () => {
+  describe('constants', () => {
+    // AC: @ralph-wrap-up-agent-on-loop-exit ac-5
+    it('DEFAULT_WRAPUP_TIMEOUT is 2 minutes', () => {
+      expect(DEFAULT_WRAPUP_TIMEOUT).toBe(2 * 60 * 1000);
+    });
+
+    it('WRAPUP_AGENT_PREFIX is [WRAP-UP]', () => {
+      expect(WRAPUP_AGENT_PREFIX).toBe('[WRAP-UP]');
+    });
+  });
+
+  describe('isWrapUpNeeded', () => {
+    // AC: @ralph-wrap-up-agent-on-loop-exit ac-1
+    it('returns needed=true when working tree has uncommitted changes', () => {
+      const context = createWrapUpContext({
+        workingTree: createDirtyWorkingTree(),
+      });
+
+      const result = isWrapUpNeeded(context);
+
+      expect(result.needed).toBe(true);
+      expect(result.reason).toBeUndefined();
+    });
+
+    it('returns needed=true when there are in-progress tasks', () => {
+      const context = createWrapUpContext({
+        inProgressTasks: [{ ref: '@task-1', title: 'Task 1' }],
+      });
+
+      const result = isWrapUpNeeded(context);
+
+      expect(result.needed).toBe(true);
+    });
+
+    it('returns needed=true when exit reason is error AND working tree dirty', () => {
+      const context = createWrapUpContext({
+        exitReason: 'error',
+        errorMessage: 'Something went wrong',
+        workingTree: createDirtyWorkingTree(),
+      });
+
+      const result = isWrapUpNeeded(context);
+
+      expect(result.needed).toBe(true);
+    });
+
+    it('returns needed=false when exit reason is error BUT tree is clean', () => {
+      const context = createWrapUpContext({
+        exitReason: 'error',
+        errorMessage: 'Something went wrong',
+        workingTree: createCleanWorkingTree(),
+        inProgressTasks: [],
+      });
+
+      const result = isWrapUpNeeded(context);
+
+      expect(result.needed).toBe(false);
+    });
+
+    it('returns needed=true when exit reason is max_failures AND in-progress tasks', () => {
+      const context = createWrapUpContext({
+        exitReason: 'max_failures',
+        inProgressTasks: [{ ref: '@task-1', title: 'Unfinished work' }],
+      });
+
+      const result = isWrapUpNeeded(context);
+
+      expect(result.needed).toBe(true);
+    });
+
+    it('returns needed=false when exit reason is max_failures BUT tree clean and no tasks', () => {
+      const context = createWrapUpContext({
+        exitReason: 'max_failures',
+        workingTree: createCleanWorkingTree(),
+        inProgressTasks: [],
+      });
+
+      const result = isWrapUpNeeded(context);
+
+      expect(result.needed).toBe(false);
+    });
+
+    it('returns needed=false with reason when clean exit and clean tree', () => {
+      const context = createWrapUpContext({
+        exitReason: 'no_tasks',
+        workingTree: createCleanWorkingTree(),
+        inProgressTasks: [],
+      });
+
+      const result = isWrapUpNeeded(context);
+
+      expect(result.needed).toBe(false);
+      expect(result.reason).toContain('clean');
+    });
+
+    it('returns needed=false for explicit_tasks_done with clean tree', () => {
+      const context = createWrapUpContext({
+        exitReason: 'explicit_tasks_done',
+        workingTree: createCleanWorkingTree(),
+        inProgressTasks: [],
+      });
+
+      const result = isWrapUpNeeded(context);
+
+      expect(result.needed).toBe(false);
+    });
+  });
+
+  describe('buildWrapUpPrompt', () => {
+    // AC: @ralph-wrap-up-agent-on-loop-exit ac-2
+    it('includes session ID in prompt', () => {
+      const context = createWrapUpContext({
+        sessionId: '01TESTSESSIONID0000000000',
+      });
+
+      const prompt = buildWrapUpPrompt(context);
+
+      expect(prompt).toContain('01TESTSESSIONID0000000000');
+    });
+
+    it('includes iteration info in prompt', () => {
+      const context = createWrapUpContext({
+        iteration: 7,
+        maxIterations: 10,
+      });
+
+      const prompt = buildWrapUpPrompt(context);
+
+      expect(prompt).toContain('7 of 10');
+    });
+
+    it('includes exit reason description for no_tasks', () => {
+      const context = createWrapUpContext({
+        exitReason: 'no_tasks',
+      });
+
+      const prompt = buildWrapUpPrompt(context);
+
+      expect(prompt).toContain('No automation-eligible tasks available');
+    });
+
+    it('includes exit reason description for end_loop_signal', () => {
+      const context = createWrapUpContext({
+        exitReason: 'end_loop_signal',
+      });
+
+      const prompt = buildWrapUpPrompt(context);
+
+      expect(prompt).toContain('Agent explicitly requested end of loop');
+    });
+
+    it('includes exit reason description for max_iterations', () => {
+      const context = createWrapUpContext({
+        exitReason: 'max_iterations',
+        maxIterations: 20,
+      });
+
+      const prompt = buildWrapUpPrompt(context);
+
+      expect(prompt).toContain('Reached maximum iterations (20)');
+    });
+
+    it('includes error message in exit reason description for error', () => {
+      const context = createWrapUpContext({
+        exitReason: 'error',
+        errorMessage: 'Connection timeout',
+      });
+
+      const prompt = buildWrapUpPrompt(context);
+
+      expect(prompt).toContain('Error occurred');
+      expect(prompt).toContain('Connection timeout');
+    });
+
+    it('includes exit reason description for max_failures', () => {
+      const context = createWrapUpContext({
+        exitReason: 'max_failures',
+      });
+
+      const prompt = buildWrapUpPrompt(context);
+
+      expect(prompt).toContain('Reached maximum consecutive failures');
+    });
+
+    it('includes exit reason description for explicit_tasks_done', () => {
+      const context = createWrapUpContext({
+        exitReason: 'explicit_tasks_done',
+      });
+
+      const prompt = buildWrapUpPrompt(context);
+
+      expect(prompt).toContain('All explicitly scoped tasks completed or blocked');
+    });
+
+    // AC: @ralph-wrap-up-agent-on-loop-exit ac-2
+    it('shows clean working tree message when no changes', () => {
+      const context = createWrapUpContext({
+        workingTree: createCleanWorkingTree(),
+      });
+
+      const prompt = buildWrapUpPrompt(context);
+
+      expect(prompt).toContain('Working tree is clean');
+      expect(prompt).toContain('No uncommitted changes');
+    });
+
+    it('lists staged changes when present', () => {
+      const context = createWrapUpContext({
+        workingTree: {
+          clean: false,
+          staged: [
+            { path: 'src/feature.ts', status: 'modified', staged: true },
+            { path: 'src/new.ts', status: 'added', staged: true },
+          ],
+          unstaged: [],
+          untracked: [],
+        },
+      });
+
+      const prompt = buildWrapUpPrompt(context);
+
+      expect(prompt).toContain('Staged (2)');
+      expect(prompt).toContain('src/feature.ts (modified)');
+      expect(prompt).toContain('src/new.ts (added)');
+    });
+
+    it('lists unstaged changes when present', () => {
+      const context = createWrapUpContext({
+        workingTree: {
+          clean: false,
+          staged: [],
+          unstaged: [{ path: 'tests/spec.test.ts', status: 'modified', staged: false }],
+          untracked: [],
+        },
+      });
+
+      const prompt = buildWrapUpPrompt(context);
+
+      expect(prompt).toContain('Unstaged (1)');
+      expect(prompt).toContain('tests/spec.test.ts (modified)');
+    });
+
+    it('lists untracked files when present', () => {
+      const context = createWrapUpContext({
+        workingTree: {
+          clean: false,
+          staged: [],
+          unstaged: [],
+          untracked: ['temp.log', 'debug.txt', '.DS_Store'],
+        },
+      });
+
+      const prompt = buildWrapUpPrompt(context);
+
+      expect(prompt).toContain('Untracked (3)');
+      expect(prompt).toContain('temp.log');
+      expect(prompt).toContain('debug.txt');
+      expect(prompt).toContain('.DS_Store');
+    });
+
+    // AC: @ralph-wrap-up-agent-on-loop-exit ac-4
+    it('lists in-progress tasks', () => {
+      const context = createWrapUpContext({
+        inProgressTasks: [
+          { ref: '@task-feature', title: 'Add new feature' },
+          { ref: '@task-bugfix', title: 'Fix critical bug' },
+        ],
+      });
+
+      const prompt = buildWrapUpPrompt(context);
+
+      expect(prompt).toContain('In-progress tasks (2)');
+      expect(prompt).toContain('@task-feature: Add new feature');
+      expect(prompt).toContain('@task-bugfix: Fix critical bug');
+    });
+
+    it('lists pending review tasks', () => {
+      const context = createWrapUpContext({
+        pendingReviewTasks: [{ ref: '@task-review', title: 'Pending PR merge' }],
+      });
+
+      const prompt = buildWrapUpPrompt(context);
+
+      expect(prompt).toContain('Pending review tasks (1)');
+      expect(prompt).toContain('@task-review: Pending PR merge');
+    });
+
+    it('lists recent task refs', () => {
+      const context = createWrapUpContext({
+        recentTaskRefs: ['@task-1', '@task-2', '@task-3'],
+      });
+
+      const prompt = buildWrapUpPrompt(context);
+
+      expect(prompt).toContain('Recent task refs worked this session');
+      expect(prompt).toContain('@task-1');
+      expect(prompt).toContain('@task-2');
+      expect(prompt).toContain('@task-3');
+    });
+
+    // AC: @ralph-wrap-up-agent-on-loop-exit ac-3
+    it('includes instructions for handling uncommitted changes', () => {
+      const context = createWrapUpContext({
+        workingTree: createDirtyWorkingTree(),
+      });
+
+      const prompt = buildWrapUpPrompt(context);
+
+      expect(prompt).toContain('Handle Uncommitted Changes');
+      expect(prompt).toContain('commit');
+      expect(prompt).toContain('stash');
+      expect(prompt).toContain('CRITICAL');
+      expect(prompt).toContain('Do NOT discard any work');
+    });
+
+    // AC: @ralph-wrap-up-agent-on-loop-exit ac-4
+    it('includes instructions for exit summary', () => {
+      const context = createWrapUpContext();
+
+      const prompt = buildWrapUpPrompt(context);
+
+      expect(prompt).toContain('Exit Summary');
+      expect(prompt).toContain('RALPH SESSION EXIT SUMMARY');
+      expect(prompt).toContain('Changes handled');
+      expect(prompt).toContain('Human attention needed');
+    });
+
+    // AC: @ralph-wrap-up-agent-on-loop-exit ac-5
+    it('includes timeout warning in prompt', () => {
+      const context = createWrapUpContext();
+
+      const prompt = buildWrapUpPrompt(context);
+
+      expect(prompt).toContain('2 minutes');
+      expect(prompt).toContain('Timeout Warning');
+      expect(prompt).toContain('prioritize');
+    });
+
+    it('instructs to exit after cleanup', () => {
+      const context = createWrapUpContext();
+
+      const prompt = buildWrapUpPrompt(context);
+
+      expect(prompt).toContain('Exit');
+      expect(prompt).toContain('Do not start new work');
+    });
+  });
+
+  describe('buildWrapUpContext', () => {
+    it('builds context with all required fields', () => {
+      // Note: buildWrapUpContext calls getWorkingTreeStatus internally,
+      // so we test the structure of the returned context
+      const context = buildWrapUpContext(
+        'no_tasks',
+        '01TESTSESSION',
+        5,
+        10,
+        [{ ref: '@task-1', title: 'Task 1' }],
+        [{ ref: '@task-2', title: 'Task 2' }],
+        ['@task-1', '@task-2'],
+        process.cwd(),
+        undefined
+      );
+
+      expect(context.exitReason).toBe('no_tasks');
+      expect(context.sessionId).toBe('01TESTSESSION');
+      expect(context.iteration).toBe(5);
+      expect(context.maxIterations).toBe(10);
+      expect(context.inProgressTasks).toHaveLength(1);
+      expect(context.pendingReviewTasks).toHaveLength(1);
+      expect(context.recentTaskRefs).toHaveLength(2);
+      expect(context.workingTree).toBeDefined();
+      expect(context.errorMessage).toBeUndefined();
+    });
+
+    it('includes error message when provided', () => {
+      const context = buildWrapUpContext(
+        'error',
+        '01TESTSESSION',
+        3,
+        10,
+        [],
+        [],
+        [],
+        process.cwd(),
+        'Connection failed'
+      );
+
+      expect(context.exitReason).toBe('error');
+      expect(context.errorMessage).toBe('Connection failed');
+    });
+  });
+
+  describe('ExitReason type coverage', () => {
+    // Verify all exit reasons are handled in prompt
+    const exitReasons: ExitReason[] = [
+      'no_tasks',
+      'end_loop_signal',
+      'max_iterations',
+      'error',
+      'max_failures',
+      'explicit_tasks_done',
+    ];
+
+    for (const reason of exitReasons) {
+      it(`handles exit reason: ${reason}`, () => {
+        const context = createWrapUpContext({
+          exitReason: reason,
+          errorMessage: reason === 'error' ? 'Test error' : undefined,
+        });
+
+        const prompt = buildWrapUpPrompt(context);
+
+        // Each exit reason should have a description in the prompt
+        expect(prompt).toContain('Exit Reason');
+        expect(prompt.length).toBeGreaterThan(500); // Ensure substantial prompt
+      });
+    }
+  });
+});

--- a/tests/ralph.test.ts
+++ b/tests/ralph.test.ts
@@ -255,6 +255,7 @@ describe('ralph command', () => {
   });
 
   // AC: @cli-ralph ac-8 - Consecutive failure guard
+  // Timeout increased because wrap-up agent runs on max_failures exit
   it('exits after max consecutive failures', async () => {
     // Always fail
     const result = runRalph('--max-loops 10 --max-retries 0 --max-failures 2', tempDir, {
@@ -266,7 +267,7 @@ describe('ralph command', () => {
     expect(result.output).toContain('Reached 2 consecutive failures');
     // Should not continue to iteration 3
     expect(result.output).not.toContain('Iteration 3/10');
-  });
+  }, 30000);
 
   it('resets failure count on success', async () => {
     // For simplicity, just verify a success resets the pattern


### PR DESCRIPTION
## Summary
- Adds wrap-up subagent that runs when ralph loop exits for any reason
- Inspects working tree for uncommitted changes and handles them (commit, stash, or flag)
- Produces exit summary with cleanup results and task states
- 2-minute timeout prevents blocking shutdown indefinitely
- Skips wrap-up when working tree clean and no in-progress tasks

## Test plan
- [ ] Run `npm test -- tests/ralph-wrap-up.test.ts` - 37 tests covering all 5 ACs
- [ ] Verify `kspec ralph --dry-run` shows wrap-up will run
- [ ] Test with uncommitted changes to verify wrap-up agent handles them
- [ ] Test max_failures exit with clean tree - wrap-up should skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)