### PR TITLE
feat: add --content-file option to skill add command

### DIFF
--- a/src/cli/commands/skill.ts
+++ b/src/cli/commands/skill.ts
@@ -174,6 +174,7 @@ export function registerSkillCommands(program: Command): void {
     });
 
   // AC: @skill-cli ac-3, ac-4 - kspec skill add
+  // AC: @skill-add ac-3 - --content-file copies existing file to SKILL.md
   markMutating(skill.command("add"))
     .description("Create a new skill")
     .requiredOption("--id <id>", "Skill ID (kebab-case)")
@@ -188,6 +189,7 @@ export function registerSkillCommands(program: Command): void {
     .option("--platform <platform...>", "Target platforms")
     .option("--tag <tag...>", "Tags for the skill")
     .option("--depends-on <ref...>", "Skill dependencies")
+    .option("--content-file <path>", "Path to existing file to use as SKILL.md content")
     .action(async (options) => {
       try {
         const ctx = await initContext();
@@ -252,8 +254,28 @@ export function registerSkillCommands(program: Command): void {
         await saveMetaItem(ctx, skill, "skill");
 
         // AC: @skill-cli ac-4 - create SKILL.md with placeholder content
+        // AC: @skill-add ac-3 - if --content-file provided, copy its contents
         const skillMdPath = getSkillContentPath(ctx, skill.id);
-        const initialContent = `# ${skill.name}\n\n${skill.description || "Add skill content here."}\n`;
+        let initialContent: string;
+
+        if (options.contentFile) {
+          // Read content from the specified file
+          const contentFilePath = path.isAbsolute(options.contentFile)
+            ? options.contentFile
+            : path.resolve(process.cwd(), options.contentFile);
+
+          try {
+            initialContent = await fs.readFile(contentFilePath, "utf-8");
+          } catch (err) {
+            // Clean up: remove the skill we just created
+            await deleteMetaItem(ctx, skill._ulid, "skill");
+            error(`Failed to read content file: ${contentFilePath}`);
+            process.exit(EXIT_CODES.ERROR);
+          }
+        } else {
+          initialContent = `# ${skill.name}\n\n${skill.description || "Add skill content here."}\n`;
+        }
+
         await fs.writeFile(skillMdPath, initialContent, "utf-8");
 
         // Commit changes

--- a/tests/skill-cli.test.ts
+++ b/tests/skill-cli.test.ts
@@ -147,6 +147,7 @@ describe('Skill CLI - skill add', () => {
   });
 
   // AC: @skill-cli ac-3
+  // AC: @skill-add ac-1 - meta entry created
   it('should create meta entry with correct origin', () => {
     const result = kspecJson<{
       _ulid: string;
@@ -168,6 +169,19 @@ describe('Skill CLI - skill add', () => {
     );
 
     expect(result.origin).toBe('local');
+  });
+
+  // AC: @skill-add ac-4, ac-5 - origin and version set correctly
+  it('should set origin and version when --origin core --skill-version provided', () => {
+    const result = kspecJson<{ id: string; origin: string; version: string }>(
+      'skill add --id core-skill --name "Core Skill" --origin core --skill-version 0.2.0',
+      tempDir
+    );
+
+    // AC: @skill-add ac-4 - origin is core
+    expect(result.origin).toBe('core');
+    // AC: @skill-add ac-5 - version is 0.2.0
+    expect(result.version).toBe('0.2.0');
   });
 
   // AC: @skill-cli ac-4
@@ -246,6 +260,7 @@ describe('Skill CLI - skill add', () => {
     expect(result.depends_on).toContain('@base-skill');
   });
 
+  // AC: @skill-add ac-6 - duplicate ID error
   it('should reject duplicate skill ID', () => {
     kspec('skill add --id my-skill --name "My Skill"', tempDir);
 
@@ -264,6 +279,59 @@ describe('Skill CLI - skill add', () => {
     const result = kspecFull('skill add --id MySkill --name "My Skill"', tempDir, { expectFail: true });
     expect(result.exitCode).not.toBe(0);
     expect(result.stderr).toContain("kebab-case");
+  });
+
+  // AC: @skill-add ac-3 - --content-file copies file to SKILL.md
+  it('should copy content from --content-file to SKILL.md', async () => {
+    // Create a source file with custom content
+    const sourceContent = `# Custom Skill Content
+
+This content comes from an existing file.
+
+## Usage
+
+Use this skill for custom tasks.
+`;
+    const sourceFile = path.join(tempDir, 'custom-skill.md');
+    await fs.writeFile(sourceFile, sourceContent);
+
+    // Create skill with --content-file
+    kspec(`skill add --id custom-skill --name "Custom Skill" --content-file ${sourceFile}`, tempDir);
+
+    // Verify SKILL.md has the content from the source file
+    const skillMdPath = path.join(tempDir, 'skills', 'custom-skill', 'SKILL.md');
+    const content = await fs.readFile(skillMdPath, 'utf-8');
+    expect(content).toBe(sourceContent);
+    expect(content).toContain('Custom Skill Content');
+    expect(content).toContain('This content comes from an existing file');
+  });
+
+  // AC: @skill-add ac-3 - --content-file with relative path
+  it('should handle relative path for --content-file', async () => {
+    // Create a source file with custom content
+    const sourceContent = '# Relative Path Skill\n\nContent from relative path.\n';
+    const sourceFile = path.join(tempDir, 'relative-source.md');
+    await fs.writeFile(sourceFile, sourceContent);
+
+    // Run kspec from tempDir so relative path works
+    // Note: kspec already runs from tempDir
+    kspec('skill add --id rel-skill --name "Relative Skill" --content-file relative-source.md', tempDir);
+
+    // Verify SKILL.md has the content
+    const skillMdPath = path.join(tempDir, 'skills', 'rel-skill', 'SKILL.md');
+    const content = await fs.readFile(skillMdPath, 'utf-8');
+    expect(content).toBe(sourceContent);
+  });
+
+  // AC: @skill-add ac-3 - error when content file doesn't exist
+  it('should error when --content-file does not exist', () => {
+    const result = kspecFull(
+      'skill add --id bad-skill --name "Bad Skill" --content-file /nonexistent/file.md',
+      tempDir,
+      { expectFail: true }
+    );
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain('Failed to read content file');
   });
 });
 


### PR DESCRIPTION
## Summary

- Implements the `--content-file` option for `kspec skill add` command
- When provided, reads the file and copies contents to `.kspec/skills/<id>/SKILL.md`
- Supports both absolute and relative file paths
- Returns error if content file doesn't exist

## Acceptance Criteria Coverage

All 6 ACs from @skill-add spec are covered:
- ac-1: Meta entry created ✅
- ac-2: Shadow commit ✅ 
- ac-3: --content-file copies file ✅ (new)
- ac-4: Origin set correctly ✅
- ac-5: Version set correctly ✅
- ac-6: Duplicate ID error ✅

## Test plan

- [x] Run skill-cli tests: `npm test -- tests/skill-cli.test.ts`
- [x] Verify --content-file copies content from existing file
- [x] Verify relative paths work
- [x] Verify error on missing file
- [x] Verify origin and version set together

🤖 Generated with [Claude Code](https://claude.com/claude-code)