### PR TITLE
feat: implement skill set command for metadata updates

### DIFF
--- a/src/cli/commands/skill.ts
+++ b/src/cli/commands/skill.ts
@@ -347,6 +347,145 @@ export function registerSkillCommands(program: Command): void {
       }
     });
 
+  // AC: @skill-set ac-1, ac-2, ac-3 - kspec skill set
+  markMutating(skill.command("set <ref>"))
+    .description("Update skill metadata fields")
+    .option("--name <name>", "Update skill name")
+    .option("--description <desc>", "Update skill description")
+    .option("--origin <origin>", "Update skill origin (core, project, local)")
+    .option("--skill-version <version>", "Update skill version")
+    .option("--add-platform <platform>", "Add a platform to the platforms array")
+    .option("--remove-platform <platform>", "Remove a platform from the platforms array")
+    .option("--add-tag <tag>", "Add a tag to the tags array")
+    .option("--remove-tag <tag>", "Remove a tag from the tags array")
+    .option("--add-depends-on <ref>", "Add a dependency reference")
+    .option("--remove-depends-on <ref>", "Remove a dependency reference")
+    .action(async (ref: string, options) => {
+      try {
+        const ctx = await initContext();
+
+        if (!ctx.manifestPath) {
+          error(errors.project.noKspecProject);
+          process.exit(EXIT_CODES.ERROR);
+        }
+
+        const metaCtx = await loadMetaContext(ctx);
+        const item = findMetaItemByRef(metaCtx, ref);
+
+        if (!item) {
+          error(`Skill not found: ${ref}`);
+          console.log(chalk.gray("Try: kspec skill list"));
+          process.exit(EXIT_CODES.NOT_FOUND);
+        }
+
+        // Check it's a skill
+        if (!("origin" in item)) {
+          error(`Item ${ref} is not a skill`);
+          process.exit(EXIT_CODES.ERROR);
+        }
+
+        const skill = item as LoadedSkill;
+
+        // AC: @skill-set ac-1 - update description field
+        if (options.name !== undefined) {
+          skill.name = options.name;
+        }
+
+        if (options.description !== undefined) {
+          skill.description = options.description;
+        }
+
+        // Update origin
+        if (options.origin !== undefined) {
+          const validOrigins: SkillOrigin[] = ["core", "project", "local"];
+          if (!validOrigins.includes(options.origin as SkillOrigin)) {
+            error(
+              `Invalid origin: ${options.origin}. Valid origins: ${validOrigins.join(", ")}`,
+            );
+            process.exit(EXIT_CODES.ERROR);
+          }
+          skill.origin = options.origin as SkillOrigin;
+        }
+
+        // Update version
+        if (options.skillVersion !== undefined) {
+          skill.version = options.skillVersion;
+        }
+
+        // AC: @skill-set ac-2 - add platform to array
+        if (options.addPlatform) {
+          if (!skill.platforms.includes(options.addPlatform)) {
+            skill.platforms.push(options.addPlatform);
+          }
+        }
+
+        // Remove platform
+        if (options.removePlatform) {
+          const idx = skill.platforms.indexOf(options.removePlatform);
+          if (idx >= 0) {
+            skill.platforms.splice(idx, 1);
+          }
+        }
+
+        // AC: @skill-set ac-3 - add tag to array
+        if (options.addTag) {
+          if (!skill.tags) {
+            skill.tags = [];
+          }
+          if (!skill.tags.includes(options.addTag)) {
+            skill.tags.push(options.addTag);
+          }
+        }
+
+        // Remove tag
+        if (options.removeTag && skill.tags) {
+          const idx = skill.tags.indexOf(options.removeTag);
+          if (idx >= 0) {
+            skill.tags.splice(idx, 1);
+          }
+        }
+
+        // Add dependency
+        if (options.addDependsOn) {
+          if (!skill.depends_on) {
+            skill.depends_on = [];
+          }
+          if (!skill.depends_on.includes(options.addDependsOn)) {
+            skill.depends_on.push(options.addDependsOn);
+          }
+        }
+
+        // Remove dependency
+        if (options.removeDependsOn && skill.depends_on) {
+          const idx = skill.depends_on.indexOf(options.removeDependsOn);
+          if (idx >= 0) {
+            skill.depends_on.splice(idx, 1);
+          }
+        }
+
+        // Validate updated skill
+        const parsed = SkillSchema.safeParse(skill);
+        if (!parsed.success) {
+          const issues = parsed.error.issues
+            .map((i) => `${i.path.join(".")}: ${i.message}`)
+            .join("; ");
+          error(`Invalid skill data: ${issues}`);
+          process.exit(EXIT_CODES.VALIDATION_FAILED);
+        }
+
+        // Save the updated skill
+        await saveMetaItem(ctx, skill, "skill");
+
+        // Commit changes
+        await commitIfShadow(ctx.shadow, "skill-set", skill.id, skill.name);
+
+        output(skill, () => success(`Updated skill: ${skill.id}`));
+      } catch (err) {
+        error("Failed to update skill", err);
+        process.exit(EXIT_CODES.ERROR);
+      }
+    });
+
   // AC: @skill-cli ac-7, ac-8 - kspec skill delete
   markMutating(skill.command("delete <ref>"))
     .description("Delete a skill")

--- a/tests/skill-cli.test.ts
+++ b/tests/skill-cli.test.ts
@@ -532,3 +532,204 @@ describe('Skill CLI - skill delete', () => {
     expect(list.some(s => s.id === 'temp-skill')).toBe(false);
   });
 });
+
+describe('Skill CLI - skill set', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await setupTempFixtures();
+    await initGitRepo(tempDir);
+
+    // Create a skill to update
+    const result = kspecFull(
+      'skill add --id my-skill --name "My Skill" --description "Original description" --origin project --skill-version 0.1.0',
+      tempDir
+    );
+    if (result.exitCode !== 0) throw new Error(`skill add failed: ${result.stderr}`);
+  });
+
+  afterEach(async () => {
+    await cleanupTempDir(tempDir);
+  });
+
+  // AC: @skill-set ac-1
+  it('should update description field in meta', () => {
+    kspec('skill set @my-skill --description "New description"', tempDir);
+
+    const result = kspecJson<{ id: string; description: string }>('skill get @my-skill', tempDir);
+    expect(result.description).toBe('New description');
+  });
+
+  // AC: @skill-set ac-1 - verify original description replaced
+  it('should replace original description completely', async () => {
+    kspec('skill set @my-skill --description "Completely new"', tempDir);
+
+    // Also verify in manifest
+    const metaPath = path.join(tempDir, 'kynetic.meta.yaml');
+    const metaContent = await fs.readFile(metaPath, 'utf-8');
+    const meta = yamlParse(metaContent);
+
+    const skill = meta.skills.find((s: { id: string }) => s.id === 'my-skill');
+    expect(skill.description).toBe('Completely new');
+    expect(skill.description).not.toContain('Original');
+  });
+
+  // AC: @skill-set ac-2
+  it('should add platform to platforms array', () => {
+    kspec('skill set @my-skill --add-platform codex', tempDir);
+
+    const result = kspecJson<{ platforms: string[] }>('skill get @my-skill', tempDir);
+    expect(result.platforms).toContain('codex');
+    expect(result.platforms).toContain('claude-code'); // Original still there
+  });
+
+  // AC: @skill-set ac-2 - multiple platforms
+  it('should allow adding multiple platforms sequentially', () => {
+    kspec('skill set @my-skill --add-platform codex', tempDir);
+    kspec('skill set @my-skill --add-platform cursor', tempDir);
+
+    const result = kspecJson<{ platforms: string[] }>('skill get @my-skill', tempDir);
+    expect(result.platforms).toContain('claude-code');
+    expect(result.platforms).toContain('codex');
+    expect(result.platforms).toContain('cursor');
+  });
+
+  // AC: @skill-set ac-2 - no duplicates
+  it('should not add duplicate platform', () => {
+    // Default platform is claude-code
+    kspec('skill set @my-skill --add-platform claude-code', tempDir);
+
+    const result = kspecJson<{ platforms: string[] }>('skill get @my-skill', tempDir);
+    const claudeCodeCount = result.platforms.filter(p => p === 'claude-code').length;
+    expect(claudeCodeCount).toBe(1);
+  });
+
+  // AC: @skill-set ac-3
+  it('should add tag to tags array', () => {
+    kspec('skill set @my-skill --add-tag automation', tempDir);
+
+    const result = kspecJson<{ tags: string[] }>('skill get @my-skill', tempDir);
+    expect(result.tags).toContain('automation');
+  });
+
+  // AC: @skill-set ac-3 - multiple tags
+  it('should allow adding multiple tags sequentially', () => {
+    kspec('skill set @my-skill --add-tag automation', tempDir);
+    kspec('skill set @my-skill --add-tag workflow', tempDir);
+
+    const result = kspecJson<{ tags: string[] }>('skill get @my-skill', tempDir);
+    expect(result.tags).toContain('automation');
+    expect(result.tags).toContain('workflow');
+  });
+
+  // AC: @skill-set ac-3 - no duplicates
+  it('should not add duplicate tag', () => {
+    kspec('skill set @my-skill --add-tag test', tempDir);
+    kspec('skill set @my-skill --add-tag test', tempDir);
+
+    const result = kspecJson<{ tags: string[] }>('skill get @my-skill', tempDir);
+    const testCount = result.tags.filter(t => t === 'test').length;
+    expect(testCount).toBe(1);
+  });
+
+  it('should update name field', () => {
+    kspec('skill set @my-skill --name "Updated Name"', tempDir);
+
+    const result = kspecJson<{ name: string }>('skill get @my-skill', tempDir);
+    expect(result.name).toBe('Updated Name');
+  });
+
+  it('should update origin field', () => {
+    kspec('skill set @my-skill --origin core', tempDir);
+
+    const result = kspecJson<{ origin: string }>('skill get @my-skill', tempDir);
+    expect(result.origin).toBe('core');
+  });
+
+  it('should reject invalid origin', () => {
+    const result = kspecFull('skill set @my-skill --origin invalid', tempDir, { expectFail: true });
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain('Invalid origin');
+  });
+
+  it('should update version field', () => {
+    kspec('skill set @my-skill --skill-version 0.2.0', tempDir);
+
+    const result = kspecJson<{ version: string }>('skill get @my-skill', tempDir);
+    expect(result.version).toBe('0.2.0');
+  });
+
+  it('should remove platform from array', () => {
+    // Add another platform first
+    kspec('skill set @my-skill --add-platform codex', tempDir);
+
+    // Now remove it
+    kspec('skill set @my-skill --remove-platform codex', tempDir);
+
+    const result = kspecJson<{ platforms: string[] }>('skill get @my-skill', tempDir);
+    expect(result.platforms).not.toContain('codex');
+    expect(result.platforms).toContain('claude-code'); // Original still there
+  });
+
+  it('should remove tag from array', () => {
+    // Add a tag first
+    kspec('skill set @my-skill --add-tag workflow', tempDir);
+
+    // Now remove it
+    kspec('skill set @my-skill --remove-tag workflow', tempDir);
+
+    const result = kspecJson<{ tags: string[] }>('skill get @my-skill', tempDir);
+    expect(result.tags).not.toContain('workflow');
+  });
+
+  it('should add dependency reference', () => {
+    // Create another skill
+    kspec('skill add --id base-skill --name "Base Skill"', tempDir);
+
+    // Add dependency
+    kspec('skill set @my-skill --add-depends-on @base-skill', tempDir);
+
+    const result = kspecJson<{ depends_on: string[] }>('skill get @my-skill', tempDir);
+    expect(result.depends_on).toContain('@base-skill');
+  });
+
+  it('should remove dependency reference', () => {
+    // Create another skill
+    kspec('skill add --id base-skill --name "Base Skill"', tempDir);
+
+    // Add and then remove dependency
+    kspec('skill set @my-skill --add-depends-on @base-skill', tempDir);
+    kspec('skill set @my-skill --remove-depends-on @base-skill', tempDir);
+
+    const result = kspecJson<{ depends_on: string[] }>('skill get @my-skill', tempDir);
+    expect(result.depends_on).not.toContain('@base-skill');
+  });
+
+  it('should find skill by ULID prefix', () => {
+    // Get the skill's ULID first
+    const list = kspecJson<Array<{ _ulid: string; id: string }>>('skill list', tempDir);
+    const skill = list.find(s => s.id === 'my-skill');
+    const ulidPrefix = skill?._ulid.slice(0, 8);
+
+    kspec(`skill set @${ulidPrefix} --description "Updated via ULID"`, tempDir);
+
+    const result = kspecJson<{ description: string }>('skill get @my-skill', tempDir);
+    expect(result.description).toBe('Updated via ULID');
+  });
+
+  it('should return error when skill not found', () => {
+    const result = kspecFull('skill set @nonexistent --description "Test"', tempDir, { expectFail: true });
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain('not found');
+  });
+
+  it('should output updated skill in JSON mode', () => {
+    const result = kspecJson<{ id: string; description: string }>(
+      'skill set @my-skill --description "JSON test"',
+      tempDir
+    );
+
+    expect(result.id).toBe('my-skill');
+    expect(result.description).toBe('JSON test');
+  });
+});


### PR DESCRIPTION
## Summary

- Implement `kspec skill set` command to update skill metadata fields
- ac-1: `--description` updates description field in meta
- ac-2: `--add-platform` adds platform to platforms array (no duplicates)
- ac-3: `--add-tag` adds tag to tags array (no duplicates)

Additional options for complete metadata management:
- `--name`, `--origin`, `--skill-version` for basic fields
- `--remove-platform`, `--remove-tag` for array removals
- `--add-depends-on`, `--remove-depends-on` for dependencies

## Test plan

- [x] 19 tests added covering all acceptance criteria
- [x] All 52 skill CLI tests pass
- [x] Full test suite passes (2366 tests, 1 pre-existing bun build failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)