### PR TITLE
feat: implement skill rendering pipeline for kspec

### DIFF
--- a/src/cli/commands/skill.ts
+++ b/src/cli/commands/skill.ts
@@ -24,6 +24,7 @@ import {
   findMetaItemByRef,
   getSkillContentPath,
   initContext,
+  type KspecContext,
   loadMetaContext,
   loadSkillContent,
   loadSkillDocs,
@@ -699,6 +700,197 @@ export function registerSkillCommands(program: Command): void {
         process.exit(EXIT_CODES.ERROR);
       }
     });
+
+  // AC: @skill-rendering ac-1 through ac-5 - kspec skill render
+  // AC: @trait-dry-run - supports --dry-run
+  // AC: @trait-error-guidance - provides error guidance
+  skill
+    .command("render")
+    .description(
+      "Render skills from shadow branch to platform-specific files on main branch"
+    )
+    .option("--clean", "Remove orphaned managed skill directories")
+    .option("--dry-run", "Show what would be changed without applying")
+    .option("--skill <id>", "Render only a specific skill")
+    .action(async (options) => {
+      try {
+        const ctx = await initContext();
+
+        if (!ctx.manifestPath) {
+          error(errors.project.noKspecProject);
+          console.log(
+            chalk.gray("Try: kspec init to initialize a kspec project")
+          );
+          process.exit(EXIT_CODES.ERROR);
+        }
+
+        const metaCtx = await loadMetaContext(ctx);
+        // Use rootDir (project root), not specDir (which is .kspec/ in shadow mode)
+        const projectRoot = ctx.rootDir;
+        const dryRun = options.dryRun || false;
+        const results: SkillRenderResult[] = [];
+        const cleanResults: CleanResult[] = [];
+
+        // Filter skills by platform (only claude-code for now)
+        let skillsToRender = metaCtx.skills.filter((s) =>
+          s.platforms.includes("claude-code")
+        );
+
+        // Filter to specific skill if requested
+        if (options.skill) {
+          skillsToRender = skillsToRender.filter(
+            (s) => s.id === options.skill
+          );
+          if (skillsToRender.length === 0) {
+            error(`Skill not found: ${options.skill}`);
+            console.log(chalk.gray("Try: kspec skill list"));
+            process.exit(EXIT_CODES.NOT_FOUND);
+          }
+        }
+
+        // Ensure .claude/skills directory exists
+        const targetSkillsDir = path.join(projectRoot, ".claude", "skills");
+        if (!dryRun) {
+          await fs.mkdir(targetSkillsDir, { recursive: true });
+        }
+
+        // Render each skill
+        for (const skill of skillsToRender) {
+          const result = await renderSkill(ctx, projectRoot, skill, dryRun);
+          results.push(result);
+        }
+
+        // Handle --clean: remove orphaned managed skills
+        // AC: @skill-rendering ac-4, ac-5
+        if (options.clean) {
+          const activeSkillIds = new Set(metaCtx.skills.map((s) => s.id));
+
+          try {
+            const entries = await fs.readdir(targetSkillsDir, {
+              withFileTypes: true,
+            });
+
+            for (const entry of entries) {
+              if (!entry.isDirectory()) continue;
+
+              const skillId = entry.name;
+              const skillDir = path.join(targetSkillsDir, skillId);
+              const skillMdPath = path.join(skillDir, "SKILL.md");
+
+              // Skip if skill still exists in meta
+              if (activeSkillIds.has(skillId)) continue;
+
+              // AC: @skill-rendering ac-4 - Only consider kspec-managed skills
+              const isManaged = await isKspecManaged(skillMdPath);
+
+              if (isManaged) {
+                // AC: @skill-rendering ac-5 - Remove orphaned directory
+                if (!dryRun) {
+                  await fs.rm(skillDir, { recursive: true, force: true });
+                }
+                cleanResults.push({
+                  id: skillId,
+                  path: skillDir,
+                  action: "removed",
+                });
+              } else {
+                cleanResults.push({
+                  id: skillId,
+                  path: skillDir,
+                  action: "skipped",
+                  reason: "Not managed by kspec",
+                });
+              }
+            }
+          } catch {
+            // No .claude/skills directory, nothing to clean
+          }
+        }
+
+        // Output results
+        // AC: @trait-dry-run ac-6 - JSON output includes dry_run field
+        output(
+          {
+            dry_run: dryRun,
+            rendered: results,
+            cleaned: cleanResults,
+          },
+          () => {
+            // AC: @trait-dry-run ac-3 - Clear indication this is a preview
+            if (dryRun) {
+              console.log(chalk.yellow("DRY RUN - No changes made"));
+              console.log();
+            }
+
+            // Render results
+            const created = results.filter((r) => r.action === "created");
+            const updated = results.filter((r) => r.action === "updated");
+            const unchanged = results.filter((r) => r.action === "unchanged");
+
+            if (created.length > 0) {
+              console.log(chalk.green(`Created: ${created.length} skill(s)`));
+              for (const r of created) {
+                console.log(`  ${chalk.green("+")} ${r.id}`);
+              }
+            }
+
+            if (updated.length > 0) {
+              console.log(chalk.blue(`Updated: ${updated.length} skill(s)`));
+              for (const r of updated) {
+                console.log(`  ${chalk.blue("~")} ${r.id}`);
+              }
+            }
+
+            if (unchanged.length > 0 && results.length <= 10) {
+              console.log(chalk.gray(`Unchanged: ${unchanged.length} skill(s)`));
+            }
+
+            // Clean results
+            if (cleanResults.length > 0) {
+              const removed = cleanResults.filter((r) => r.action === "removed");
+              const skipped = cleanResults.filter((r) => r.action === "skipped");
+
+              if (removed.length > 0) {
+                console.log();
+                console.log(chalk.red(`Removed: ${removed.length} orphaned skill(s)`));
+                for (const r of removed) {
+                  console.log(`  ${chalk.red("-")} ${r.id}`);
+                }
+              }
+
+              if (skipped.length > 0) {
+                console.log(
+                  chalk.gray(`Skipped: ${skipped.length} unmanaged skill(s)`)
+                );
+              }
+            }
+
+            // Summary
+            console.log();
+            if (dryRun) {
+              console.log(
+                chalk.yellow("No changes were made. Run without --dry-run to apply.")
+              );
+            } else {
+              const changedCount = created.length + updated.length;
+              const cleanedCount = cleanResults.filter(
+                (r) => r.action === "removed"
+              ).length;
+              if (changedCount > 0 || cleanedCount > 0) {
+                success(
+                  `Rendered ${changedCount} skill(s)${cleanedCount > 0 ? `, cleaned ${cleanedCount}` : ""}`
+                );
+              } else {
+                console.log(chalk.gray("No changes needed"));
+              }
+            }
+          }
+        );
+      } catch (err) {
+        error("Failed to render skills", err);
+        process.exit(EXIT_CODES.ERROR);
+      }
+    });
 }
 
 /**
@@ -763,3 +955,240 @@ async function copyDirectory(src: string, dest: string): Promise<void> {
     }
   }
 }
+
+/**
+ * Marker comment that identifies skill directories managed by kspec
+ * AC: @skill-rendering ac-4 - Only skill directories that were rendered by kspec are considered
+ */
+const KSPEC_MANAGED_MARKER = "<!-- kspec-managed -->";
+
+/**
+ * Result of rendering a single skill
+ */
+interface SkillRenderResult {
+  id: string;
+  action: "created" | "updated" | "unchanged";
+  path: string;
+  docsAction?: "created" | "updated" | "unchanged" | "skipped";
+}
+
+/**
+ * Result of a clean operation
+ */
+interface CleanResult {
+  id: string;
+  path: string;
+  action: "removed" | "skipped";
+  reason?: string;
+}
+
+/**
+ * Generate YAML frontmatter for a skill
+ * AC: @skill-rendering ac-1 - .claude/skills/<id>/SKILL.md is created with YAML frontmatter
+ */
+function generateFrontmatter(skill: LoadedSkill): string {
+  const frontmatter: Record<string, unknown> = {
+    name: skill.id,
+    description: skill.description || skill.name,
+  };
+  return `---\n${yaml.stringify(frontmatter).trim()}\n---`;
+}
+
+/**
+ * Check if two contents are equal (for idempotency check)
+ */
+function contentsEqual(a: string, b: string): boolean {
+  return a.trim() === b.trim();
+}
+
+/**
+ * Check if a directory is managed by kspec
+ * AC: @skill-rendering ac-4 - Only skill directories rendered by kspec are considered
+ */
+async function isKspecManaged(skillMdPath: string): Promise<boolean> {
+  try {
+    const content = await fs.readFile(skillMdPath, "utf-8");
+    return content.includes(KSPEC_MANAGED_MARKER);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Recursively check if two directories have the same contents
+ */
+async function directoriesEqual(src: string, dest: string): Promise<boolean> {
+  try {
+    const srcEntries = await fs.readdir(src, { withFileTypes: true });
+    const destEntries = await fs.readdir(dest, { withFileTypes: true });
+
+    // Different number of entries = not equal
+    if (srcEntries.length !== destEntries.length) {
+      return false;
+    }
+
+    // Create a map of dest entries for quick lookup
+    const destMap = new Map(destEntries.map((e) => [e.name, e]));
+
+    for (const srcEntry of srcEntries) {
+      const destEntry = destMap.get(srcEntry.name);
+      if (!destEntry) {
+        return false;
+      }
+
+      const srcPath = path.join(src, srcEntry.name);
+      const destPath = path.join(dest, srcEntry.name);
+
+      if (srcEntry.isDirectory() && destEntry.isDirectory()) {
+        if (!(await directoriesEqual(srcPath, destPath))) {
+          return false;
+        }
+      } else if (srcEntry.isFile() && destEntry.isFile()) {
+        const srcContent = await fs.readFile(srcPath, "utf-8");
+        const destContent = await fs.readFile(destPath, "utf-8");
+        if (!contentsEqual(srcContent, destContent)) {
+          return false;
+        }
+      } else {
+        // Type mismatch
+        return false;
+      }
+    }
+
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Get the target path for rendered skills (main branch .claude/skills/)
+ */
+function getRenderedSkillPath(projectRoot: string, skillId: string): string {
+  return path.join(projectRoot, ".claude", "skills", skillId);
+}
+
+/**
+ * Render a single skill from shadow branch to main branch.
+ * AC: @skill-rendering ac-1 - Creates .claude/skills/<id>/SKILL.md with YAML frontmatter
+ * AC: @skill-rendering ac-2 - Copies docs to .claude/skills/<id>/docs/
+ * AC: @skill-rendering ac-3 - Idempotent (no changes if content unchanged)
+ */
+async function renderSkill(
+  ctx: KspecContext,
+  projectRoot: string,
+  skill: LoadedSkill,
+  dryRun: boolean
+): Promise<SkillRenderResult> {
+  const targetDir = getRenderedSkillPath(projectRoot, skill.id);
+  const targetSkillMd = path.join(targetDir, "SKILL.md");
+
+  // Load source content
+  const sourceContent = await loadSkillContent(ctx, skill);
+  if (!sourceContent) {
+    // No source content, but skill exists in meta - create placeholder
+    const frontmatter = generateFrontmatter(skill);
+    const renderedContent = `${frontmatter}\n${KSPEC_MANAGED_MARKER}\n\n# ${skill.name}\n\n${skill.description || ""}\n`;
+
+    if (!dryRun) {
+      await fs.mkdir(targetDir, { recursive: true });
+      await fs.writeFile(targetSkillMd, renderedContent, "utf-8");
+    }
+
+    return {
+      id: skill.id,
+      action: "created",
+      path: targetSkillMd,
+    };
+  }
+
+  // Generate rendered content with frontmatter and marker
+  const frontmatter = generateFrontmatter(skill);
+
+  // Check if source already has frontmatter - if so, strip it
+  const frontmatterMatch = sourceContent.match(/^---\n[\s\S]*?\n---\n?/);
+  const contentWithoutFrontmatter = frontmatterMatch
+    ? sourceContent.slice(frontmatterMatch[0].length)
+    : sourceContent;
+
+  // Build the rendered content
+  const renderedContent = `${frontmatter}\n${KSPEC_MANAGED_MARKER}\n${contentWithoutFrontmatter}`;
+
+  // Check if target exists and compare for idempotency
+  // AC: @skill-rendering ac-3 - No changes if content unchanged
+  let targetExists = false;
+  let targetContent = "";
+  try {
+    targetContent = await fs.readFile(targetSkillMd, "utf-8");
+    targetExists = true;
+  } catch {
+    // Target doesn't exist
+  }
+
+  // Determine action based on comparison
+  let action: "created" | "updated" | "unchanged";
+
+  if (!targetExists) {
+    action = "created";
+  } else if (contentsEqual(renderedContent, targetContent)) {
+    action = "unchanged";
+  } else {
+    action = "updated";
+  }
+
+  // Apply changes if not dry run and there are changes
+  if (!dryRun && action !== "unchanged") {
+    await fs.mkdir(targetDir, { recursive: true });
+    await fs.writeFile(targetSkillMd, renderedContent, "utf-8");
+  }
+
+  // Handle docs directory
+  // AC: @skill-rendering ac-2 - Copy docs to target
+  const sourceDocsDir = path.join(ctx.specDir, "skills", skill.id, "docs");
+  const targetDocsDir = path.join(targetDir, "docs");
+  let docsAction: "created" | "updated" | "unchanged" | "skipped" = "skipped";
+
+  try {
+    const stats = await fs.stat(sourceDocsDir);
+    if (stats.isDirectory()) {
+      // Check if target docs exist and compare
+      let targetDocsExist = false;
+      try {
+        await fs.stat(targetDocsDir);
+        targetDocsExist = true;
+      } catch {
+        // Target docs don't exist
+      }
+
+      if (!targetDocsExist) {
+        docsAction = "created";
+      } else {
+        // Compare directories
+        const equal = await directoriesEqual(sourceDocsDir, targetDocsDir);
+        docsAction = equal ? "unchanged" : "updated";
+      }
+
+      // Apply changes
+      if (!dryRun && docsAction !== "unchanged") {
+        // Remove existing docs and copy fresh
+        if (targetDocsExist) {
+          await fs.rm(targetDocsDir, { recursive: true, force: true });
+        }
+        await fs.mkdir(targetDocsDir, { recursive: true });
+        await copyDirectory(sourceDocsDir, targetDocsDir);
+      }
+    }
+  } catch {
+    // No source docs directory
+  }
+
+  return {
+    id: skill.id,
+    action,
+    path: targetSkillMd,
+    docsAction,
+  };
+}
+
+// Re-export for testing
+export { renderSkill, isKspecManaged, KSPEC_MANAGED_MARKER };

--- a/tests/skill-rendering.test.ts
+++ b/tests/skill-rendering.test.ts
@@ -1,0 +1,396 @@
+/**
+ * Tests for Skill Rendering Pipeline
+ * AC: @skill-rendering ac-1 through ac-5
+ * AC: @trait-dry-run (dry run support)
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import {
+  kspec as kspecFull,
+  kspecOutput as kspec,
+  kspecJson,
+  setupTempFixtures,
+  cleanupTempDir,
+  initGitRepo,
+} from './helpers/cli';
+
+describe('Skill Rendering Pipeline', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await setupTempFixtures();
+    await initGitRepo(tempDir);
+
+    // Create a test skill
+    const result = kspecFull(
+      'skill add --id test-skill --name "Test Skill" --description "A test skill for rendering" --platform claude-code',
+      tempDir
+    );
+    if (result.exitCode !== 0) {
+      throw new Error(`skill add failed: ${result.stderr || result.stdout}`);
+    }
+
+    // Note: In test fixtures (non-shadow mode), skills are at tempDir/skills/ not tempDir/.kspec/skills/
+    const skillMdPath = path.join(tempDir, 'skills', 'test-skill', 'SKILL.md');
+
+    // Write custom content to the skill's SKILL.md
+    await fs.writeFile(skillMdPath, '# Test Skill\n\nThis is test content.\n', 'utf-8');
+  });
+
+  afterEach(async () => {
+    await cleanupTempDir(tempDir);
+  });
+
+  // AC: @skill-rendering ac-1
+  describe('ac-1: Creates .claude/skills/<id>/SKILL.md with YAML frontmatter', () => {
+    it('should create SKILL.md with YAML frontmatter when rendering', async () => {
+      kspecFull('skill render', tempDir);
+
+      const renderedPath = path.join(tempDir, '.claude', 'skills', 'test-skill', 'SKILL.md');
+      const content = await fs.readFile(renderedPath, 'utf-8');
+
+      // Check frontmatter exists
+      expect(content).toMatch(/^---\n/);
+      expect(content).toContain('name: test-skill');
+      expect(content).toContain('description: A test skill for rendering');
+      expect(content).toContain('---');
+
+      // Check marker is present
+      expect(content).toContain('<!-- kspec-managed -->');
+
+      // Check original content is preserved
+      expect(content).toContain('# Test Skill');
+      expect(content).toContain('This is test content.');
+    });
+
+    it('should use skill id as frontmatter name', async () => {
+      kspecFull('skill render', tempDir);
+
+      const renderedPath = path.join(tempDir, '.claude', 'skills', 'test-skill', 'SKILL.md');
+      const content = await fs.readFile(renderedPath, 'utf-8');
+
+      // name should be the skill id, not the skill name
+      expect(content).toContain('name: test-skill');
+    });
+  });
+
+  // AC: @skill-rendering ac-2
+  describe('ac-2: Copies docs to .claude/skills/<id>/docs/', () => {
+    beforeEach(async () => {
+      // Create docs directory in source
+      const docsDir = path.join(tempDir, 'skills', 'test-skill', 'docs');
+      await fs.mkdir(docsDir, { recursive: true });
+      await fs.writeFile(path.join(docsDir, 'quickref.md'), '# Quick Reference\n\nSome docs.\n', 'utf-8');
+      await fs.writeFile(path.join(docsDir, 'advanced.md'), '# Advanced Guide\n\nMore docs.\n', 'utf-8');
+    });
+
+    it('should copy docs directory to rendered location', async () => {
+      kspecFull('skill render', tempDir);
+
+      const renderedDocsDir = path.join(tempDir, '.claude', 'skills', 'test-skill', 'docs');
+      const quickref = await fs.readFile(path.join(renderedDocsDir, 'quickref.md'), 'utf-8');
+      const advanced = await fs.readFile(path.join(renderedDocsDir, 'advanced.md'), 'utf-8');
+
+      expect(quickref).toContain('# Quick Reference');
+      expect(advanced).toContain('# Advanced Guide');
+    });
+
+    it('should work when skill has no docs directory', async () => {
+      // Remove the docs we just created
+      await fs.rm(path.join(tempDir, 'skills', 'test-skill', 'docs'), { recursive: true });
+
+      const result = kspecFull('skill render', tempDir);
+      expect(result.exitCode).toBe(0);
+
+      // Should still render the skill successfully
+      const renderedPath = path.join(tempDir, '.claude', 'skills', 'test-skill', 'SKILL.md');
+      const content = await fs.readFile(renderedPath, 'utf-8');
+      expect(content).toContain('# Test Skill');
+    });
+  });
+
+  // AC: @skill-rendering ac-3
+  describe('ac-3: Idempotent rendering', () => {
+    it('should not modify files when called twice with no content changes', async () => {
+      // First render
+      kspecFull('skill render', tempDir);
+
+      const renderedPath = path.join(tempDir, '.claude', 'skills', 'test-skill', 'SKILL.md');
+      const firstRenderStats = await fs.stat(renderedPath);
+      const firstRenderMtime = firstRenderStats.mtimeMs;
+
+      // Wait a bit to ensure different mtime if file is modified
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      // Second render - should report unchanged
+      const result = kspecFull('skill render', tempDir);
+      expect(result.stdout).toContain('Unchanged');
+
+      // Check file was not modified
+      const secondRenderStats = await fs.stat(renderedPath);
+      expect(secondRenderStats.mtimeMs).toBe(firstRenderMtime);
+    });
+
+    it('should update files when source content changes', async () => {
+      // First render
+      kspecFull('skill render', tempDir);
+
+      const renderedPath = path.join(tempDir, '.claude', 'skills', 'test-skill', 'SKILL.md');
+      const firstContent = await fs.readFile(renderedPath, 'utf-8');
+
+      // Modify source
+      const skillMdPath = path.join(tempDir, 'skills', 'test-skill', 'SKILL.md');
+      await fs.writeFile(skillMdPath, '# Test Skill\n\nUpdated content!\n', 'utf-8');
+
+      // Second render
+      const result = kspecFull('skill render', tempDir);
+      expect(result.stdout).toContain('Updated');
+
+      // Check file was updated
+      const secondContent = await fs.readFile(renderedPath, 'utf-8');
+      expect(secondContent).toContain('Updated content!');
+      expect(secondContent).not.toBe(firstContent);
+    });
+
+    it('should report unchanged in JSON output when no changes', async () => {
+      kspecFull('skill render', tempDir);
+
+      const result = kspecJson<{
+        dry_run: boolean;
+        rendered: Array<{ id: string; action: string }>;
+      }>('skill render', tempDir);
+
+      expect(result.rendered[0].action).toBe('unchanged');
+    });
+  });
+
+  // AC: @skill-rendering ac-4, ac-5
+  describe('ac-4, ac-5: Clean removes orphaned managed skills', () => {
+    it('should remove managed skill directories that no longer exist in meta', async () => {
+      // Render the skill first
+      kspecFull('skill render', tempDir);
+
+      // Verify it was rendered
+      const renderedPath = path.join(tempDir, '.claude', 'skills', 'test-skill', 'SKILL.md');
+      await fs.access(renderedPath);
+
+      // Delete the skill from meta
+      kspecFull('skill delete test-skill --confirm', tempDir);
+
+      // Run render --clean
+      const result = kspecFull('skill render --clean', tempDir);
+      expect(result.stdout).toContain('Removed');
+      expect(result.stdout).toContain('test-skill');
+
+      // Verify directory was removed
+      await expect(fs.access(path.join(tempDir, '.claude', 'skills', 'test-skill'))).rejects.toThrow();
+    });
+
+    it('should NOT remove unmanaged skill directories (ac-4)', async () => {
+      // Create an unmanaged skill directory (no kspec-managed marker)
+      const unmanagedDir = path.join(tempDir, '.claude', 'skills', 'unmanaged-skill');
+      await fs.mkdir(unmanagedDir, { recursive: true });
+      await fs.writeFile(
+        path.join(unmanagedDir, 'SKILL.md'),
+        '---\nname: unmanaged\n---\n\n# Unmanaged\n\nNo marker.\n',
+        'utf-8'
+      );
+
+      // Run render --clean
+      const result = kspecFull('skill render --clean', tempDir);
+      expect(result.stdout).toContain('Skipped');
+      expect(result.stdout).toContain('unmanaged');
+
+      // Verify directory was NOT removed
+      const content = await fs.readFile(path.join(unmanagedDir, 'SKILL.md'), 'utf-8');
+      expect(content).toContain('# Unmanaged');
+    });
+
+    it('should identify managed skills by kspec-managed marker', async () => {
+      // Render a skill (will have marker)
+      kspecFull('skill render', tempDir);
+
+      // Create another "orphan" with the marker manually
+      const orphanDir = path.join(tempDir, '.claude', 'skills', 'orphan-skill');
+      await fs.mkdir(orphanDir, { recursive: true });
+      await fs.writeFile(
+        path.join(orphanDir, 'SKILL.md'),
+        '---\nname: orphan\n---\n<!-- kspec-managed -->\n\n# Orphan\n',
+        'utf-8'
+      );
+
+      // Delete the original skill
+      kspecFull('skill delete test-skill --confirm', tempDir);
+
+      // Run render --clean - should remove both orphaned managed skills
+      const result = kspecFull('skill render --clean', tempDir);
+
+      // Both should be removed
+      await expect(fs.access(path.join(tempDir, '.claude', 'skills', 'test-skill'))).rejects.toThrow();
+      await expect(fs.access(path.join(tempDir, '.claude', 'skills', 'orphan-skill'))).rejects.toThrow();
+    });
+  });
+
+  // AC: @trait-dry-run
+  describe('Dry run mode (trait)', () => {
+    it('should not modify files when --dry-run is provided (ac-2)', async () => {
+      kspecFull('skill render --dry-run', tempDir);
+
+      // Rendered directory should NOT exist
+      await expect(
+        fs.access(path.join(tempDir, '.claude', 'skills', 'test-skill'))
+      ).rejects.toThrow();
+    });
+
+    it('should show what would be changed (ac-1)', async () => {
+      const result = kspecFull('skill render --dry-run', tempDir);
+
+      expect(result.stdout).toContain('DRY RUN');
+      expect(result.stdout).toContain('Created');
+      expect(result.stdout).toContain('test-skill');
+    });
+
+    it('should include dry_run boolean in JSON output (ac-6)', async () => {
+      const result = kspecJson<{ dry_run: boolean }>('skill render --dry-run', tempDir);
+      expect(result.dry_run).toBe(true);
+    });
+
+    it('should not remove orphaned skills in dry run mode with --clean', async () => {
+      // First render normally
+      kspecFull('skill render', tempDir);
+
+      // Delete skill from meta
+      kspecFull('skill delete test-skill --confirm', tempDir);
+
+      // Dry run clean
+      kspecFull('skill render --clean --dry-run', tempDir);
+
+      // Directory should still exist
+      const renderedPath = path.join(tempDir, '.claude', 'skills', 'test-skill', 'SKILL.md');
+      await fs.access(renderedPath);
+    });
+  });
+
+  describe('Filtering by skill', () => {
+    beforeEach(async () => {
+      // Add another skill
+      kspecFull(
+        'skill add --id another-skill --name "Another Skill" --description "Another test skill"',
+        tempDir
+      );
+      const anotherSkillMd = path.join(tempDir, 'skills', 'another-skill', 'SKILL.md');
+      await fs.writeFile(anotherSkillMd, '# Another Skill\n\nAnother content.\n', 'utf-8');
+    });
+
+    it('should render only specified skill with --skill', async () => {
+      kspecFull('skill render --skill test-skill', tempDir);
+
+      // test-skill should be rendered
+      const testSkillPath = path.join(tempDir, '.claude', 'skills', 'test-skill', 'SKILL.md');
+      await fs.access(testSkillPath);
+
+      // another-skill should NOT be rendered
+      await expect(
+        fs.access(path.join(tempDir, '.claude', 'skills', 'another-skill'))
+      ).rejects.toThrow();
+    });
+
+    it('should error when specified skill not found', async () => {
+      const result = kspecFull('skill render --skill nonexistent', tempDir);
+      expect(result.exitCode).not.toBe(0);
+      expect(result.stderr).toContain('Skill not found');
+    });
+  });
+
+  describe('Platform filtering', () => {
+    beforeEach(async () => {
+      // Add a skill with different platform
+      kspecFull(
+        'skill add --id copilot-skill --name "Copilot Skill" --description "For Copilot" --platform copilot',
+        tempDir
+      );
+    });
+
+    it('should only render skills with claude-code platform', async () => {
+      kspecFull('skill render', tempDir);
+
+      // claude-code skill should be rendered
+      const testSkillPath = path.join(tempDir, '.claude', 'skills', 'test-skill', 'SKILL.md');
+      await fs.access(testSkillPath);
+
+      // copilot skill should NOT be rendered
+      await expect(
+        fs.access(path.join(tempDir, '.claude', 'skills', 'copilot-skill'))
+      ).rejects.toThrow();
+    });
+  });
+
+  describe('Edge cases', () => {
+    it('should handle skills with no source SKILL.md', async () => {
+      // Delete the source SKILL.md
+      await fs.rm(path.join(tempDir, 'skills', 'test-skill', 'SKILL.md'));
+
+      const result = kspecFull('skill render', tempDir);
+      expect(result.exitCode).toBe(0);
+
+      // Should create a placeholder
+      const renderedPath = path.join(tempDir, '.claude', 'skills', 'test-skill', 'SKILL.md');
+      const content = await fs.readFile(renderedPath, 'utf-8');
+      expect(content).toContain('name: test-skill');
+      expect(content).toContain('<!-- kspec-managed -->');
+    });
+
+    it('should strip existing frontmatter from source and replace with generated', async () => {
+      // Write source with frontmatter
+      const skillMdPath = path.join(tempDir, 'skills', 'test-skill', 'SKILL.md');
+      await fs.writeFile(
+        skillMdPath,
+        '---\nname: wrong-name\ndescription: wrong description\n---\n\n# Actual Content\n',
+        'utf-8'
+      );
+
+      kspecFull('skill render', tempDir);
+
+      const renderedPath = path.join(tempDir, '.claude', 'skills', 'test-skill', 'SKILL.md');
+      const content = await fs.readFile(renderedPath, 'utf-8');
+
+      // Should have new frontmatter
+      expect(content).toContain('name: test-skill');
+      expect(content).toContain('description: A test skill for rendering');
+
+      // Should NOT have duplicate frontmatter
+      const frontmatterMatches = content.match(/^---/gm);
+      expect(frontmatterMatches?.length).toBe(2); // opening and closing
+
+      // Should have the content
+      expect(content).toContain('# Actual Content');
+    });
+
+    it('should work when .claude/skills directory does not exist', async () => {
+      // Remove .claude directory if it exists
+      try {
+        await fs.rm(path.join(tempDir, '.claude'), { recursive: true });
+      } catch {
+        // Already doesn't exist
+      }
+
+      const result = kspecFull('skill render', tempDir);
+      expect(result.exitCode).toBe(0);
+
+      // Directory should be created
+      const renderedPath = path.join(tempDir, '.claude', 'skills', 'test-skill', 'SKILL.md');
+      await fs.access(renderedPath);
+    });
+
+    it('should work when no skills exist', async () => {
+      // Delete all skills
+      kspecFull('skill delete test-skill --confirm', tempDir);
+
+      const result = kspecFull('skill render', tempDir);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('No changes needed');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Implements `kspec skill render` command to render skills from shadow branch to platform-specific files
- Creates `.claude/skills/<id>/SKILL.md` with YAML frontmatter for Claude Code compatibility
- Copies docs directory from `.kspec/skills/<id>/docs/` to `.claude/skills/<id>/docs/`
- Implements idempotent rendering - no file modifications when content unchanged
- Adds `--clean` flag to remove orphaned managed skill directories (identified by marker comment)
- Adds `--dry-run` flag for preview mode

## Acceptance Criteria Coverage

All 5 ACs from @skill-rendering are covered:
- [x] ac-1: `.claude/skills/<id>/SKILL.md` created with YAML frontmatter
- [x] ac-2: docs copied to `.claude/skills/<id>/docs/`
- [x] ac-3: Idempotent rendering (no changes if unchanged)
- [x] ac-4: `--clean` only considers kspec-managed skills
- [x] ac-5: `--clean` removes orphaned managed directories

Plus trait support:
- [x] @trait-dry-run: `--dry-run` flag works correctly
- [x] @trait-error-guidance: Error messages include guidance

## Test Plan

- [x] 21 tests added covering all acceptance criteria
- [x] All 167 skill-related tests pass
- [x] Full test suite passes (2415 tests)

Task: @implement-skill-rendering-pipeline
Spec: @skill-rendering

🤖 Generated with [Claude Code](https://claude.ai/code)