### PR TITLE
feat: implement skill CLI commands for kspec

### DIFF
--- a/src/cli/commands/index.ts
+++ b/src/cli/commands/index.ts
@@ -21,6 +21,7 @@ export { registerServeCommands } from "./serve.js";
 export { registerSessionCommands } from "./session.js";
 export { registerSetupCommand } from "./setup.js";
 export { registerShadowCommands } from "./shadow.js";
+export { registerSkillCommands } from "./skill.js";
 export { registerTaskCommands } from "./task.js";
 export { registerTasksCommands } from "./tasks.js";
 export { registerItemTraitCommands, registerTraitCommands } from "./trait.js";

--- a/src/cli/commands/skill.ts
+++ b/src/cli/commands/skill.ts
@@ -1,0 +1,401 @@
+/**
+ * Skill CLI commands for managing skills.
+ *
+ * AC: @skill-cli ac-1 - kspec skill list outputs table with ID, Name, Origin, Version, Platforms
+ * AC: @skill-cli ac-2 - kspec skill list --json outputs JSON array with full skill metadata
+ * AC: @skill-cli ac-3 - kspec skill add creates meta entry with origin custom
+ * AC: @skill-cli ac-4 - kspec skill add creates .kspec/skills/<id>/SKILL.md
+ * AC: @skill-cli ac-5 - kspec skill get outputs metadata including id, name, origin, platforms
+ * AC: @skill-cli ac-6 - kspec skill get outputs SKILL.md content
+ * AC: @skill-cli ac-7 - kspec skill delete --confirm removes meta entry
+ * AC: @skill-cli ac-8 - kspec skill delete removes .kspec/skills/<id>/ directory
+ */
+
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import chalk from "chalk";
+import Table from "cli-table3";
+import type { Command } from "commander";
+import { ulid } from "ulid";
+import { markMutating } from "../command-annotations.js";
+import {
+  deleteMetaItem,
+  findMetaItemByRef,
+  getSkillContentPath,
+  initContext,
+  loadMetaContext,
+  loadSkillContent,
+  loadSkillDocs,
+  type LoadedSkill,
+  saveMetaItem,
+  type Skill,
+} from "../../parser/index.js";
+import { commitIfShadow } from "../../parser/shadow.js";
+import { SkillSchema, type SkillOrigin } from "../../schema/index.js";
+import { errors } from "../../strings/errors.js";
+import { EXIT_CODES } from "../exit-codes.js";
+import { error, output, success } from "../output.js";
+import { parseTagsArray } from "../parse-utils.js";
+
+/**
+ * Format skills as a table
+ * AC: @skill-cli ac-1 - table displays ID, Name, Origin, Version, Platforms
+ */
+function formatSkillsTable(skills: LoadedSkill[]): void {
+  if (skills.length === 0) {
+    console.log(chalk.yellow("No skills defined"));
+    return;
+  }
+
+  const table = new Table({
+    head: [
+      chalk.bold("ID"),
+      chalk.bold("Name"),
+      chalk.bold("Origin"),
+      chalk.bold("Version"),
+      chalk.bold("Platforms"),
+    ],
+    style: {
+      head: [],
+      border: [],
+    },
+  });
+
+  for (const skill of skills) {
+    table.push([
+      skill.id,
+      skill.name,
+      skill.origin,
+      skill.version || "-",
+      skill.platforms.join(", "),
+    ]);
+  }
+
+  console.log(table.toString());
+  console.log(chalk.gray(`\n${skills.length} skill(s)`));
+}
+
+/**
+ * Format skill details
+ * AC: @skill-cli ac-5 - outputs metadata including id, name, origin, platforms
+ */
+function formatSkillDetails(skill: LoadedSkill, content: string | null): void {
+  console.log(chalk.bold(skill.name));
+  console.log(chalk.gray("─".repeat(40)));
+  console.log(`ID:          ${skill.id}`);
+  console.log(`ULID:        ${skill._ulid}`);
+  console.log(`Origin:      ${skill.origin}`);
+  console.log(`Platforms:   ${skill.platforms.join(", ")}`);
+
+  if (skill.version) {
+    console.log(`Version:     ${skill.version}`);
+  }
+
+  if (skill.description) {
+    console.log(`\n─── Description ───`);
+    console.log(skill.description);
+  }
+
+  if (skill.depends_on && skill.depends_on.length > 0) {
+    console.log(`\n─── Dependencies ───`);
+    for (const dep of skill.depends_on) {
+      console.log(`  • ${dep}`);
+    }
+  }
+
+  if (skill.tags && skill.tags.length > 0) {
+    console.log(`\nTags:        ${skill.tags.join(", ")}`);
+  }
+
+  // AC: @skill-cli ac-6 - display SKILL.md content
+  if (content) {
+    console.log(`\n─── SKILL.md Content ───`);
+    console.log(content);
+  } else {
+    console.log(chalk.gray("\n(No SKILL.md content found)"));
+  }
+}
+
+/**
+ * Register skill commands
+ */
+export function registerSkillCommands(program: Command): void {
+  const skill = program
+    .command("skill")
+    .description("Skill management commands");
+
+  // AC: @skill-cli ac-1, ac-2 - kspec skill list
+  skill
+    .command("list")
+    .description("List all skills")
+    .option("--origin <origin>", "Filter by origin (core, project, local)")
+    .option("--tag <tag>", "Filter by tag")
+    .action(async (options) => {
+      try {
+        const ctx = await initContext();
+
+        if (!ctx.manifestPath) {
+          error(errors.project.noKspecProject);
+          process.exit(EXIT_CODES.ERROR);
+        }
+
+        const metaCtx = await loadMetaContext(ctx);
+        let skills = metaCtx.skills || [];
+
+        // Apply filters
+        if (options.origin) {
+          skills = skills.filter((s) => s.origin === options.origin);
+        }
+
+        if (options.tag) {
+          skills = skills.filter((s) => s.tags?.includes(options.tag));
+        }
+
+        // AC: @skill-cli ac-2 - JSON output includes full skill metadata
+        output(
+          skills.map((s) => ({
+            _ulid: s._ulid,
+            id: s.id,
+            name: s.name,
+            description: s.description,
+            origin: s.origin,
+            version: s.version,
+            platforms: s.platforms,
+            depends_on: s.depends_on,
+            tags: s.tags,
+          })),
+          // AC: @skill-cli ac-1 - Table output
+          () => formatSkillsTable(skills),
+        );
+      } catch (err) {
+        error("Failed to list skills", err);
+        process.exit(EXIT_CODES.ERROR);
+      }
+    });
+
+  // AC: @skill-cli ac-3, ac-4 - kspec skill add
+  markMutating(skill.command("add"))
+    .description("Create a new skill")
+    .requiredOption("--id <id>", "Skill ID (kebab-case)")
+    .requiredOption("--name <name>", "Skill name")
+    .option("--description <desc>", "Skill description")
+    .option(
+      "--origin <origin>",
+      "Skill origin (core, project, local)",
+      "project",
+    )
+    .option("--skill-version <version>", "Skill version")
+    .option("--platform <platform...>", "Target platforms")
+    .option("--tag <tag...>", "Tags for the skill")
+    .option("--depends-on <ref...>", "Skill dependencies")
+    .action(async (options) => {
+      try {
+        const ctx = await initContext();
+
+        if (!ctx.manifestPath) {
+          error(errors.project.noKspecProject);
+          process.exit(EXIT_CODES.ERROR);
+        }
+
+        // Validate origin
+        const validOrigins: SkillOrigin[] = ["core", "project", "local"];
+        if (!validOrigins.includes(options.origin as SkillOrigin)) {
+          error(
+            `Invalid origin: ${options.origin}. Valid origins: ${validOrigins.join(", ")}`,
+          );
+          process.exit(EXIT_CODES.ERROR);
+        }
+
+        // Check if skill with this ID already exists
+        const metaCtx = await loadMetaContext(ctx);
+        const existingSkill = metaCtx.skills.find((s) => s.id === options.id);
+        if (existingSkill) {
+          error(`Skill with ID '${options.id}' already exists`);
+          process.exit(EXIT_CODES.CONFLICT);
+        }
+
+        // Build skill object
+        const skillData: Skill = {
+          _ulid: ulid(),
+          id: options.id,
+          name: options.name,
+          description: options.description,
+          origin: options.origin as SkillOrigin,
+          version: options.skillVersion,
+          platforms:
+            options.platform && options.platform.length > 0
+              ? options.platform
+              : ["claude-code"],
+          depends_on:
+            options.dependsOn && options.dependsOn.length > 0
+              ? options.dependsOn
+              : [],
+          tags:
+            options.tag && options.tag.length > 0
+              ? parseTagsArray(options.tag)
+              : [],
+        };
+
+        // Validate with schema
+        const parsed = SkillSchema.safeParse(skillData);
+        if (!parsed.success) {
+          const issues = parsed.error.issues
+            .map((i) => `${i.path.join(".")}: ${i.message}`)
+            .join("; ");
+          error(`Invalid skill data: ${issues}`);
+          process.exit(EXIT_CODES.VALIDATION_FAILED);
+        }
+
+        const skill: LoadedSkill = { ...parsed.data };
+
+        // AC: @skill-cli ac-3 - save meta entry (also creates directory per ac-4)
+        await saveMetaItem(ctx, skill, "skill");
+
+        // AC: @skill-cli ac-4 - create SKILL.md with placeholder content
+        const skillMdPath = getSkillContentPath(ctx, skill.id);
+        const initialContent = `# ${skill.name}\n\n${skill.description || "Add skill content here."}\n`;
+        await fs.writeFile(skillMdPath, initialContent, "utf-8");
+
+        // Commit changes
+        await commitIfShadow(ctx.shadow, "skill-add", skill.id, skill.name);
+
+        output(skill, () =>
+          success(`Created skill: ${skill.id}`, { skill }),
+        );
+      } catch (err) {
+        error("Failed to create skill", err);
+        process.exit(EXIT_CODES.ERROR);
+      }
+    });
+
+  // AC: @skill-cli ac-5, ac-6 - kspec skill get
+  skill
+    .command("get <ref>")
+    .description("Show skill details")
+    .action(async (ref: string) => {
+      try {
+        const ctx = await initContext();
+
+        if (!ctx.manifestPath) {
+          error(errors.project.noKspecProject);
+          process.exit(EXIT_CODES.ERROR);
+        }
+
+        const metaCtx = await loadMetaContext(ctx);
+        const item = findMetaItemByRef(metaCtx, ref);
+
+        if (!item) {
+          error(`Skill not found: ${ref}`);
+          console.log(chalk.gray("Try: kspec skill list"));
+          process.exit(EXIT_CODES.NOT_FOUND);
+        }
+
+        // Check it's a skill
+        if (!("origin" in item)) {
+          error(`Item ${ref} is not a skill`);
+          process.exit(EXIT_CODES.ERROR);
+        }
+
+        const skill = item as LoadedSkill;
+
+        // AC: @skill-cli ac-6 - load SKILL.md content
+        const content = await loadSkillContent(ctx, skill);
+        const docs = await loadSkillDocs(ctx, skill);
+
+        // AC: @skill-cli ac-5, ac-6 - output metadata and content
+        output(
+          {
+            _ulid: skill._ulid,
+            id: skill.id,
+            name: skill.name,
+            description: skill.description,
+            origin: skill.origin,
+            version: skill.version,
+            platforms: skill.platforms,
+            depends_on: skill.depends_on,
+            tags: skill.tags,
+            content,
+            docs: docs.map((d) => ({ name: d.name, path: d.path })),
+          },
+          () => formatSkillDetails(skill, content),
+        );
+      } catch (err) {
+        error("Failed to get skill", err);
+        process.exit(EXIT_CODES.ERROR);
+      }
+    });
+
+  // AC: @skill-cli ac-7, ac-8 - kspec skill delete
+  markMutating(skill.command("delete <ref>"))
+    .description("Delete a skill")
+    .option("--confirm", "Skip confirmation prompt")
+    .action(async (ref: string, options) => {
+      try {
+        const ctx = await initContext();
+
+        if (!ctx.manifestPath) {
+          error(errors.project.noKspecProject);
+          process.exit(EXIT_CODES.ERROR);
+        }
+
+        const metaCtx = await loadMetaContext(ctx);
+        const item = findMetaItemByRef(metaCtx, ref);
+
+        if (!item) {
+          error(`Skill not found: ${ref}`);
+          console.log(chalk.gray("Try: kspec skill list"));
+          process.exit(EXIT_CODES.NOT_FOUND);
+        }
+
+        // Check it's a skill
+        if (!("origin" in item)) {
+          error(`Item ${ref} is not a skill`);
+          process.exit(EXIT_CODES.ERROR);
+        }
+
+        const skill = item as LoadedSkill;
+
+        // Check for confirmation
+        if (!options.confirm) {
+          error(`Confirm deletion of skill '${skill.id}' with --confirm flag`);
+          process.exit(EXIT_CODES.ERROR);
+        }
+
+        // Check for dependencies from other skills
+        const dependentSkills = metaCtx.skills.filter(
+          (s) =>
+            s._ulid !== skill._ulid &&
+            s.depends_on?.some(
+              (dep) =>
+                dep === `@${skill.id}` ||
+                dep === skill.id ||
+                dep.startsWith(`@${skill._ulid.substring(0, 8)}`),
+            ),
+        );
+
+        if (dependentSkills.length > 0) {
+          const depRefs = dependentSkills.map((s) => `@${s.id}`).join(", ");
+          error(
+            `Cannot delete skill '${skill.id}': referenced by ${dependentSkills.length} skill(s): ${depRefs}`,
+          );
+          process.exit(EXIT_CODES.ERROR);
+        }
+
+        // AC: @skill-cli ac-7, ac-8 - delete meta entry and directory
+        const deleted = await deleteMetaItem(ctx, skill._ulid, "skill");
+
+        if (!deleted) {
+          error(`Failed to delete skill: ${skill.id}`);
+          process.exit(EXIT_CODES.ERROR);
+        }
+
+        // Commit changes
+        await commitIfShadow(ctx.shadow, "skill-delete", skill.id);
+
+        success(`Deleted skill: ${skill.id}`);
+      } catch (err) {
+        error("Failed to delete skill", err);
+        process.exit(EXIT_CODES.ERROR);
+      }
+    });
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -36,6 +36,7 @@ import {
   registerSessionCommands,
   registerSetupCommand,
   registerShadowCommands,
+  registerSkillCommands,
   registerTaskCommands,
   registerTasksCommands,
   registerTraitCommands,
@@ -212,6 +213,7 @@ registerMergeDriverCommand(program);
 registerExportCommand(program);
 registerUtilCommands(program);
 registerBatchCommand(program);
+registerSkillCommands(program);
 
 // Handle unknown commands with suggestions
 program.on("command:*", (operands) => {

--- a/tests/skill-cli.test.ts
+++ b/tests/skill-cli.test.ts
@@ -1,0 +1,466 @@
+/**
+ * Tests for Skill CLI Commands
+ * AC: @skill-cli ac-1 through ac-8
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { parse as yamlParse, stringify as yamlStringify } from 'yaml';
+import {
+  kspecOutput as kspec,
+  kspecJson,
+  kspec as kspecFull,
+  setupTempFixtures,
+  cleanupTempDir,
+  createTempDir,
+  initGitRepo,
+} from './helpers/cli';
+
+describe('Skill CLI - skill list', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await setupTempFixtures();
+    await initGitRepo(tempDir);
+
+    // Create some skills via kspec add - note: run sequentially
+    const result1 = kspecFull(
+      'skill add --id task-work --name "Task Work" --description "Work on tasks" --origin core --skill-version 0.1.0',
+      tempDir
+    );
+    const result2 = kspecFull(
+      'skill add --id pr-review --name "PR Review" --origin project --tag workflow --tag review',
+      tempDir
+    );
+    // Fail fast if skill creation failed
+    if (result1.exitCode !== 0) throw new Error(`skill add failed: ${result1.stderr}`);
+    if (result2.exitCode !== 0) throw new Error(`skill add failed: ${result2.stderr}`);
+  });
+
+  afterEach(async () => {
+    await cleanupTempDir(tempDir);
+  });
+
+  // AC: @skill-cli ac-1
+  it('should display table with ID, Name, Origin, Version, and Platforms columns', () => {
+    const output = kspec('skill list', tempDir);
+
+    // Check headers are present
+    expect(output).toContain('ID');
+    expect(output).toContain('Name');
+    expect(output).toContain('Origin');
+    expect(output).toContain('Version');
+    expect(output).toContain('Platforms');
+
+    // Check data
+    expect(output).toContain('task-work');
+    expect(output).toContain('Task Work');
+    expect(output).toContain('core');
+    expect(output).toContain('pr-review');
+    expect(output).toContain('PR Review');
+    expect(output).toContain('project');
+
+    // Check skill count
+    expect(output).toContain('2 skill(s)');
+  });
+
+  // AC: @skill-cli ac-2
+  it('should return JSON array with full skill metadata when --json flag provided', () => {
+    const result = kspecJson<Array<{
+      _ulid: string;
+      id: string;
+      name: string;
+      description?: string;
+      origin: string;
+      version?: string;
+      platforms: string[];
+      depends_on: string[];
+      tags: string[];
+    }>>('skill list', tempDir);
+
+    expect(Array.isArray(result)).toBe(true);
+    expect(result.length).toBe(2);
+
+    const taskWork = result.find(s => s.id === 'task-work');
+    expect(taskWork).toBeDefined();
+    expect(taskWork?._ulid).toMatch(/^[0-9A-Z]{26}$/);
+    expect(taskWork?.name).toBe('Task Work');
+    expect(taskWork?.description).toBe('Work on tasks');
+    expect(taskWork?.origin).toBe('core');
+    expect(taskWork?.version).toBe('0.1.0');
+    expect(taskWork?.platforms).toContain('claude-code');
+    expect(taskWork?.depends_on).toEqual([]);
+
+    const prReview = result.find(s => s.id === 'pr-review');
+    expect(prReview).toBeDefined();
+    expect(prReview?.origin).toBe('project');
+    expect(prReview?.tags).toContain('workflow');
+    expect(prReview?.tags).toContain('review');
+  });
+
+  it('should filter by origin', () => {
+    const result = kspecJson<Array<{ id: string; origin: string }>>('skill list --origin core', tempDir);
+
+    expect(result.length).toBe(1);
+    expect(result[0].id).toBe('task-work');
+    expect(result[0].origin).toBe('core');
+  });
+
+  it('should filter by tag', () => {
+    const result = kspecJson<Array<{ id: string; tags: string[] }>>('skill list --tag workflow', tempDir);
+
+    expect(result.length).toBe(1);
+    expect(result[0].id).toBe('pr-review');
+    expect(result[0].tags).toContain('workflow');
+  });
+
+  it('should show message when no skills defined', async () => {
+    // Create fresh project with no skills
+    const emptyDir = await createTempDir();
+    await initGitRepo(emptyDir);
+    await fs.writeFile(path.join(emptyDir, 'kynetic.yaml'), yamlStringify({ kynetic: '1.0' }));
+    await fs.writeFile(
+      path.join(emptyDir, 'kynetic.meta.yaml'),
+      yamlStringify({ kynetic_meta: '1.0', skills: [] })
+    );
+
+    try {
+      const output = kspec('skill list', emptyDir);
+      expect(output).toContain('No skills defined');
+    } finally {
+      await cleanupTempDir(emptyDir);
+    }
+  });
+});
+
+describe('Skill CLI - skill add', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await setupTempFixtures();
+    await initGitRepo(tempDir);
+  });
+
+  afterEach(async () => {
+    await cleanupTempDir(tempDir);
+  });
+
+  // AC: @skill-cli ac-3
+  it('should create meta entry with correct origin', () => {
+    const result = kspecJson<{
+      _ulid: string;
+      id: string;
+      name: string;
+      origin: string;
+    }>('skill add --id my-skill --name "My Skill" --description "A test skill"', tempDir);
+
+    expect(result.id).toBe('my-skill');
+    expect(result.name).toBe('My Skill');
+    expect(result.origin).toBe('project'); // Default origin
+    expect(result._ulid).toMatch(/^[0-9A-Z]{26}$/);
+  });
+
+  it('should create meta entry with custom origin', () => {
+    const result = kspecJson<{ id: string; origin: string }>(
+      'skill add --id local-skill --name "Local Skill" --origin local',
+      tempDir
+    );
+
+    expect(result.origin).toBe('local');
+  });
+
+  // AC: @skill-cli ac-4
+  it('should create .kspec/skills/<id>/SKILL.md file', async () => {
+    kspec('skill add --id my-skill --name "My Skill" --description "Test skill"', tempDir);
+
+    const skillMdPath = path.join(tempDir, 'skills', 'my-skill', 'SKILL.md');
+    const exists = await fs.access(skillMdPath).then(() => true).catch(() => false);
+    expect(exists).toBe(true);
+
+    const content = await fs.readFile(skillMdPath, 'utf-8');
+    expect(content).toContain('# My Skill');
+    expect(content).toContain('Test skill');
+  });
+
+  it('should add skill to meta manifest', async () => {
+    kspec('skill add --id my-skill --name "My Skill"', tempDir);
+
+    const metaPath = path.join(tempDir, 'kynetic.meta.yaml');
+    const metaContent = await fs.readFile(metaPath, 'utf-8');
+    const meta = yamlParse(metaContent);
+
+    expect(meta.skills).toBeDefined();
+    const skill = meta.skills.find((s: { id: string }) => s.id === 'my-skill');
+    expect(skill).toBeDefined();
+    expect(skill.name).toBe('My Skill');
+  });
+
+  it('should set platforms to default value when not specified', () => {
+    const result = kspecJson<{ platforms: string[] }>(
+      'skill add --id my-skill --name "My Skill"',
+      tempDir
+    );
+
+    expect(result.platforms).toEqual(['claude-code']);
+  });
+
+  it('should accept custom platforms', () => {
+    const result = kspecJson<{ platforms: string[] }>(
+      'skill add --id my-skill --name "My Skill" --platform cursor --platform windsurf',
+      tempDir
+    );
+
+    expect(result.platforms).toContain('cursor');
+    expect(result.platforms).toContain('windsurf');
+  });
+
+  it('should accept version option', () => {
+    const result = kspecJson<{ version: string }>(
+      'skill add --id my-skill --name "My Skill" --skill-version 1.2.3',
+      tempDir
+    );
+
+    expect(result.version).toBe('1.2.3');
+  });
+
+  it('should accept tags option', () => {
+    const result = kspecJson<{ tags: string[] }>(
+      'skill add --id my-skill --name "My Skill" --tag workflow --tag automation',
+      tempDir
+    );
+
+    expect(result.tags).toContain('workflow');
+    expect(result.tags).toContain('automation');
+  });
+
+  it('should accept depends-on option', () => {
+    // First create a skill to depend on
+    kspec('skill add --id base-skill --name "Base Skill"', tempDir);
+
+    const result = kspecJson<{ depends_on: string[] }>(
+      'skill add --id my-skill --name "My Skill" --depends-on @base-skill',
+      tempDir
+    );
+
+    expect(result.depends_on).toContain('@base-skill');
+  });
+
+  it('should reject duplicate skill ID', () => {
+    kspec('skill add --id my-skill --name "My Skill"', tempDir);
+
+    const result = kspecFull('skill add --id my-skill --name "Another Skill"', tempDir, { expectFail: true });
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain("already exists");
+  });
+
+  it('should reject invalid origin', () => {
+    const result = kspecFull('skill add --id my-skill --name "My Skill" --origin invalid', tempDir, { expectFail: true });
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain("Invalid origin");
+  });
+
+  it('should validate kebab-case ID', () => {
+    const result = kspecFull('skill add --id MySkill --name "My Skill"', tempDir, { expectFail: true });
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain("kebab-case");
+  });
+});
+
+describe('Skill CLI - skill get', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await setupTempFixtures();
+    await initGitRepo(tempDir);
+
+    // Create a skill with custom content
+    const result = kspecFull(
+      'skill add --id task-work --name "Task Work" --description "Work on tasks" --origin core --skill-version 0.1.0 --tag workflow',
+      tempDir
+    );
+    if (result.exitCode !== 0) throw new Error(`skill add failed: ${result.stderr}`);
+
+    // Update SKILL.md with custom content - the directory was created by skill add
+    const skillMdPath = path.join(tempDir, 'skills', 'task-work', 'SKILL.md');
+    await fs.writeFile(skillMdPath, `# Task Work
+
+Use this skill when working on kspec tasks.
+
+## Usage
+
+\`\`\`bash
+kspec task start @ref
+\`\`\`
+`);
+  });
+
+  afterEach(async () => {
+    await cleanupTempDir(tempDir);
+  });
+
+  // AC: @skill-cli ac-5
+  it('should display metadata including id, name, origin, and platforms', () => {
+    const output = kspec('skill get @task-work', tempDir);
+
+    expect(output).toContain('Task Work');
+    expect(output).toContain('ID:');
+    expect(output).toContain('task-work');
+    expect(output).toContain('Origin:');
+    expect(output).toContain('core');
+    expect(output).toContain('Platforms:');
+    expect(output).toContain('claude-code');
+    expect(output).toContain('Version:');
+    expect(output).toContain('0.1.0');
+  });
+
+  // AC: @skill-cli ac-6
+  it('should display SKILL.md content', () => {
+    const output = kspec('skill get @task-work', tempDir);
+
+    expect(output).toContain('SKILL.md Content');
+    expect(output).toContain('Use this skill when working on kspec tasks');
+    expect(output).toContain('kspec task start @ref');
+  });
+
+  it('should include all metadata in JSON output', () => {
+    const result = kspecJson<{
+      _ulid: string;
+      id: string;
+      name: string;
+      description: string;
+      origin: string;
+      version: string;
+      platforms: string[];
+      depends_on: string[];
+      tags: string[];
+      content: string;
+      docs: Array<{ name: string; path: string }>;
+    }>('skill get @task-work', tempDir);
+
+    expect(result.id).toBe('task-work');
+    expect(result.name).toBe('Task Work');
+    expect(result.description).toBe('Work on tasks');
+    expect(result.origin).toBe('core');
+    expect(result.version).toBe('0.1.0');
+    expect(result.platforms).toContain('claude-code');
+    expect(result.tags).toContain('workflow');
+    expect(result.content).toContain('Use this skill when working on kspec tasks');
+    expect(Array.isArray(result.docs)).toBe(true);
+  });
+
+  it('should find skill by ULID prefix', async () => {
+    // Get the skill's ULID first
+    const list = kspecJson<Array<{ _ulid: string; id: string }>>('skill list', tempDir);
+    const skill = list.find(s => s.id === 'task-work');
+    const ulidPrefix = skill?._ulid.slice(0, 8);
+
+    const output = kspec(`skill get @${ulidPrefix}`, tempDir);
+    expect(output).toContain('task-work');
+    expect(output).toContain('Task Work');
+  });
+
+  it('should return error when skill not found', () => {
+    const result = kspecFull('skill get @nonexistent', tempDir, { expectFail: true });
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain('not found');
+  });
+
+  it('should show (No SKILL.md content found) when file missing', async () => {
+    // Delete the SKILL.md file
+    const skillMdPath = path.join(tempDir, 'skills', 'task-work', 'SKILL.md');
+    await fs.unlink(skillMdPath);
+
+    const output = kspec('skill get @task-work', tempDir);
+    expect(output).toContain('No SKILL.md content found');
+  });
+});
+
+describe('Skill CLI - skill delete', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await setupTempFixtures();
+    await initGitRepo(tempDir);
+
+    // Create skills
+    kspec('skill add --id my-skill --name "My Skill"', tempDir);
+    kspec('skill add --id dependent-skill --name "Dependent Skill" --depends-on @my-skill', tempDir);
+  });
+
+  afterEach(async () => {
+    await cleanupTempDir(tempDir);
+  });
+
+  // AC: @skill-cli ac-7
+  it('should remove meta entry from manifest when --confirm provided', async () => {
+    // First create a skill that has no dependencies
+    kspec('skill add --id standalone-skill --name "Standalone Skill"', tempDir);
+
+    // Verify it exists
+    let list = kspecJson<Array<{ id: string }>>('skill list', tempDir);
+    expect(list.some(s => s.id === 'standalone-skill')).toBe(true);
+
+    // Delete it
+    kspec('skill delete @standalone-skill --confirm', tempDir);
+
+    // Verify it's gone
+    list = kspecJson<Array<{ id: string }>>('skill list', tempDir);
+    expect(list.some(s => s.id === 'standalone-skill')).toBe(false);
+  });
+
+  // AC: @skill-cli ac-8
+  it('should delete .kspec/skills/<id>/ directory', async () => {
+    // Create a standalone skill
+    kspec('skill add --id standalone-skill --name "Standalone Skill"', tempDir);
+
+    // Verify directory exists
+    const skillDir = path.join(tempDir, 'skills', 'standalone-skill');
+    let exists = await fs.access(skillDir).then(() => true).catch(() => false);
+    expect(exists).toBe(true);
+
+    // Delete the skill
+    kspec('skill delete @standalone-skill --confirm', tempDir);
+
+    // Verify directory is gone
+    exists = await fs.access(skillDir).then(() => true).catch(() => false);
+    expect(exists).toBe(false);
+  });
+
+  it('should require --confirm flag', () => {
+    const result = kspecFull('skill delete @my-skill', tempDir, { expectFail: true });
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain('--confirm');
+  });
+
+  it('should prevent deletion when other skills depend on it', () => {
+    const result = kspecFull('skill delete @my-skill --confirm', tempDir, { expectFail: true });
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain('referenced by');
+    expect(result.stderr).toContain('@dependent-skill');
+  });
+
+  it('should return error when skill not found', () => {
+    const result = kspecFull('skill delete @nonexistent --confirm', tempDir, { expectFail: true });
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain('not found');
+  });
+
+  it('should find skill by ULID prefix', async () => {
+    // Create a standalone skill and get its ULID
+    const createResult = kspecJson<{ _ulid: string; id: string }>(
+      'skill add --id temp-skill --name "Temp Skill"',
+      tempDir
+    );
+    // Use a longer prefix to ensure uniqueness (12 chars instead of 8)
+    const ulidPrefix = createResult._ulid.slice(0, 12);
+
+    // Delete by ULID prefix
+    const output = kspec(`skill delete @${ulidPrefix} --confirm`, tempDir);
+    expect(output).toContain('Deleted');
+
+    // Verify it's gone
+    const list = kspecJson<Array<{ id: string }>>('skill list', tempDir);
+    expect(list.some(s => s.id === 'temp-skill')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Add `kspec skill list` command with table display (ID, Name, Origin, Version, Platforms)
- Add `kspec skill add` command for creating skills with meta entry and SKILL.md file
- Add `kspec skill get` command to display skill metadata and content
- Add `kspec skill delete` command with confirmation and dependency checking
- Add origin/tag filtering for skill list
- Add 29 tests covering all 8 acceptance criteria

## Implementation Notes

- Changed `--version` to `--skill-version` to avoid conflict with CLI global `--version` flag
- Dependency checking prevents deletion of skills that other skills depend on

## Test plan

- [x] All 29 tests pass for skill CLI commands
- [x] All 95 skill-related tests pass
- [x] Build succeeds

Task: @implement-skill-cli-commands
Spec: @skill-cli

🤖 Generated with [Claude Code](https://claude.ai/code)