### PR TITLE
feat: integrate skills into kspec meta commands

### DIFF
--- a/src/cli/commands/meta.ts
+++ b/src/cli/commands/meta.ts
@@ -54,14 +54,15 @@ import { parseIntOption } from "../validators.js";
 
 /**
  * Resolve a meta reference to its ULID
- * Handles semantic IDs (agent.id, workflow.id, convention.domain) and ULID prefixes
+ * Handles semantic IDs (agent.id, workflow.id, skill.id, convention.domain) and ULID prefixes
+ * AC: @skill-meta-integration ac-4 - skills included in resolution
  */
 function resolveMetaRefToUlid(
   ref: string,
   metaCtx: MetaContext,
 ): {
   ulid: string;
-  type: "agent" | "workflow" | "convention" | "observation";
+  type: "agent" | "workflow" | "convention" | "observation" | "skill";
 } | null {
   const normalizedRef = ref.startsWith("@") ? ref.substring(1) : ref;
 
@@ -89,6 +90,12 @@ function resolveMetaRefToUlid(
   );
   if (observation) return { ulid: observation._ulid, type: "observation" };
 
+  // AC: @skill-meta-integration ac-4 - Check skills
+  const skill = (metaCtx.skills || []).find(
+    (s) => s.id === normalizedRef || s._ulid.startsWith(normalizedRef),
+  );
+  if (skill) return { ulid: skill._ulid, type: "skill" };
+
   return null;
 }
 
@@ -115,6 +122,7 @@ function resolveObservationRefForBatch(
 
 /**
  * Format meta show output
+ * AC: @skill-meta-integration ac-3 - skill count included in summary
  */
 function formatMetaShow(meta: MetaContext): void {
   const stats = getMetaStats(meta);
@@ -123,7 +131,7 @@ function formatMetaShow(meta: MetaContext): void {
     console.log(chalk.yellow("No meta manifest found (kynetic.meta.yaml)"));
     console.log(
       chalk.gray(
-        "Create one to define agents, workflows, conventions, and observations",
+        "Create one to define agents, workflows, conventions, observations, and skills",
       ),
     );
     return;
@@ -137,6 +145,8 @@ function formatMetaShow(meta: MetaContext): void {
   console.log(
     `Observations: ${stats.observations} (${stats.unresolvedObservations} unresolved)`,
   );
+  // AC: @skill-meta-integration ac-3 - include skill count
+  console.log(`Skills:       ${stats.skills}`);
 }
 
 /**
@@ -570,10 +580,11 @@ export function registerMetaCommands(program: Command): void {
     });
 
   // meta-get-cmd: kspec meta get <ref>
+  // AC: @skill-meta-integration ac-1 - skills can be retrieved by id
   meta
     .command("get <ref>")
     .description(
-      "Get a meta item by reference (agent, workflow, convention, or observation)",
+      "Get a meta item by reference (agent, workflow, convention, observation, or skill)",
     )
     .action(async (ref: string) => {
       try {
@@ -594,6 +605,7 @@ export function registerMetaCommands(program: Command): void {
         const workflows = metaCtx.workflows || [];
         const conventions = metaCtx.conventions || [];
         const observations = metaCtx.observations || [];
+        const skills = metaCtx.skills || [];
 
         // Try to find by ID or ULID prefix
         let found: any = null;
@@ -642,6 +654,17 @@ export function registerMetaCommands(program: Command): void {
           }
         }
 
+        // AC: @skill-meta-integration ac-1 - Check skills (by id or ULID)
+        if (!found) {
+          const skill = skills.find(
+            (s) => s.id === normalizedRef || s._ulid.startsWith(normalizedRef),
+          );
+          if (skill) {
+            found = skill;
+            itemType = "skill";
+          }
+        }
+
         if (!found) {
           error(errors.reference.metaNotFound(ref));
           process.exit(EXIT_CODES.ERROR);
@@ -664,12 +687,13 @@ export function registerMetaCommands(program: Command): void {
     });
 
   // meta-list-cmd: kspec meta list
+  // AC: @skill-meta-integration ac-2 - skills can be filtered with --type skill
   meta
     .command("list")
     .description("List all meta items")
     .option(
       "--type <type>",
-      "Filter by type (agent, workflow, convention, observation)",
+      "Filter by type (agent, workflow, convention, observation, skill)",
     )
     .action(async (options) => {
       try {
@@ -737,6 +761,18 @@ export function registerMetaCommands(program: Command): void {
               type: "observation",
               context: `${observation.type} ${observation.resolved ? "(resolved)" : ""}`,
               ulid: observation._ulid,
+            });
+          }
+        }
+
+        // AC: @skill-meta-integration ac-2 - Add skills
+        if (!options.type || options.type === "skill") {
+          for (const skill of metaCtx.skills || []) {
+            items.push({
+              id: skill.id,
+              type: "skill",
+              context: skill.name || skill.description || skill.origin,
+              ulid: skill._ulid,
             });
           }
         }

--- a/tests/skill-meta-integration.test.ts
+++ b/tests/skill-meta-integration.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Tests for Skill Meta Integration
+ * AC: @skill-meta-integration ac-1 through ac-4
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { stringify as yamlStringify } from 'yaml';
+import {
+  kspecOutput as kspec,
+  kspecJson,
+  kspec as kspecFull,
+  setupTempFixtures,
+  cleanupTempDir,
+  initGitRepo,
+  testUlid,
+} from './helpers/cli';
+
+describe('Skill Meta Integration', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await setupTempFixtures();
+    await initGitRepo(tempDir);
+
+    // Create skills via kspec skill add
+    const result1 = kspecFull(
+      'skill add --id task-work --name "Task Work" --description "Work on tasks" --origin core --skill-version 0.1.0',
+      tempDir
+    );
+    const result2 = kspecFull(
+      'skill add --id pr-review --name "PR Review" --origin project --tag workflow',
+      tempDir
+    );
+    if (result1.exitCode !== 0) throw new Error(`skill add failed: ${result1.stderr}`);
+    if (result2.exitCode !== 0) throw new Error(`skill add failed: ${result2.stderr}`);
+  });
+
+  afterEach(async () => {
+    await cleanupTempDir(tempDir);
+  });
+
+  describe('kspec meta get for skills', () => {
+    // AC: @skill-meta-integration ac-1
+    it('should return skill metadata when kspec meta get @skill-id is run', () => {
+      const result = kspecJson<{
+        _ulid: string;
+        id: string;
+        name: string;
+        origin: string;
+      }>('meta get @task-work', tempDir);
+
+      expect(result).toBeDefined();
+      expect(result.id).toBe('task-work');
+      expect(result.name).toBe('Task Work');
+      expect(result.origin).toBe('core');
+    });
+
+    // AC: @skill-meta-integration ac-1 - using ULID prefix
+    it('should return skill metadata by ULID prefix', () => {
+      // First get the skill list to find its ULID
+      const skills = kspecJson<Array<{ _ulid: string; id: string }>>('skill list', tempDir);
+      const taskWorkSkill = skills.find(s => s.id === 'task-work');
+      expect(taskWorkSkill).toBeDefined();
+
+      // Get by ULID prefix (first 8 chars)
+      const ulidPrefix = taskWorkSkill!._ulid.slice(0, 8);
+      const result = kspecJson<{
+        id: string;
+        name: string;
+      }>(`meta get @${ulidPrefix}`, tempDir);
+
+      expect(result).toBeDefined();
+      expect(result.id).toBe('task-work');
+    });
+
+    // AC: @skill-meta-integration ac-1 - human-readable output
+    it('should display skill type and reference in human-readable output', () => {
+      const output = kspec('meta get task-work', tempDir);
+
+      expect(output).toContain('Skill: task-work');
+      expect(output).toContain('task-work');
+    });
+  });
+
+  describe('kspec meta list --type skill', () => {
+    // AC: @skill-meta-integration ac-2
+    it('should show only skills when --type skill is used', () => {
+      const output = kspec('meta list --type skill', tempDir);
+
+      // Should show skills
+      expect(output).toContain('task-work');
+      expect(output).toContain('pr-review');
+      expect(output).toContain('skill');
+
+      // Verify these are the only meta items shown (no agents, workflows, etc.)
+      expect(output).not.toContain('agent');
+      expect(output).not.toContain('workflow');
+      expect(output).not.toContain('convention');
+      expect(output).not.toContain('observation');
+    });
+
+    // AC: @skill-meta-integration ac-2 - JSON output
+    it('should return only skills in JSON when --type skill is used', () => {
+      const result = kspecJson<Array<{ id: string; type: string }>>('meta list --type skill', tempDir);
+
+      expect(Array.isArray(result)).toBe(true);
+      expect(result.length).toBe(2);
+      expect(result.every(item => item.type === 'skill')).toBe(true);
+
+      const ids = result.map(item => item.id);
+      expect(ids).toContain('task-work');
+      expect(ids).toContain('pr-review');
+    });
+
+    // AC: @skill-meta-integration ac-2 - skills included in full listing
+    it('should include skills when listing all meta items', () => {
+      const result = kspecJson<Array<{ id: string; type: string }>>('meta list', tempDir);
+
+      const skills = result.filter(item => item.type === 'skill');
+      expect(skills.length).toBe(2);
+    });
+  });
+
+  describe('kspec meta show skill count', () => {
+    // AC: @skill-meta-integration ac-3
+    it('should include skill count in meta show summary', () => {
+      const output = kspec('meta show', tempDir);
+
+      // Should include skill count
+      expect(output).toContain('Skills:');
+      expect(output).toMatch(/Skills:\s*2/);
+    });
+
+    // AC: @skill-meta-integration ac-3 - with no skills
+    it('should show 0 skills when none exist', async () => {
+      // Create a new temp dir without skills
+      const emptyDir = await setupTempFixtures();
+      await initGitRepo(emptyDir);
+
+      // Ensure .kspec directory exists and create empty meta manifest
+      await fs.mkdir(path.join(emptyDir, '.kspec'), { recursive: true });
+      await fs.writeFile(
+        path.join(emptyDir, '.kspec', 'kynetic.meta.yaml'),
+        yamlStringify({ kynetic_meta: '1.0', skills: [] })
+      );
+
+      try {
+        const output = kspec('meta show', emptyDir);
+        expect(output).toContain('Skills:');
+        expect(output).toMatch(/Skills:\s*0/);
+      } finally {
+        await cleanupTempDir(emptyDir);
+      }
+    });
+
+    // AC: @skill-meta-integration ac-3 - JSON output includes skills
+    it('should include skill count in JSON output', () => {
+      const result = kspecJson<{ stats: { skills: number } }>('meta show', tempDir);
+
+      expect(result.stats).toBeDefined();
+      expect(result.stats.skills).toBe(2);
+    });
+  });
+
+  describe('resolveMetaRefToUlid for skills', () => {
+    // AC: @skill-meta-integration ac-4 - indirect test via meta delete
+    it('should resolve skill id when checking references', async () => {
+      // Create an agent that would reference a skill (if supported)
+      // For now, we test that the skill can be found by ref in meta get
+
+      // Get skill ULID via list
+      const skills = kspecJson<Array<{ _ulid: string; id: string }>>('skill list', tempDir);
+      const skill = skills.find(s => s.id === 'task-work');
+      expect(skill).toBeDefined();
+
+      // Try to get by both id and ULID - this exercises resolveMetaRefToUlid
+      const byId = kspecJson<{ _ulid: string }>('meta get task-work', tempDir);
+      const byUlid = kspecJson<{ _ulid: string }>(`meta get ${skill!._ulid}`, tempDir);
+
+      expect(byId._ulid).toBe(skill!._ulid);
+      expect(byUlid._ulid).toBe(skill!._ulid);
+    });
+
+    // AC: @skill-meta-integration ac-4 - skill ULID is returned correctly
+    it('should return skill ULID when resolving by id', () => {
+      const skills = kspecJson<Array<{ _ulid: string; id: string }>>('skill list', tempDir);
+      const prReview = skills.find(s => s.id === 'pr-review');
+      expect(prReview).toBeDefined();
+
+      const result = kspecJson<{ _ulid: string; id: string }>('meta get @pr-review', tempDir);
+      expect(result._ulid).toBe(prReview!._ulid);
+    });
+
+    // AC: @skill-meta-integration ac-4 - skill ULID prefix resolution
+    it('should return skill when resolved by ULID prefix', () => {
+      const skills = kspecJson<Array<{ _ulid: string; id: string }>>('skill list', tempDir);
+      const taskWork = skills.find(s => s.id === 'task-work');
+      expect(taskWork).toBeDefined();
+
+      // Use 10-char prefix
+      const prefix = taskWork!._ulid.slice(0, 10);
+      const result = kspecJson<{ _ulid: string; id: string }>(`meta get @${prefix}`, tempDir);
+      expect(result.id).toBe('task-work');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Update `kspec meta get @skill-id` to return skill metadata (by id or ULID prefix)
- Update `kspec meta list --type skill` to filter and show only skills
- Update `kspec meta show` to include skill count in summary
- Update `resolveMetaRefToUlid` to include skills in reference resolution

## Test plan

- [x] All 12 new tests in `skill-meta-integration.test.ts` pass
- [x] Full test suite passes (2394 passing, pre-existing daemon-executable failure)
- [x] `kspec meta get @skill-id` returns skill metadata
- [x] `kspec meta list --type skill` shows only skills
- [x] `kspec meta show` displays skill count

Task: @implement-skill-meta-integration
Spec: @skill-meta-integration

🤖 Generated with [Claude Code](https://claude.ai/code)