### PR TITLE
feat: add Skill as 5th meta item type

### DIFF
--- a/src/parser/meta.ts
+++ b/src/parser/meta.ts
@@ -25,6 +25,8 @@ import {
   type ObservationType,
   type SessionContext,
   SessionContextSchema,
+  type Skill,
+  SkillSchema,
   type Workflow,
   type WorkflowRun,
   type WorkflowRunsFile,
@@ -68,13 +70,21 @@ export interface LoadedObservation extends Observation {
 }
 
 /**
+ * Loaded skill with runtime metadata
+ */
+export interface LoadedSkill extends Skill {
+  _sourceFile?: string;
+}
+
+/**
  * Any loaded meta item
  */
 export type LoadedMetaItem =
   | LoadedAgent
   | LoadedWorkflow
   | LoadedConvention
-  | LoadedObservation;
+  | LoadedObservation
+  | LoadedSkill;
 
 /**
  * Meta context containing all loaded meta items
@@ -86,6 +96,7 @@ export interface MetaContext {
   workflows: LoadedWorkflow[];
   conventions: LoadedConvention[];
   observations: LoadedObservation[];
+  skills: LoadedSkill[];
 }
 
 /**
@@ -170,17 +181,20 @@ async function loadMetaFile(filePath: string): Promise<{
   workflows: LoadedWorkflow[];
   conventions: LoadedConvention[];
   observations: LoadedObservation[];
+  skills: LoadedSkill[];
 }> {
   const result: {
     agents: LoadedAgent[];
     workflows: LoadedWorkflow[];
     conventions: LoadedConvention[];
     observations: LoadedObservation[];
+    skills: LoadedSkill[];
   } = {
     agents: [],
     workflows: [],
     conventions: [],
     observations: [],
+    skills: [],
   };
 
   try {
@@ -230,6 +244,17 @@ async function loadMetaFile(filePath: string): Promise<{
         }
       }
     }
+
+    // Parse skills
+    // AC: @skill-meta-type ac-4 - skills loaded with _sourceFile set
+    if (Array.isArray(obj.skills)) {
+      for (const skill of obj.skills) {
+        const parsed = SkillSchema.safeParse(skill);
+        if (parsed.success) {
+          result.skills.push({ ...parsed.data, _sourceFile: filePath });
+        }
+      }
+    }
   } catch {
     // File doesn't exist or parse error
   }
@@ -240,6 +265,7 @@ async function loadMetaFile(filePath: string): Promise<{
 /**
  * Load the meta context from a kspec context.
  * Loads meta manifest and follows includes.
+ * AC: @skill-meta-type ac-4 - MetaContext.skills contains LoadedSkill objects with _sourceFile set
  */
 export async function loadMetaContext(ctx: KspecContext): Promise<MetaContext> {
   const result: MetaContext = {
@@ -249,6 +275,7 @@ export async function loadMetaContext(ctx: KspecContext): Promise<MetaContext> {
     workflows: [],
     conventions: [],
     observations: [],
+    skills: [],
   };
 
   const manifestPath = await findMetaManifest(ctx.specDir);
@@ -268,6 +295,7 @@ export async function loadMetaContext(ctx: KspecContext): Promise<MetaContext> {
       result.workflows.push(...items.workflows);
       result.conventions.push(...items.conventions);
       result.observations.push(...items.observations);
+      result.skills.push(...items.skills);
       return result;
     }
 
@@ -279,6 +307,7 @@ export async function loadMetaContext(ctx: KspecContext): Promise<MetaContext> {
     result.workflows.push(...manifestItems.workflows);
     result.conventions.push(...manifestItems.conventions);
     result.observations.push(...manifestItems.observations);
+    result.skills.push(...manifestItems.skills);
 
     // Process includes
     const includes = parsed.data.includes || [];
@@ -293,6 +322,7 @@ export async function loadMetaContext(ctx: KspecContext): Promise<MetaContext> {
         result.workflows.push(...items.workflows);
         result.conventions.push(...items.conventions);
         result.observations.push(...items.observations);
+        result.skills.push(...items.skills);
       }
     }
   } catch {
@@ -311,6 +341,7 @@ export function getMetaStats(meta: MetaContext): {
   conventions: number;
   observations: number;
   unresolvedObservations: number;
+  skills: number;
 } {
   return {
     agents: meta.agents.length,
@@ -318,11 +349,14 @@ export function getMetaStats(meta: MetaContext): {
     conventions: meta.conventions.length,
     observations: meta.observations.length,
     unresolvedObservations: meta.observations.filter((o) => !o.resolved).length,
+    skills: meta.skills.length,
   };
 }
 
 /**
  * Find a meta item by reference (ULID, short ULID, or id)
+ * AC: @skill-meta-type ac-5 - skills returned by semantic id lookup
+ * AC: @skill-meta-type ac-6 - skills returned by ULID prefix lookup
  */
 export function findMetaItemByRef(
   meta: MetaContext,
@@ -336,6 +370,7 @@ export function findMetaItemByRef(
     ...meta.workflows,
     ...meta.conventions,
     ...meta.observations,
+    ...meta.skills,
   ];
 
   for (const item of allItems) {
@@ -346,7 +381,7 @@ export function findMetaItemByRef(
     if (item._ulid.toLowerCase().startsWith(cleanRef.toLowerCase()))
       return item;
 
-    // Match by id (for agents and workflows)
+    // Match by id (for agents, workflows, and skills)
     if ("id" in item && item.id === cleanRef) return item;
 
     // Match by domain (for conventions)
@@ -360,7 +395,9 @@ export function findMetaItemByRef(
  * Determine if an item is a meta item type
  */
 export function isMetaItemType(type: string): boolean {
-  return ["agent", "workflow", "convention", "observation"].includes(type);
+  return ["agent", "workflow", "convention", "observation", "skill"].includes(
+    type,
+  );
 }
 
 // ============================================================
@@ -430,6 +467,7 @@ export async function saveObservation(
     workflows: [],
     conventions: [],
     observations: [],
+    skills: [],
     includes: [],
   };
 
@@ -489,9 +527,34 @@ export async function deleteObservation(
   }
 }
 
+/**
+ * Get the path for skill content file.
+ * Skills are stored in .kspec/skills/<id>/SKILL.md
+ */
+export function getSkillContentPath(ctx: KspecContext, skillId: string): string {
+  return path.join(ctx.specDir, "skills", skillId, "SKILL.md");
+}
+
+/**
+ * Load skill content from the SKILL.md file.
+ * AC: @skill-meta-type ac-3 - loadSkillContent returns full markdown content
+ */
+export async function loadSkillContent(
+  ctx: KspecContext,
+  skill: LoadedSkill,
+): Promise<string | null> {
+  const contentPath = getSkillContentPath(ctx, skill.id);
+  try {
+    const content = await fs.readFile(contentPath, "utf-8");
+    return content;
+  } catch {
+    return null;
+  }
+}
+
 // Re-export the getMetaItemType function
 export { getMetaItemType };
-export type { Agent, Workflow, Convention, Observation, MetaItem };
+export type { Agent, Workflow, Convention, Observation, Skill, MetaItem };
 
 // ============================================================
 // GENERIC META ITEM CRUD
@@ -518,6 +581,7 @@ export async function saveMetaItem(
     workflows: [],
     conventions: [],
     observations: [],
+    skills: [],
     includes: [],
   };
 

--- a/src/schema/meta.ts
+++ b/src/schema/meta.ts
@@ -150,6 +150,25 @@ export const ObservationSchema = z.object({
 });
 
 /**
+ * Skill origin - where the skill comes from
+ */
+export const SkillOriginSchema = z.enum(["core", "project", "local"]);
+
+/**
+ * Skill definition - reusable agent capabilities stored in files
+ * Content is stored in .kspec/skills/<id>/SKILL.md
+ */
+export const SkillSchema = z.object({
+  _ulid: MetaUlidSchema,
+  id: z.string().min(1, "Skill ID is required"),
+  name: z.string().min(1, "Skill name is required"),
+  description: z.string().optional(),
+  origin: SkillOriginSchema,
+  version: z.string().optional(),
+  tags: z.array(z.string()).default([]),
+});
+
+/**
  * Session context schema - ephemeral session state
  */
 export const SessionContextSchema = z.object({
@@ -237,6 +256,7 @@ export const MetaManifestSchema = z.object({
   workflows: z.array(WorkflowSchema).default([]),
   conventions: z.array(ConventionSchema).default([]),
   observations: z.array(ObservationSchema).default([]),
+  skills: z.array(SkillSchema).default([]),
   includes: z.array(z.string()).default([]),
 });
 
@@ -254,6 +274,8 @@ export type ConventionValidation = z.infer<typeof ConventionValidationSchema>;
 export type Convention = z.infer<typeof ConventionSchema>;
 export type ObservationType = z.infer<typeof ObservationTypeSchema>;
 export type Observation = z.infer<typeof ObservationSchema>;
+export type SkillOrigin = z.infer<typeof SkillOriginSchema>;
+export type Skill = z.infer<typeof SkillSchema>;
 export type SessionContext = z.infer<typeof SessionContextSchema>;
 export type MetaManifest = z.infer<typeof MetaManifestSchema>;
 export type StepResultStatus = z.infer<typeof StepResultStatusSchema>;
@@ -266,14 +288,16 @@ export type WorkflowRunsFile = z.infer<typeof WorkflowRunsFileSchema>;
 /**
  * Meta item type - union of all meta item types
  */
-export type MetaItem = Agent | Workflow | Convention | Observation;
+export type MetaItem = Agent | Workflow | Convention | Observation | Skill;
 
 /**
  * Determine the type of a meta item
+ * AC: @skill-meta-type ac-7 - skills discriminated by the origin field (unique to skills)
  */
 export function getMetaItemType(
   item: MetaItem,
-): "agent" | "workflow" | "convention" | "observation" {
+): "agent" | "workflow" | "convention" | "observation" | "skill" {
+  if ("origin" in item) return "skill";
   if ("capabilities" in item) return "agent";
   if ("trigger" in item) return "workflow";
   if ("domain" in item) return "convention";

--- a/tests/skill-meta-type.test.ts
+++ b/tests/skill-meta-type.test.ts
@@ -1,0 +1,439 @@
+/**
+ * Tests for Skill Meta Type
+ * AC: @skill-meta-type ac-1 through ac-7
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { stringify as yamlStringify } from 'yaml';
+import { createTempDir, cleanupTempDir, testUlid, initGitRepo } from './helpers/cli';
+import {
+  loadMetaContext,
+  loadSkillContent,
+  findMetaItemByRef,
+  getSkillContentPath,
+} from '../src/parser/meta';
+import { getMetaItemType, MetaManifestSchema, SkillSchema } from '../src/schema/meta';
+import type { KspecContext } from '../src/parser/yaml';
+
+describe('Skill Meta Type', () => {
+  let tempDir: string;
+  let ctx: KspecContext;
+
+  beforeEach(async () => {
+    tempDir = await createTempDir();
+    await initGitRepo(tempDir);
+    ctx = {
+      specDir: tempDir,
+      manifestPath: path.join(tempDir, 'kynetic.yaml'),
+      rootPath: tempDir,
+    };
+
+    // Create minimal manifest
+    await fs.writeFile(
+      path.join(tempDir, 'kynetic.yaml'),
+      yamlStringify({ kynetic: '1.0' }),
+    );
+  });
+
+  afterEach(async () => {
+    await cleanupTempDir(tempDir);
+  });
+
+  describe('SkillSchema validation', () => {
+    // AC: @skill-meta-type ac-1
+    it('should validate skill entries via MetaManifestSchema', () => {
+      const skillUlid = testUlid('SKTEST');
+      const manifest = {
+        kynetic_meta: '1.0',
+        skills: [
+          {
+            _ulid: skillUlid,
+            id: 'task-work',
+            name: 'Task Work',
+            description: 'Work on kspec tasks',
+            origin: 'core',
+            version: '0.2.0',
+            tags: ['workflow'],
+          },
+        ],
+      };
+
+      const result = MetaManifestSchema.safeParse(manifest);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.skills).toHaveLength(1);
+        expect(result.data.skills[0].id).toBe('task-work');
+        expect(result.data.skills[0].origin).toBe('core');
+      }
+    });
+
+    // AC: @skill-meta-type ac-2
+    it('should validate skill with origin core and version', () => {
+      const skillUlid = testUlid('SKCORE');
+      const skill = {
+        _ulid: skillUlid,
+        id: 'pr-review',
+        name: 'PR Review',
+        origin: 'core',
+        version: '0.2.0',
+      };
+
+      const result = SkillSchema.safeParse(skill);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.origin).toBe('core');
+        expect(result.data.version).toBe('0.2.0');
+      }
+    });
+
+    it('should accept origin values: core, project, local', () => {
+      const baseSkill = {
+        _ulid: testUlid('SKORIG'),
+        id: 'test-skill',
+        name: 'Test Skill',
+      };
+
+      for (const origin of ['core', 'project', 'local']) {
+        const result = SkillSchema.safeParse({ ...baseSkill, origin, _ulid: testUlid('SK' + origin.toUpperCase().slice(0, 3)) });
+        expect(result.success).toBe(true);
+        if (result.success) {
+          expect(result.data.origin).toBe(origin);
+        }
+      }
+    });
+
+    it('should reject invalid origin values', () => {
+      const skill = {
+        _ulid: testUlid('SKBAD'),
+        id: 'bad-skill',
+        name: 'Bad Skill',
+        origin: 'invalid',
+      };
+
+      const result = SkillSchema.safeParse(skill);
+      expect(result.success).toBe(false);
+    });
+
+    it('should require id and name fields', () => {
+      const skillNoId = {
+        _ulid: testUlid('SKNOID'),
+        name: 'No ID Skill',
+        origin: 'core',
+      };
+
+      const skillNoName = {
+        _ulid: testUlid('SKNONA'),
+        id: 'no-name',
+        origin: 'core',
+      };
+
+      expect(SkillSchema.safeParse(skillNoId).success).toBe(false);
+      expect(SkillSchema.safeParse(skillNoName).success).toBe(false);
+    });
+  });
+
+  describe('loadSkillContent', () => {
+    // AC: @skill-meta-type ac-3
+    it('should return full markdown content of SKILL.md', async () => {
+      const skillId = 'my-skill';
+      const skillUlid = testUlid('SKLCNT');
+
+      // Create skill directory and SKILL.md file
+      const skillDir = path.join(tempDir, 'skills', skillId);
+      await fs.mkdir(skillDir, { recursive: true });
+
+      const skillContent = `# My Skill
+
+This is the skill content.
+
+## Usage
+
+Some usage instructions.
+`;
+      await fs.writeFile(path.join(skillDir, 'SKILL.md'), skillContent);
+
+      const skill = {
+        _ulid: skillUlid,
+        id: skillId,
+        name: 'My Skill',
+        origin: 'core' as const,
+        tags: [],
+      };
+
+      const content = await loadSkillContent(ctx, skill);
+      expect(content).toBe(skillContent);
+    });
+
+    it('should return null when SKILL.md does not exist', async () => {
+      const skill = {
+        _ulid: testUlid('SKNONE'),
+        id: 'nonexistent-skill',
+        name: 'Nonexistent Skill',
+        origin: 'core' as const,
+        tags: [],
+      };
+
+      const content = await loadSkillContent(ctx, skill);
+      expect(content).toBeNull();
+    });
+
+    it('should use correct path for skill content', () => {
+      const skillPath = getSkillContentPath(ctx, 'test-skill');
+      expect(skillPath).toBe(path.join(tempDir, 'skills', 'test-skill', 'SKILL.md'));
+    });
+  });
+
+  describe('loadMetaContext with skills', () => {
+    // AC: @skill-meta-type ac-4
+    it('should load skills into MetaContext with _sourceFile set', async () => {
+      const skill1Ulid = testUlid('SK001');
+      const skill2Ulid = testUlid('SK002');
+      const skill3Ulid = testUlid('SK003');
+
+      const metaManifest = {
+        kynetic_meta: '1.0',
+        skills: [
+          {
+            _ulid: skill1Ulid,
+            id: 'skill-one',
+            name: 'Skill One',
+            origin: 'core',
+            version: '0.1.0',
+          },
+          {
+            _ulid: skill2Ulid,
+            id: 'skill-two',
+            name: 'Skill Two',
+            origin: 'project',
+          },
+          {
+            _ulid: skill3Ulid,
+            id: 'skill-three',
+            name: 'Skill Three',
+            origin: 'local',
+          },
+        ],
+      };
+
+      await fs.writeFile(
+        path.join(tempDir, 'kynetic.meta.yaml'),
+        yamlStringify(metaManifest),
+      );
+
+      const meta = await loadMetaContext(ctx);
+      expect(meta.skills).toHaveLength(3);
+
+      // Verify _sourceFile is set for all skills
+      for (const skill of meta.skills) {
+        expect(skill._sourceFile).toBe(path.join(tempDir, 'kynetic.meta.yaml'));
+      }
+
+      // Verify skill data
+      const skillOne = meta.skills.find(s => s.id === 'skill-one');
+      expect(skillOne).toBeDefined();
+      expect(skillOne?.origin).toBe('core');
+      expect(skillOne?.version).toBe('0.1.0');
+    });
+
+    it('should return empty skills array when no skills defined', async () => {
+      const metaManifest = {
+        kynetic_meta: '1.0',
+        agents: [],
+      };
+
+      await fs.writeFile(
+        path.join(tempDir, 'kynetic.meta.yaml'),
+        yamlStringify(metaManifest),
+      );
+
+      const meta = await loadMetaContext(ctx);
+      expect(meta.skills).toEqual([]);
+    });
+  });
+
+  describe('findMetaItemByRef for skills', () => {
+    // AC: @skill-meta-type ac-5
+    it('should return skill by semantic id lookup', async () => {
+      const skillUlid = testUlid('SKTW01');
+      const metaManifest = {
+        kynetic_meta: '1.0',
+        skills: [
+          {
+            _ulid: skillUlid,
+            id: 'task-work',
+            name: 'Task Work',
+            origin: 'core',
+          },
+        ],
+      };
+
+      await fs.writeFile(
+        path.join(tempDir, 'kynetic.meta.yaml'),
+        yamlStringify(metaManifest),
+      );
+
+      const meta = await loadMetaContext(ctx);
+      const found = findMetaItemByRef(meta, 'task-work');
+      expect(found).toBeDefined();
+      expect('id' in found! && found.id).toBe('task-work');
+      expect('origin' in found! && found.origin).toBe('core');
+    });
+
+    // AC: @skill-meta-type ac-6
+    it('should return skill by ULID prefix lookup', async () => {
+      const skillUlid = testUlid('SKTW02');
+      const metaManifest = {
+        kynetic_meta: '1.0',
+        skills: [
+          {
+            _ulid: skillUlid,
+            id: 'task-work',
+            name: 'Task Work',
+            origin: 'core',
+          },
+        ],
+      };
+
+      await fs.writeFile(
+        path.join(tempDir, 'kynetic.meta.yaml'),
+        yamlStringify(metaManifest),
+      );
+
+      const meta = await loadMetaContext(ctx);
+      // Use first 8 chars of the generated ULID as prefix
+      const found = findMetaItemByRef(meta, skillUlid.slice(0, 8));
+      expect(found).toBeDefined();
+      expect('id' in found! && found.id).toBe('task-work');
+    });
+
+    it('should return skill by full ULID', async () => {
+      const skillUlid = testUlid('SKTW03');
+      const metaManifest = {
+        kynetic_meta: '1.0',
+        skills: [
+          {
+            _ulid: skillUlid,
+            id: 'task-work',
+            name: 'Task Work',
+            origin: 'core',
+          },
+        ],
+      };
+
+      await fs.writeFile(
+        path.join(tempDir, 'kynetic.meta.yaml'),
+        yamlStringify(metaManifest),
+      );
+
+      const meta = await loadMetaContext(ctx);
+      const found = findMetaItemByRef(meta, skillUlid);
+      expect(found).toBeDefined();
+      expect('id' in found! && found.id).toBe('task-work');
+    });
+
+    it('should return skill with @ prefix', async () => {
+      const skillUlid = testUlid('SKTW04');
+      const metaManifest = {
+        kynetic_meta: '1.0',
+        skills: [
+          {
+            _ulid: skillUlid,
+            id: 'task-work',
+            name: 'Task Work',
+            origin: 'core',
+          },
+        ],
+      };
+
+      await fs.writeFile(
+        path.join(tempDir, 'kynetic.meta.yaml'),
+        yamlStringify(metaManifest),
+      );
+
+      const meta = await loadMetaContext(ctx);
+      const found = findMetaItemByRef(meta, '@task-work');
+      expect(found).toBeDefined();
+      expect('id' in found! && found.id).toBe('task-work');
+    });
+
+    it('should return undefined for non-existent ref', async () => {
+      const metaManifest = {
+        kynetic_meta: '1.0',
+        skills: [],
+      };
+
+      await fs.writeFile(
+        path.join(tempDir, 'kynetic.meta.yaml'),
+        yamlStringify(metaManifest),
+      );
+
+      const meta = await loadMetaContext(ctx);
+      const found = findMetaItemByRef(meta, 'nonexistent');
+      expect(found).toBeUndefined();
+    });
+  });
+
+  describe('getMetaItemType for skills', () => {
+    // AC: @skill-meta-type ac-7
+    it('should return skill for item with origin field', () => {
+      const skill = {
+        _ulid: testUlid('SKTYPE'),
+        id: 'test-skill',
+        name: 'Test Skill',
+        origin: 'core' as const,
+        tags: [],
+      };
+
+      const itemType = getMetaItemType(skill);
+      expect(itemType).toBe('skill');
+    });
+
+    it('should correctly discriminate skill from other meta types', () => {
+      const agent = {
+        _ulid: testUlid('AGTYPE'),
+        id: 'test-agent',
+        name: 'Test Agent',
+        capabilities: [],
+        tools: [],
+        conventions: [],
+      };
+
+      const workflow = {
+        _ulid: testUlid('WFTYPE'),
+        id: 'test-workflow',
+        trigger: 'on command',
+        steps: [],
+      };
+
+      const convention = {
+        _ulid: testUlid('CVTYPE'),
+        domain: 'test-convention',
+        rules: [],
+        examples: [],
+      };
+
+      const observation = {
+        _ulid: testUlid('OBTYPE'),
+        type: 'friction' as const,
+        content: 'Test observation',
+        created_at: new Date().toISOString(),
+        resolved: false,
+      };
+
+      const skill = {
+        _ulid: testUlid('SKTYPE'),
+        id: 'test-skill',
+        name: 'Test Skill',
+        origin: 'core' as const,
+        tags: [],
+      };
+
+      expect(getMetaItemType(agent)).toBe('agent');
+      expect(getMetaItemType(workflow)).toBe('workflow');
+      expect(getMetaItemType(convention)).toBe('convention');
+      expect(getMetaItemType(observation)).toBe('observation');
+      expect(getMetaItemType(skill)).toBe('skill');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements skill metadata as a first-class meta item type in kspec:

- Added `SkillSchema` with id, name, description, origin (core/project/local), version, tags
- Added `skills` array to `MetaManifestSchema`
- Updated `MetaContext` to include loaded skills with `_sourceFile` metadata
- Implemented `loadSkillContent()` to read skill content from `.kspec/skills/<id>/SKILL.md`
- Updated `findMetaItemByRef()` to include skills in search (by id, ULID, or ULID prefix)
- Updated `getMetaItemType()` to discriminate skills by the `origin` field (unique to skills)
- Updated `isMetaItemType()` and `getMetaStats()` to include skills

## Test plan

- [x] 17 tests covering all 7 acceptance criteria
- [x] Build passes with no type errors
- [x] Full test suite passes (except unrelated daemon executable test)

Task: @implement-skill-meta-type
Spec: @skill-meta-type

🤖 Generated with [Claude Code](https://claude.ai/code)