### PR TITLE
feat: add kebab-case validation and platforms default to SkillSchema

### DIFF
--- a/src/schema/meta.ts
+++ b/src/schema/meta.ts
@@ -155,16 +155,29 @@ export const ObservationSchema = z.object({
 export const SkillOriginSchema = z.enum(["core", "project", "local"]);
 
 /**
+ * Kebab-case regex for skill IDs - lowercase letters, numbers, and hyphens only
+ * Must start with a letter and not end with a hyphen
+ */
+const KEBAB_CASE_REGEX = /^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/;
+
+/**
  * Skill definition - reusable agent capabilities stored in files
  * Content is stored in .kspec/skills/<id>/SKILL.md
  */
 export const SkillSchema = z.object({
   _ulid: MetaUlidSchema,
-  id: z.string().min(1, "Skill ID is required"),
+  id: z
+    .string({ required_error: "Skill ID is required" })
+    .regex(
+      KEBAB_CASE_REGEX,
+      "Skill ID must be in kebab-case format (lowercase letters, numbers, and hyphens)",
+    ),
   name: z.string().min(1, "Skill name is required"),
   description: z.string().optional(),
   origin: SkillOriginSchema,
   version: z.string().optional(),
+  platforms: z.array(z.string()).default(["claude-code"]),
+  depends_on: z.array(RefSchema).default([]),
   tags: z.array(z.string()).default([]),
 });
 

--- a/tests/skill-schema.test.ts
+++ b/tests/skill-schema.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Tests for Skill Schema Definition
+ * AC: @skill-schema ac-1 through ac-3
+ */
+import { describe, it, expect } from 'vitest';
+import { testUlid } from './helpers/cli';
+import { SkillSchema } from '../src/schema/meta';
+
+describe('Skill Schema Definition', () => {
+  describe('id validation', () => {
+    // AC: @skill-schema ac-1
+    it('should reject id with uppercase characters', () => {
+      const skill = {
+        _ulid: testUlid('SKUPPR'),
+        id: 'TaskWork', // uppercase
+        name: 'Task Work',
+        origin: 'core',
+      };
+
+      const result = SkillSchema.safeParse(skill);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const idError = result.error.issues.find(
+          (issue) => issue.path.includes('id'),
+        );
+        expect(idError).toBeDefined();
+        expect(idError?.message).toContain('kebab-case');
+      }
+    });
+
+    // AC: @skill-schema ac-1
+    it('should reject id with special characters', () => {
+      const skill = {
+        _ulid: testUlid('SKSPEC'),
+        id: 'task_work', // underscore
+        name: 'Task Work',
+        origin: 'core',
+      };
+
+      const result = SkillSchema.safeParse(skill);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const idError = result.error.issues.find(
+          (issue) => issue.path.includes('id'),
+        );
+        expect(idError).toBeDefined();
+        expect(idError?.message).toContain('kebab-case');
+      }
+    });
+
+    // AC: @skill-schema ac-1
+    it('should reject id starting with number', () => {
+      const skill = {
+        _ulid: testUlid('SKNUM1'),
+        id: '123-task',
+        name: 'Task Work',
+        origin: 'core',
+      };
+
+      const result = SkillSchema.safeParse(skill);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const idError = result.error.issues.find(
+          (issue) => issue.path.includes('id'),
+        );
+        expect(idError).toBeDefined();
+        expect(idError?.message).toContain('kebab-case');
+      }
+    });
+
+    // AC: @skill-schema ac-1
+    it('should accept valid kebab-case ids', () => {
+      const validIds = ['task-work', 'pr-review', 'e2e', 'my-skill-v2'];
+
+      for (const id of validIds) {
+        const skill = {
+          _ulid: testUlid('SKVAL'),
+          id,
+          name: 'Test Skill',
+          origin: 'core',
+        };
+
+        const result = SkillSchema.safeParse(skill);
+        expect(result.success).toBe(true);
+      }
+    });
+
+    // AC: @skill-schema ac-2
+    it('should reject missing id field', () => {
+      const skill = {
+        _ulid: testUlid('SKNOID'),
+        name: 'No ID Skill',
+        origin: 'core',
+      };
+
+      const result = SkillSchema.safeParse(skill);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const idError = result.error.issues.find(
+          (issue) => issue.path.includes('id'),
+        );
+        expect(idError).toBeDefined();
+        // Check for required field error
+        expect(idError?.code === 'invalid_type' || idError?.message?.toLowerCase().includes('required')).toBe(true);
+      }
+    });
+  });
+
+  describe('platforms default', () => {
+    // AC: @skill-schema ac-3
+    it('should default platforms to ["claude-code"] when not specified', () => {
+      const skill = {
+        _ulid: testUlid('SKPLAT'),
+        id: 'test-skill',
+        name: 'Test Skill',
+        origin: 'core',
+      };
+
+      const result = SkillSchema.safeParse(skill);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.platforms).toEqual(['claude-code']);
+      }
+    });
+
+    // AC: @skill-schema ac-3
+    it('should preserve custom platforms when specified', () => {
+      const skill = {
+        _ulid: testUlid('SKCUST'),
+        id: 'multi-platform-skill',
+        name: 'Multi-Platform Skill',
+        origin: 'core',
+        platforms: ['claude-code', 'cursor', 'windsurf'],
+      };
+
+      const result = SkillSchema.safeParse(skill);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.platforms).toEqual(['claude-code', 'cursor', 'windsurf']);
+      }
+    });
+  });
+
+  describe('other fields', () => {
+    it('should default depends_on to empty array', () => {
+      const skill = {
+        _ulid: testUlid('SKDEPS'),
+        id: 'test-skill',
+        name: 'Test Skill',
+        origin: 'core',
+      };
+
+      const result = SkillSchema.safeParse(skill);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.depends_on).toEqual([]);
+      }
+    });
+
+    it('should accept depends_on refs', () => {
+      const skill = {
+        _ulid: testUlid('SKDEP2'),
+        id: 'test-skill',
+        name: 'Test Skill',
+        origin: 'core',
+        depends_on: ['@other-skill', '@another'],
+      };
+
+      const result = SkillSchema.safeParse(skill);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.depends_on).toEqual(['@other-skill', '@another']);
+      }
+    });
+
+    it('should default tags to empty array', () => {
+      const skill = {
+        _ulid: testUlid('SKTAGS'),
+        id: 'test-skill',
+        name: 'Test Skill',
+        origin: 'core',
+      };
+
+      const result = SkillSchema.safeParse(skill);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.tags).toEqual([]);
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add kebab-case regex validation for skill `id` field (must start with letter, only lowercase + numbers + hyphens)
- Add `platforms` field with default `['claude-code']`
- Add `depends_on` field for skill dependencies (RefSchema array)
- Add 10 tests covering all 3 acceptance criteria

## Test plan
- [x] Tests pass for invalid IDs (uppercase, special chars, starts with number)
- [x] Tests pass for valid kebab-case IDs
- [x] Tests pass for missing `id` field (required error)
- [x] Tests pass for platforms defaulting to `['claude-code']`
- [x] Tests pass for custom platforms preservation
- [x] Tests pass for depends_on default and custom values

Task: @implement-skill-schema-definition
Spec: @skill-schema

🤖 Generated with [Claude Code](https://claude.ai/code)