### PR TITLE
feat: add skill validation for kspec

### DIFF
--- a/src/parser/validate.ts
+++ b/src/parser/validate.ts
@@ -12,6 +12,7 @@ import {
   ManifestSchema,
   MetaManifestSchema,
   ObservationSchema,
+  SkillSchema,
   SpecItemSchema,
   TaskSchema,
   TasksFileSchema,
@@ -113,6 +114,7 @@ export interface ValidationResult {
     workflows: number;
     conventions: number;
     observations: number;
+    skills: number;
   };
 }
 
@@ -431,6 +433,44 @@ async function validateMetaManifestFile(
             errors.push({
               file: filePath,
               path: `observations[${i}]._ulid`,
+              message: "Invalid ULID format (expected 26 characters)",
+            });
+          }
+        }
+      }
+    }
+
+    // AC: @skill-validation ac-4 - validate each skill with strict ULID validation
+    if (
+      raw &&
+      typeof raw === "object" &&
+      "skills" in raw &&
+      Array.isArray((raw as Record<string, unknown>).skills)
+    ) {
+      const skills = (raw as Record<string, unknown>).skills as unknown[];
+      for (let i = 0; i < skills.length; i++) {
+        const skill = skills[i];
+        const skillResult = SkillSchema.safeParse(skill);
+        if (!skillResult.success) {
+          for (const issue of skillResult.error.issues) {
+            errors.push({
+              file: filePath,
+              path: `skills[${i}].${issue.path.join(".")}`,
+              message: issue.message,
+              details: issue,
+            });
+          }
+        }
+
+        // Strict ULID validation
+        if (skill && typeof skill === "object" && "_ulid" in skill) {
+          const ulidResult = UlidSchema.safeParse(
+            (skill as Record<string, unknown>)._ulid,
+          );
+          if (!ulidResult.success) {
+            errors.push({
+              file: filePath,
+              path: `skills[${i}]._ulid`,
               message: "Invalid ULID format (expected 26 characters)",
             });
           }
@@ -1312,6 +1352,97 @@ function checkAutomationEligibility(
 }
 
 // ============================================================
+// SKILL VALIDATION
+// ============================================================
+
+/**
+ * Validate skill depends_on references
+ * AC: @skill-validation ac-2 - broken depends_on ref reports warning
+ */
+function validateSkillDependsOn(
+  skills: LoadedSkill[],
+  index: ReferenceIndex,
+): RefValidationWarning[] {
+  const warnings: RefValidationWarning[] = [];
+
+  for (const skill of skills) {
+    if (!skill.depends_on || skill.depends_on.length === 0) {
+      continue;
+    }
+
+    for (const depRef of skill.depends_on) {
+      const result = index.resolve(depRef);
+      if (!result.ok) {
+        warnings.push({
+          ref: depRef,
+          sourceFile: skill._sourceFile,
+          sourceUlid: skill._ulid,
+          field: "depends_on",
+          warning: "deprecated_target", // Reuse warning type for broken refs
+          message: `Skill '${skill.id}' depends_on reference '${depRef}' cannot be resolved`,
+        });
+      } else {
+        // Check that the resolved item is actually a skill (has origin field)
+        const resolvedItem = result.item as { origin?: string };
+        if (!("origin" in resolvedItem)) {
+          warnings.push({
+            ref: depRef,
+            sourceFile: skill._sourceFile,
+            sourceUlid: skill._ulid,
+            field: "depends_on",
+            warning: "deprecated_target",
+            message: `Skill '${skill.id}' depends_on reference '${depRef}' points to non-skill item`,
+          });
+        }
+      }
+    }
+  }
+
+  return warnings;
+}
+
+/**
+ * Find orphaned skill directories (directories with no corresponding meta entry)
+ * AC: @skill-validation ac-3 - orphaned directory reports warning
+ */
+async function findOrphanedSkillDirectories(
+  ctx: KspecContext,
+  skills: LoadedSkill[],
+): Promise<RefValidationWarning[]> {
+  const warnings: RefValidationWarning[] = [];
+  const skillsDir = path.join(ctx.specDir, "skills");
+
+  try {
+    // Check if skills directory exists
+    await fs.access(skillsDir);
+
+    // Read all directories in skills/
+    const entries = await fs.readdir(skillsDir, { withFileTypes: true });
+    const directories = entries.filter(entry => entry.isDirectory());
+
+    // Build set of skill IDs from meta
+    const skillIds = new Set(skills.map(s => s.id));
+
+    // Find orphaned directories
+    for (const dir of directories) {
+      if (!skillIds.has(dir.name)) {
+        warnings.push({
+          ref: `@${dir.name}`,
+          sourceFile: path.join(skillsDir, dir.name),
+          field: "directory",
+          warning: "deprecated_target", // Reuse warning type
+          message: `Orphaned skill directory '${dir.name}' has no corresponding meta entry`,
+        });
+      }
+    }
+  } catch {
+    // Skills directory doesn't exist - that's fine
+  }
+
+  return warnings;
+}
+
+// ============================================================
 // MAIN VALIDATION
 // ============================================================
 
@@ -1430,6 +1561,7 @@ export async function validate(
     ...metaCtx.workflows,
     ...metaCtx.conventions,
     ...metaCtx.observations,
+    ...metaCtx.skills, // Include skills for reference indexing
   ];
 
   // Load plans for reference validation
@@ -1453,6 +1585,10 @@ export async function validate(
     const refResult = validateRefs(index, allTasks, allItems);
     result.refErrors = refResult.errors;
     result.refWarnings = refResult.warnings;
+
+    // AC: @skill-validation ac-2 - validate skill depends_on references
+    const skillDependsOnWarnings = validateSkillDependsOn(metaCtx.skills, index);
+    result.refWarnings.push(...skillDependsOnWarnings);
 
     // AC: @trait-edge-cases ac-2
     // Detect circular trait references
@@ -1492,6 +1628,7 @@ export async function validate(
       workflows: metaCtx.workflows.length,
       conventions: metaCtx.conventions.length,
       observations: metaCtx.observations.length,
+      skills: metaCtx.skills.length,
     };
 
     // Validate meta manifest schema with strict ULID validation
@@ -1509,6 +1646,10 @@ export async function validate(
         const skillContentErrors = await validateSkillContentFiles(ctx, metaCtx.skills);
         result.schemaErrors.push(...skillContentErrors);
       }
+
+      // AC: @skill-validation ac-3 - detect orphaned skill directories
+      const orphanedSkillWarnings = await findOrphanedSkillDirectories(ctx, metaCtx.skills);
+      result.refWarnings.push(...orphanedSkillWarnings);
     }
   }
 

--- a/tests/kspec-skill-validation.test.ts
+++ b/tests/kspec-skill-validation.test.ts
@@ -1,0 +1,563 @@
+/**
+ * Tests for Skill Validation in kspec
+ * AC: @skill-validation ac-1, ac-2, ac-3, ac-4
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { stringify as yamlStringify } from 'yaml';
+import { createTempDir, cleanupTempDir, testUlid, initGitRepo } from './helpers/cli';
+import { validate } from '../src/parser/validate';
+import { initContext } from '../src/parser/yaml';
+
+describe('Kspec Skill Validation', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await createTempDir();
+    await initGitRepo(tempDir);
+
+    // Create minimal manifest
+    await fs.writeFile(
+      path.join(tempDir, 'kynetic.yaml'),
+      yamlStringify({ kynetic: '1.0', includes: [] }),
+    );
+  });
+
+  afterEach(async () => {
+    await cleanupTempDir(tempDir);
+  });
+
+  describe('missing content file validation (ac-1)', () => {
+    // AC: @skill-validation ac-1
+    it('should report error when skill has no SKILL.md file', async () => {
+      const skillUlid = testUlid('SKVAL1');
+
+      // Create meta manifest with a skill but NO corresponding SKILL.md
+      const metaManifest = {
+        kynetic_meta: '1.0',
+        skills: [
+          {
+            _ulid: skillUlid,
+            id: 'missing-content-skill',
+            name: 'Missing Content Skill',
+            origin: 'core',
+          },
+        ],
+      };
+
+      await fs.writeFile(
+        path.join(tempDir, 'kynetic.meta.yaml'),
+        yamlStringify(metaManifest),
+      );
+
+      const ctx = await initContext(tempDir);
+      const result = await validate(ctx);
+
+      // Should have a schema error for the missing content file
+      const missingContentError = result.schemaErrors.find(
+        err => err.message.includes('missing content file') ||
+               err.message.includes('missing-content-skill'),
+      );
+      expect(missingContentError).toBeDefined();
+      expect(missingContentError?.message).toContain('missing-content-skill');
+    });
+
+    // AC: @skill-validation ac-1
+    it('should not report error when skill has SKILL.md file', async () => {
+      const skillUlid = testUlid('SKVAL2');
+      const skillId = 'valid-skill';
+
+      // Create skill directory and SKILL.md
+      const skillDir = path.join(tempDir, 'skills', skillId);
+      await fs.mkdir(skillDir, { recursive: true });
+      await fs.writeFile(path.join(skillDir, 'SKILL.md'), '# Valid Skill\n\nContent here.');
+
+      // Create meta manifest with the skill
+      const metaManifest = {
+        kynetic_meta: '1.0',
+        skills: [
+          {
+            _ulid: skillUlid,
+            id: skillId,
+            name: 'Valid Skill',
+            origin: 'core',
+          },
+        ],
+      };
+
+      await fs.writeFile(
+        path.join(tempDir, 'kynetic.meta.yaml'),
+        yamlStringify(metaManifest),
+      );
+
+      const ctx = await initContext(tempDir);
+      const result = await validate(ctx);
+
+      // Should not have any skill content errors
+      const skillContentErrors = result.schemaErrors.filter(
+        err => err.message.includes('missing content file'),
+      );
+      expect(skillContentErrors).toHaveLength(0);
+    });
+  });
+
+  describe('depends_on reference validation (ac-2)', () => {
+    // AC: @skill-validation ac-2
+    it('should report warning when skill depends_on references non-existent skill', async () => {
+      const skillUlid = testUlid('SKDEP1');
+      const skillId = 'skill-with-broken-dep';
+
+      // Create skill directory and SKILL.md
+      const skillDir = path.join(tempDir, 'skills', skillId);
+      await fs.mkdir(skillDir, { recursive: true });
+      await fs.writeFile(path.join(skillDir, 'SKILL.md'), '# Skill with broken dep');
+
+      // Create meta manifest with skill referencing non-existent skill
+      const metaManifest = {
+        kynetic_meta: '1.0',
+        skills: [
+          {
+            _ulid: skillUlid,
+            id: skillId,
+            name: 'Skill With Broken Dep',
+            origin: 'core',
+            depends_on: ['@nonexistent-skill'],
+          },
+        ],
+      };
+
+      await fs.writeFile(
+        path.join(tempDir, 'kynetic.meta.yaml'),
+        yamlStringify(metaManifest),
+      );
+
+      const ctx = await initContext(tempDir);
+      const result = await validate(ctx);
+
+      // Should have a warning for the broken reference
+      const brokenRefWarning = result.refWarnings.find(
+        warn => warn.message.includes('cannot be resolved') &&
+                warn.message.includes('nonexistent-skill'),
+      );
+      expect(brokenRefWarning).toBeDefined();
+      expect(brokenRefWarning?.field).toBe('depends_on');
+    });
+
+    // AC: @skill-validation ac-2
+    it('should not report warning when skill depends_on references existing skill', async () => {
+      const skill1Ulid = testUlid('SKDEP2');
+      const skill2Ulid = testUlid('SKDEP3');
+      const skill1Id = 'base-skill';
+      const skill2Id = 'dependent-skill';
+
+      // Create skill directories and SKILL.md files
+      const skill1Dir = path.join(tempDir, 'skills', skill1Id);
+      const skill2Dir = path.join(tempDir, 'skills', skill2Id);
+      await fs.mkdir(skill1Dir, { recursive: true });
+      await fs.mkdir(skill2Dir, { recursive: true });
+      await fs.writeFile(path.join(skill1Dir, 'SKILL.md'), '# Base Skill');
+      await fs.writeFile(path.join(skill2Dir, 'SKILL.md'), '# Dependent Skill');
+
+      // Create meta manifest with skill referencing existing skill
+      const metaManifest = {
+        kynetic_meta: '1.0',
+        skills: [
+          {
+            _ulid: skill1Ulid,
+            id: skill1Id,
+            name: 'Base Skill',
+            origin: 'core',
+          },
+          {
+            _ulid: skill2Ulid,
+            id: skill2Id,
+            name: 'Dependent Skill',
+            origin: 'core',
+            depends_on: [`@${skill1Id}`],
+          },
+        ],
+      };
+
+      await fs.writeFile(
+        path.join(tempDir, 'kynetic.meta.yaml'),
+        yamlStringify(metaManifest),
+      );
+
+      const ctx = await initContext(tempDir);
+      const result = await validate(ctx);
+
+      // Should not have any warnings for depends_on
+      const dependsOnWarnings = result.refWarnings.filter(
+        warn => warn.field === 'depends_on',
+      );
+      expect(dependsOnWarnings).toHaveLength(0);
+    });
+
+    // AC: @skill-validation ac-2
+    it('should report warning when skill depends_on references non-skill item', async () => {
+      const skillUlid = testUlid('SKDEP4');
+      const agentUlid = testUlid('SKDEP5');
+      const skillId = 'skill-dep-agent';
+
+      // Create skill directory and SKILL.md
+      const skillDir = path.join(tempDir, 'skills', skillId);
+      await fs.mkdir(skillDir, { recursive: true });
+      await fs.writeFile(path.join(skillDir, 'SKILL.md'), '# Skill depending on agent');
+
+      // Create meta manifest with skill referencing an agent (not a skill)
+      const metaManifest = {
+        kynetic_meta: '1.0',
+        agents: [
+          {
+            _ulid: agentUlid,
+            id: 'test-agent',
+            name: 'Test Agent',
+          },
+        ],
+        skills: [
+          {
+            _ulid: skillUlid,
+            id: skillId,
+            name: 'Skill Depending on Agent',
+            origin: 'core',
+            depends_on: ['@test-agent'],
+          },
+        ],
+      };
+
+      await fs.writeFile(
+        path.join(tempDir, 'kynetic.meta.yaml'),
+        yamlStringify(metaManifest),
+      );
+
+      const ctx = await initContext(tempDir);
+      const result = await validate(ctx);
+
+      // Should have a warning that dep points to non-skill
+      const nonSkillWarning = result.refWarnings.find(
+        warn => warn.message.includes('non-skill'),
+      );
+      expect(nonSkillWarning).toBeDefined();
+    });
+  });
+
+  describe('orphaned skill directory detection (ac-3)', () => {
+    // AC: @skill-validation ac-3
+    it('should report warning for directory with no corresponding meta entry', async () => {
+      // Create orphaned skill directory (no meta entry)
+      const orphanedDir = path.join(tempDir, 'skills', 'orphaned-skill');
+      await fs.mkdir(orphanedDir, { recursive: true });
+      await fs.writeFile(path.join(orphanedDir, 'SKILL.md'), '# Orphaned');
+
+      // Create empty meta manifest (no skills)
+      const metaManifest = {
+        kynetic_meta: '1.0',
+        skills: [],
+      };
+
+      await fs.writeFile(
+        path.join(tempDir, 'kynetic.meta.yaml'),
+        yamlStringify(metaManifest),
+      );
+
+      const ctx = await initContext(tempDir);
+      const result = await validate(ctx);
+
+      // Should have a warning for the orphaned directory
+      const orphanedWarning = result.refWarnings.find(
+        warn => warn.message.includes('Orphaned skill directory') &&
+                warn.message.includes('orphaned-skill'),
+      );
+      expect(orphanedWarning).toBeDefined();
+    });
+
+    // AC: @skill-validation ac-3
+    it('should not report warning for directory with corresponding meta entry', async () => {
+      const skillUlid = testUlid('SKORP1');
+      const skillId = 'valid-skill';
+
+      // Create skill directory
+      const skillDir = path.join(tempDir, 'skills', skillId);
+      await fs.mkdir(skillDir, { recursive: true });
+      await fs.writeFile(path.join(skillDir, 'SKILL.md'), '# Valid Skill');
+
+      // Create meta manifest with matching skill entry
+      const metaManifest = {
+        kynetic_meta: '1.0',
+        skills: [
+          {
+            _ulid: skillUlid,
+            id: skillId,
+            name: 'Valid Skill',
+            origin: 'core',
+          },
+        ],
+      };
+
+      await fs.writeFile(
+        path.join(tempDir, 'kynetic.meta.yaml'),
+        yamlStringify(metaManifest),
+      );
+
+      const ctx = await initContext(tempDir);
+      const result = await validate(ctx);
+
+      // Should not have any orphan warnings
+      const orphanedWarnings = result.refWarnings.filter(
+        warn => warn.message.includes('Orphaned skill directory'),
+      );
+      expect(orphanedWarnings).toHaveLength(0);
+    });
+
+    // AC: @skill-validation ac-3
+    it('should report multiple warnings for multiple orphaned directories', async () => {
+      // Create multiple orphaned directories
+      await fs.mkdir(path.join(tempDir, 'skills', 'orphan-one'), { recursive: true });
+      await fs.mkdir(path.join(tempDir, 'skills', 'orphan-two'), { recursive: true });
+
+      // Create empty meta manifest
+      const metaManifest = {
+        kynetic_meta: '1.0',
+        skills: [],
+      };
+
+      await fs.writeFile(
+        path.join(tempDir, 'kynetic.meta.yaml'),
+        yamlStringify(metaManifest),
+      );
+
+      const ctx = await initContext(tempDir);
+      const result = await validate(ctx);
+
+      // Should have warnings for both orphaned directories
+      const orphanedWarnings = result.refWarnings.filter(
+        warn => warn.message.includes('Orphaned skill directory'),
+      );
+      expect(orphanedWarnings).toHaveLength(2);
+      expect(orphanedWarnings.some(w => w.message.includes('orphan-one'))).toBe(true);
+      expect(orphanedWarnings.some(w => w.message.includes('orphan-two'))).toBe(true);
+    });
+  });
+
+  describe('schema validation (ac-4)', () => {
+    // AC: @skill-validation ac-4
+    it('should report schema validation errors for invalid skill fields', async () => {
+      // Create meta manifest with invalid skill (missing required fields)
+      const metaManifest = {
+        kynetic_meta: '1.0',
+        skills: [
+          {
+            _ulid: testUlid('SKSCH1'),
+            // Missing required 'id' field
+            name: 'Invalid Skill',
+            origin: 'core',
+          },
+        ],
+      };
+
+      await fs.writeFile(
+        path.join(tempDir, 'kynetic.meta.yaml'),
+        yamlStringify(metaManifest),
+      );
+
+      const ctx = await initContext(tempDir);
+      const result = await validate(ctx);
+
+      // Should have schema error for missing id
+      // Path format is "meta:skills.0.id" (dot notation with meta: prefix)
+      // Error message is "Skill ID is required"
+      const schemaError = result.schemaErrors.find(
+        err => err.path?.includes('skills') &&
+               (err.message.includes('ID is required') || err.message.includes('id')),
+      );
+      expect(schemaError).toBeDefined();
+    });
+
+    // AC: @skill-validation ac-4
+    it('should report schema validation errors for invalid ULID format', async () => {
+      // Create meta manifest with invalid ULID
+      const metaManifest = {
+        kynetic_meta: '1.0',
+        skills: [
+          {
+            _ulid: 'invalid-ulid',
+            id: 'test-skill',
+            name: 'Test Skill',
+            origin: 'core',
+          },
+        ],
+      };
+
+      await fs.writeFile(
+        path.join(tempDir, 'kynetic.meta.yaml'),
+        yamlStringify(metaManifest),
+      );
+
+      const ctx = await initContext(tempDir);
+      const result = await validate(ctx);
+
+      // Should have schema error for invalid ULID
+      // Path format is "meta:skills.0._ulid" (dot notation with meta: prefix)
+      const ulidError = result.schemaErrors.find(
+        err => err.path?.includes('skills') &&
+               (err.path?.includes('_ulid') || err.message.includes('ULID') || err.message.includes('26 characters')),
+      );
+      expect(ulidError).toBeDefined();
+    });
+
+    // AC: @skill-validation ac-4
+    it('should report schema validation errors for invalid origin value', async () => {
+      // Create meta manifest with invalid origin
+      const metaManifest = {
+        kynetic_meta: '1.0',
+        skills: [
+          {
+            _ulid: testUlid('SKSCH3'),
+            id: 'test-skill',
+            name: 'Test Skill',
+            origin: 'invalid-origin', // Invalid - must be core/project/local
+          },
+        ],
+      };
+
+      await fs.writeFile(
+        path.join(tempDir, 'kynetic.meta.yaml'),
+        yamlStringify(metaManifest),
+      );
+
+      const ctx = await initContext(tempDir);
+      const result = await validate(ctx);
+
+      // Should have schema error for invalid origin
+      // Path format is "meta:skills.0.origin" (dot notation with meta: prefix)
+      const originError = result.schemaErrors.find(
+        err => err.path?.includes('skills') && err.path?.includes('origin'),
+      );
+      expect(originError).toBeDefined();
+    });
+
+    // AC: @skill-validation ac-4
+    it('should report schema validation errors for invalid id format (not kebab-case)', async () => {
+      // Create skill directory first to avoid content file error
+      const skillDir = path.join(tempDir, 'skills', 'InvalidSkillId');
+      await fs.mkdir(skillDir, { recursive: true });
+      await fs.writeFile(path.join(skillDir, 'SKILL.md'), '# Invalid');
+
+      // Create meta manifest with invalid id format
+      const metaManifest = {
+        kynetic_meta: '1.0',
+        skills: [
+          {
+            _ulid: testUlid('SKSCH4'),
+            id: 'InvalidSkillId', // Invalid - must be kebab-case
+            name: 'Test Skill',
+            origin: 'core',
+          },
+        ],
+      };
+
+      await fs.writeFile(
+        path.join(tempDir, 'kynetic.meta.yaml'),
+        yamlStringify(metaManifest),
+      );
+
+      const ctx = await initContext(tempDir);
+      const result = await validate(ctx);
+
+      // Should have schema error for invalid id format
+      // Path format is "meta:skills.0.id" (dot notation with meta: prefix)
+      const idError = result.schemaErrors.find(
+        err => err.path?.includes('skills') &&
+               err.path?.includes('id') &&
+               err.message.includes('kebab-case'),
+      );
+      expect(idError).toBeDefined();
+    });
+
+    // AC: @skill-validation ac-4
+    it('should pass validation for valid skill with all required fields', async () => {
+      const skillUlid = testUlid('SKSCH5');
+      const skillId = 'valid-skill';
+
+      // Create skill directory and SKILL.md
+      const skillDir = path.join(tempDir, 'skills', skillId);
+      await fs.mkdir(skillDir, { recursive: true });
+      await fs.writeFile(path.join(skillDir, 'SKILL.md'), '# Valid Skill');
+
+      // Create meta manifest with valid skill
+      const metaManifest = {
+        kynetic_meta: '1.0',
+        skills: [
+          {
+            _ulid: skillUlid,
+            id: skillId,
+            name: 'Valid Skill',
+            origin: 'core',
+            description: 'A valid skill',
+            platforms: ['claude-code'],
+            tags: ['test'],
+          },
+        ],
+      };
+
+      await fs.writeFile(
+        path.join(tempDir, 'kynetic.meta.yaml'),
+        yamlStringify(metaManifest),
+      );
+
+      const ctx = await initContext(tempDir);
+      const result = await validate(ctx);
+
+      // Should not have any skill-related schema errors
+      const skillErrors = result.schemaErrors.filter(
+        err => err.path?.includes('skills'),
+      );
+      expect(skillErrors).toHaveLength(0);
+    });
+  });
+
+  describe('metaStats includes skills', () => {
+    it('should include skills count in metaStats', async () => {
+      const skill1Ulid = testUlid('SKSTA1');
+      const skill2Ulid = testUlid('SKSTA2');
+
+      // Create skill directories and SKILL.md files
+      await fs.mkdir(path.join(tempDir, 'skills', 'skill-one'), { recursive: true });
+      await fs.mkdir(path.join(tempDir, 'skills', 'skill-two'), { recursive: true });
+      await fs.writeFile(path.join(tempDir, 'skills', 'skill-one', 'SKILL.md'), '# One');
+      await fs.writeFile(path.join(tempDir, 'skills', 'skill-two', 'SKILL.md'), '# Two');
+
+      // Create meta manifest with two skills
+      const metaManifest = {
+        kynetic_meta: '1.0',
+        skills: [
+          {
+            _ulid: skill1Ulid,
+            id: 'skill-one',
+            name: 'Skill One',
+            origin: 'core',
+          },
+          {
+            _ulid: skill2Ulid,
+            id: 'skill-two',
+            name: 'Skill Two',
+            origin: 'project',
+          },
+        ],
+      };
+
+      await fs.writeFile(
+        path.join(tempDir, 'kynetic.meta.yaml'),
+        yamlStringify(metaManifest),
+      );
+
+      const ctx = await initContext(tempDir);
+      const result = await validate(ctx);
+
+      // metaStats should include skills count
+      expect(result.metaStats).toBeDefined();
+      expect(result.metaStats?.skills).toBe(2);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add skill-aware validation to `src/parser/validate.ts`
- **AC-1**: Missing content file validation (validates skill meta entries have SKILL.md)
- **AC-2**: Broken `depends_on` reference detection (warns when skill depends on non-existent or non-skill items)
- **AC-3**: Orphaned skill directory detection (warns when `.kspec/skills/<id>/` exists without meta entry)
- **AC-4**: Schema validation parity (validates skills with same pattern as agents/workflows/conventions)
- Include skills in `allMetaItems` for reference indexing
- Add skills count to `metaStats`

## Test plan

- [x] 14 tests covering all 4 ACs in `tests/kspec-skill-validation.test.ts`
- [x] Verify existing skill-validation tests still pass (tests `.claude/skills/` validation)
- [x] Full test suite passes (2301 passed, 1 pre-existing failure in daemon-executable)
- [x] Build succeeds

Task: @implement-skill-validation
Spec: @skill-validation

🤖 Generated with [Claude Code](https://claude.ai/code)