### PR TITLE
feat: implement skill render CLI commands (status and diff)

### DIFF
--- a/src/cli/commands/skill.ts
+++ b/src/cli/commands/skill.ts
@@ -702,17 +702,18 @@ export function registerSkillCommands(program: Command): void {
     });
 
   // AC: @skill-rendering ac-1 through ac-5 - kspec skill render
+  // AC: @skill-render-cli ac-1, ac-2 - kspec skill render / kspec skill render @skill-id
   // AC: @trait-dry-run - supports --dry-run
   // AC: @trait-error-guidance - provides error guidance
   skill
-    .command("render")
+    .command("render [ref]")
     .description(
       "Render skills from shadow branch to platform-specific files on main branch"
     )
     .option("--clean", "Remove orphaned managed skill directories")
     .option("--dry-run", "Show what would be changed without applying")
-    .option("--skill <id>", "Render only a specific skill")
-    .action(async (options) => {
+    .option("--skill <id>", "Render only a specific skill (deprecated, use positional arg)")
+    .action(async (ref: string | undefined, options) => {
       try {
         const ctx = await initContext();
 
@@ -736,15 +737,22 @@ export function registerSkillCommands(program: Command): void {
           s.platforms.includes("claude-code")
         );
 
-        // Filter to specific skill if requested
-        if (options.skill) {
-          skillsToRender = skillsToRender.filter(
-            (s) => s.id === options.skill
-          );
-          if (skillsToRender.length === 0) {
-            error(`Skill not found: ${options.skill}`);
+        // AC: @skill-render-cli ac-2 - Filter to specific skill if requested
+        // Support both positional ref argument and --skill option
+        const skillRef = ref || options.skill;
+        if (skillRef) {
+          // Resolve the ref to a skill
+          const item = findMetaItemByRef(metaCtx, skillRef);
+          if (!item || !("origin" in item)) {
+            error(`Skill not found: ${skillRef}`);
             console.log(chalk.gray("Try: kspec skill list"));
             process.exit(EXIT_CODES.NOT_FOUND);
+          }
+          const skill = item as LoadedSkill;
+          skillsToRender = skillsToRender.filter((s) => s.id === skill.id);
+          if (skillsToRender.length === 0) {
+            error(`Skill '${skill.id}' does not have claude-code platform`);
+            process.exit(EXIT_CODES.ERROR);
           }
         }
 
@@ -888,6 +896,200 @@ export function registerSkillCommands(program: Command): void {
         );
       } catch (err) {
         error("Failed to render skills", err);
+        process.exit(EXIT_CODES.ERROR);
+      }
+    });
+
+  // AC: @skill-render-cli ac-3 - kspec skill status
+  skill
+    .command("status")
+    .description("Show sync status of rendered skills")
+    .action(async () => {
+      try {
+        const ctx = await initContext();
+
+        if (!ctx.manifestPath) {
+          error(errors.project.noKspecProject);
+          console.log(
+            chalk.gray("Try: kspec init to initialize a kspec project")
+          );
+          process.exit(EXIT_CODES.ERROR);
+        }
+
+        const metaCtx = await loadMetaContext(ctx);
+        const projectRoot = ctx.rootDir;
+
+        // Filter skills by platform (only claude-code for now)
+        const skillsToCheck = metaCtx.skills.filter((s) =>
+          s.platforms.includes("claude-code")
+        );
+
+        if (skillsToCheck.length === 0) {
+          console.log(chalk.yellow("No skills found"));
+          return;
+        }
+
+        const statusResults: SkillStatusResult[] = [];
+
+        for (const skill of skillsToCheck) {
+          const status = await getSkillSyncStatus(ctx, projectRoot, skill);
+          statusResults.push(status);
+        }
+
+        // Output results
+        output(
+          statusResults,
+          () => {
+            const table = new Table({
+              head: [
+                chalk.bold("ID"),
+                chalk.bold("Status"),
+                chalk.bold("Docs"),
+              ],
+              style: {
+                head: [],
+                border: [],
+              },
+            });
+
+            for (const result of statusResults) {
+              const statusColor =
+                result.status === "in-sync"
+                  ? chalk.green
+                  : result.status === "drifted"
+                    ? chalk.yellow
+                    : chalk.gray;
+
+              const docsStatusColor =
+                result.docsStatus === "in-sync"
+                  ? chalk.green
+                  : result.docsStatus === "drifted"
+                    ? chalk.yellow
+                    : chalk.gray;
+
+              table.push([
+                result.id,
+                statusColor(result.status),
+                docsStatusColor(result.docsStatus || "-"),
+              ]);
+            }
+
+            console.log(table.toString());
+
+            // Summary
+            const inSync = statusResults.filter((r) => r.status === "in-sync").length;
+            const drifted = statusResults.filter((r) => r.status === "drifted").length;
+            const notRendered = statusResults.filter((r) => r.status === "not-rendered").length;
+
+            console.log();
+            if (drifted > 0) {
+              console.log(chalk.yellow(`${drifted} skill(s) drifted - run 'kspec skill render' to sync`));
+            }
+            if (notRendered > 0) {
+              console.log(chalk.gray(`${notRendered} skill(s) not rendered`));
+            }
+            if (inSync === statusResults.length) {
+              console.log(chalk.green("All skills in sync"));
+            }
+          }
+        );
+      } catch (err) {
+        error("Failed to check skill status", err);
+        process.exit(EXIT_CODES.ERROR);
+      }
+    });
+
+  // AC: @skill-render-cli ac-4 - kspec skill diff
+  skill
+    .command("diff <ref>")
+    .description("Show diff between source and rendered skill")
+    .action(async (ref: string) => {
+      try {
+        const ctx = await initContext();
+
+        if (!ctx.manifestPath) {
+          error(errors.project.noKspecProject);
+          console.log(
+            chalk.gray("Try: kspec init to initialize a kspec project")
+          );
+          process.exit(EXIT_CODES.ERROR);
+        }
+
+        const metaCtx = await loadMetaContext(ctx);
+        const item = findMetaItemByRef(metaCtx, ref);
+
+        if (!item) {
+          error(`Skill not found: ${ref}`);
+          console.log(chalk.gray("Try: kspec skill list"));
+          process.exit(EXIT_CODES.NOT_FOUND);
+        }
+
+        // Check it's a skill
+        if (!("origin" in item)) {
+          error(`Item ${ref} is not a skill`);
+          process.exit(EXIT_CODES.ERROR);
+        }
+
+        const skill = item as LoadedSkill;
+        const projectRoot = ctx.rootDir;
+
+        // Get expected rendered content
+        const expectedContent = await getExpectedRenderedContent(ctx, skill);
+
+        // Get actual rendered content
+        const renderedPath = path.join(
+          projectRoot,
+          ".claude",
+          "skills",
+          skill.id,
+          "SKILL.md"
+        );
+
+        let actualContent = "";
+        try {
+          actualContent = await fs.readFile(renderedPath, "utf-8");
+        } catch {
+          // File doesn't exist
+        }
+
+        // Generate diff
+        const diff = generateUnifiedDiff(
+          actualContent,
+          expectedContent,
+          `a/${skill.id}/SKILL.md`,
+          `b/${skill.id}/SKILL.md`
+        );
+
+        // Output
+        output(
+          {
+            id: skill.id,
+            hasDiff: diff.length > 0,
+            diff,
+          },
+          () => {
+            if (diff.length === 0) {
+              console.log(chalk.green(`${skill.id}: in sync`));
+            } else {
+              console.log(chalk.yellow(`${skill.id}: drifted`));
+              console.log();
+              // Print colored diff
+              for (const line of diff) {
+                if (line.startsWith("+") && !line.startsWith("+++")) {
+                  console.log(chalk.green(line));
+                } else if (line.startsWith("-") && !line.startsWith("---")) {
+                  console.log(chalk.red(line));
+                } else if (line.startsWith("@@")) {
+                  console.log(chalk.cyan(line));
+                } else {
+                  console.log(line);
+                }
+              }
+            }
+          }
+        );
+      } catch (err) {
+        error("Failed to generate diff", err);
         process.exit(EXIT_CODES.ERROR);
       }
     });
@@ -1190,5 +1392,222 @@ async function renderSkill(
   };
 }
 
+/**
+ * Result of checking a skill's sync status
+ * AC: @skill-render-cli ac-3
+ */
+interface SkillStatusResult {
+  id: string;
+  status: "in-sync" | "drifted" | "not-rendered";
+  docsStatus?: "in-sync" | "drifted" | "not-rendered" | "no-docs";
+}
+
+/**
+ * Get the sync status of a skill
+ * AC: @skill-render-cli ac-3
+ */
+async function getSkillSyncStatus(
+  ctx: KspecContext,
+  projectRoot: string,
+  skill: LoadedSkill
+): Promise<SkillStatusResult> {
+  const expectedContent = await getExpectedRenderedContent(ctx, skill);
+  const renderedPath = path.join(
+    projectRoot,
+    ".claude",
+    "skills",
+    skill.id,
+    "SKILL.md"
+  );
+
+  let actualContent = "";
+  let status: "in-sync" | "drifted" | "not-rendered" = "not-rendered";
+
+  try {
+    actualContent = await fs.readFile(renderedPath, "utf-8");
+    status = contentsEqual(expectedContent, actualContent) ? "in-sync" : "drifted";
+  } catch {
+    // File doesn't exist
+    status = "not-rendered";
+  }
+
+  // Check docs status
+  const sourceDocsDir = path.join(ctx.specDir, "skills", skill.id, "docs");
+  const targetDocsDir = path.join(projectRoot, ".claude", "skills", skill.id, "docs");
+  let docsStatus: "in-sync" | "drifted" | "not-rendered" | "no-docs" = "no-docs";
+
+  try {
+    await fs.stat(sourceDocsDir);
+    // Source docs exist, check target
+    try {
+      await fs.stat(targetDocsDir);
+      // Both exist, compare
+      const equal = await directoriesEqual(sourceDocsDir, targetDocsDir);
+      docsStatus = equal ? "in-sync" : "drifted";
+    } catch {
+      docsStatus = "not-rendered";
+    }
+  } catch {
+    // No source docs
+    docsStatus = "no-docs";
+  }
+
+  return {
+    id: skill.id,
+    status,
+    docsStatus,
+  };
+}
+
+/**
+ * Get the expected rendered content for a skill
+ */
+async function getExpectedRenderedContent(
+  ctx: KspecContext,
+  skill: LoadedSkill
+): Promise<string> {
+  const sourceContent = await loadSkillContent(ctx, skill);
+
+  if (!sourceContent) {
+    // No source content, generate placeholder
+    const frontmatter = generateFrontmatter(skill);
+    return `${frontmatter}\n${KSPEC_MANAGED_MARKER}\n\n# ${skill.name}\n\n${skill.description || ""}\n`;
+  }
+
+  // Generate rendered content with frontmatter and marker
+  const frontmatter = generateFrontmatter(skill);
+
+  // Check if source already has frontmatter - if so, strip it
+  const frontmatterMatch = sourceContent.match(/^---\n[\s\S]*?\n---\n?/);
+  const contentWithoutFrontmatter = frontmatterMatch
+    ? sourceContent.slice(frontmatterMatch[0].length)
+    : sourceContent;
+
+  return `${frontmatter}\n${KSPEC_MANAGED_MARKER}\n${contentWithoutFrontmatter}`;
+}
+
+/**
+ * Generate unified diff between two strings
+ * AC: @skill-render-cli ac-4
+ */
+function generateUnifiedDiff(
+  actual: string,
+  expected: string,
+  actualPath: string,
+  expectedPath: string
+): string[] {
+  if (contentsEqual(actual, expected)) {
+    return [];
+  }
+
+  const actualLines = actual.split("\n");
+  const expectedLines = expected.split("\n");
+  const diffLines: string[] = [];
+
+  // Simple line-by-line diff (unified format)
+  diffLines.push(`--- ${actualPath}`);
+  diffLines.push(`+++ ${expectedPath}`);
+
+  // Find differing sections and create hunks
+  let i = 0;
+  let j = 0;
+
+  while (i < actualLines.length || j < expectedLines.length) {
+    // Find start of difference
+    const contextStart = i;
+    const contextStartExpected = j;
+
+    // Skip matching lines
+    while (
+      i < actualLines.length &&
+      j < expectedLines.length &&
+      actualLines[i] === expectedLines[j]
+    ) {
+      i++;
+      j++;
+    }
+
+    // If we've reached the end, we're done
+    if (i >= actualLines.length && j >= expectedLines.length) {
+      break;
+    }
+
+    // Find end of difference
+    let diffEndActual = i;
+    let diffEndExpected = j;
+
+    // Collect differing lines
+    while (
+      diffEndActual < actualLines.length &&
+      diffEndExpected < expectedLines.length &&
+      actualLines[diffEndActual] !== expectedLines[diffEndExpected]
+    ) {
+      diffEndActual++;
+      diffEndExpected++;
+    }
+
+    // Also handle case where one side has more lines
+    while (diffEndActual < actualLines.length && diffEndExpected >= expectedLines.length) {
+      diffEndActual++;
+    }
+    while (diffEndExpected < expectedLines.length && diffEndActual >= actualLines.length) {
+      diffEndExpected++;
+    }
+
+    // Create hunk header (show 3 lines of context)
+    const hunkStartActual = Math.max(0, contextStart - 3);
+    const hunkStartExpected = Math.max(0, contextStartExpected - 3);
+
+    // Include context after diff too
+    const hunkEndActual = Math.min(actualLines.length, diffEndActual + 3);
+    const hunkEndExpected = Math.min(expectedLines.length, diffEndExpected + 3);
+
+    const actualCount = hunkEndActual - hunkStartActual;
+    const expectedCount = hunkEndExpected - hunkStartExpected;
+
+    diffLines.push(
+      `@@ -${hunkStartActual + 1},${actualCount} +${hunkStartExpected + 1},${expectedCount} @@`
+    );
+
+    // Leading context
+    for (let k = hunkStartActual; k < contextStart; k++) {
+      diffLines.push(` ${actualLines[k]}`);
+    }
+
+    // Removed lines (from actual)
+    for (let k = contextStart; k < diffEndActual; k++) {
+      if (k < actualLines.length) {
+        diffLines.push(`-${actualLines[k]}`);
+      }
+    }
+
+    // Added lines (from expected)
+    for (let k = contextStartExpected; k < diffEndExpected; k++) {
+      if (k < expectedLines.length) {
+        diffLines.push(`+${expectedLines[k]}`);
+      }
+    }
+
+    // Trailing context
+    for (let k = diffEndActual; k < hunkEndActual; k++) {
+      if (k < actualLines.length) {
+        diffLines.push(` ${actualLines[k]}`);
+      }
+    }
+
+    i = hunkEndActual;
+    j = hunkEndExpected;
+  }
+
+  return diffLines;
+}
+
 // Re-export for testing
-export { renderSkill, isKspecManaged, KSPEC_MANAGED_MARKER };
+export {
+  renderSkill,
+  isKspecManaged,
+  KSPEC_MANAGED_MARKER,
+  getSkillSyncStatus,
+  getExpectedRenderedContent,
+  generateUnifiedDiff,
+};

--- a/tests/skill-rendering.test.ts
+++ b/tests/skill-rendering.test.ts
@@ -273,7 +273,8 @@ describe('Skill Rendering Pipeline', () => {
     });
   });
 
-  describe('Filtering by skill', () => {
+  // AC: @skill-render-cli ac-2
+  describe('ac-2: Filtering by skill (positional ref)', () => {
     beforeEach(async () => {
       // Add another skill
       kspecFull(
@@ -284,7 +285,21 @@ describe('Skill Rendering Pipeline', () => {
       await fs.writeFile(anotherSkillMd, '# Another Skill\n\nAnother content.\n', 'utf-8');
     });
 
-    it('should render only specified skill with --skill', async () => {
+    it('should render only specified skill with positional ref', async () => {
+      // AC: @skill-render-cli ac-2 - kspec skill render @task-work renders only that skill
+      kspecFull('skill render @test-skill', tempDir);
+
+      // test-skill should be rendered
+      const testSkillPath = path.join(tempDir, '.claude', 'skills', 'test-skill', 'SKILL.md');
+      await fs.access(testSkillPath);
+
+      // another-skill should NOT be rendered
+      await expect(
+        fs.access(path.join(tempDir, '.claude', 'skills', 'another-skill'))
+      ).rejects.toThrow();
+    });
+
+    it('should render only specified skill with --skill option (deprecated)', async () => {
       kspecFull('skill render --skill test-skill', tempDir);
 
       // test-skill should be rendered
@@ -297,8 +312,8 @@ describe('Skill Rendering Pipeline', () => {
       ).rejects.toThrow();
     });
 
-    it('should error when specified skill not found', async () => {
-      const result = kspecFull('skill render --skill nonexistent', tempDir);
+    it('should error when specified skill ref not found', async () => {
+      const result = kspecFull('skill render @nonexistent', tempDir);
       expect(result.exitCode).not.toBe(0);
       expect(result.stderr).toContain('Skill not found');
     });
@@ -391,6 +406,190 @@ describe('Skill Rendering Pipeline', () => {
       const result = kspecFull('skill render', tempDir);
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain('No changes needed');
+    });
+  });
+});
+
+/**
+ * Tests for Skill Render CLI commands
+ * AC: @skill-render-cli ac-3, ac-4
+ */
+describe('Skill Render CLI', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await setupTempFixtures();
+    await initGitRepo(tempDir);
+
+    // Create a test skill
+    const result = kspecFull(
+      'skill add --id test-skill --name "Test Skill" --description "A test skill" --platform claude-code',
+      tempDir
+    );
+    if (result.exitCode !== 0) {
+      throw new Error(`skill add failed: ${result.stderr || result.stdout}`);
+    }
+
+    // Write custom content to the skill's SKILL.md
+    const skillMdPath = path.join(tempDir, 'skills', 'test-skill', 'SKILL.md');
+    await fs.writeFile(skillMdPath, '# Test Skill\n\nThis is test content.\n', 'utf-8');
+  });
+
+  afterEach(async () => {
+    await cleanupTempDir(tempDir);
+  });
+
+  // AC: @skill-render-cli ac-3
+  describe('ac-3: kspec skill status shows sync status table', () => {
+    it('should show "not-rendered" for skills not yet rendered', async () => {
+      const result = kspecFull('skill status', tempDir);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('test-skill');
+      expect(result.stdout).toContain('not-rendered');
+    });
+
+    it('should show "in-sync" for skills that are in sync', async () => {
+      // Render the skill first
+      kspecFull('skill render', tempDir);
+
+      const result = kspecFull('skill status', tempDir);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('test-skill');
+      expect(result.stdout).toContain('in-sync');
+      expect(result.stdout).toContain('All skills in sync');
+    });
+
+    it('should show "drifted" when rendered file differs from source', async () => {
+      // Render the skill
+      kspecFull('skill render', tempDir);
+
+      // Modify the rendered file directly
+      const renderedPath = path.join(tempDir, '.claude', 'skills', 'test-skill', 'SKILL.md');
+      const content = await fs.readFile(renderedPath, 'utf-8');
+      await fs.writeFile(renderedPath, content + '\n\n# Added Section\n', 'utf-8');
+
+      const result = kspecFull('skill status', tempDir);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('test-skill');
+      expect(result.stdout).toContain('drifted');
+      expect(result.stdout).toContain("run 'kspec skill render' to sync");
+    });
+
+    it('should output JSON with status fields', async () => {
+      kspecFull('skill render', tempDir);
+
+      const result = kspecJson<Array<{ id: string; status: string; docsStatus: string }>>(
+        'skill status',
+        tempDir
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('test-skill');
+      expect(result[0].status).toBe('in-sync');
+      expect(result[0].docsStatus).toBe('no-docs');
+    });
+
+    it('should track docs status separately', async () => {
+      // Add docs directory
+      const docsDir = path.join(tempDir, 'skills', 'test-skill', 'docs');
+      await fs.mkdir(docsDir, { recursive: true });
+      await fs.writeFile(path.join(docsDir, 'guide.md'), '# Guide\n', 'utf-8');
+
+      // Render
+      kspecFull('skill render', tempDir);
+
+      // Check status (should be in-sync)
+      let result = kspecJson<Array<{ id: string; status: string; docsStatus: string }>>(
+        'skill status',
+        tempDir
+      );
+      expect(result[0].docsStatus).toBe('in-sync');
+
+      // Modify source docs
+      await fs.writeFile(path.join(docsDir, 'guide.md'), '# Guide\n\nUpdated content.\n', 'utf-8');
+
+      // Check status again (docs should be drifted)
+      result = kspecJson<Array<{ id: string; status: string; docsStatus: string }>>(
+        'skill status',
+        tempDir
+      );
+      expect(result[0].docsStatus).toBe('drifted');
+    });
+  });
+
+  // AC: @skill-render-cli ac-4
+  describe('ac-4: kspec skill diff shows unified diff', () => {
+    it('should show "in sync" message when no diff', async () => {
+      // Render the skill
+      kspecFull('skill render', tempDir);
+
+      const result = kspecFull('skill diff test-skill', tempDir);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('in sync');
+    });
+
+    it('should show unified diff when rendered file differs', async () => {
+      // Render the skill
+      kspecFull('skill render', tempDir);
+
+      // Modify the rendered file
+      const renderedPath = path.join(tempDir, '.claude', 'skills', 'test-skill', 'SKILL.md');
+      const content = await fs.readFile(renderedPath, 'utf-8');
+      await fs.writeFile(renderedPath, content.replace('test content', 'modified content'), 'utf-8');
+
+      const result = kspecFull('skill diff test-skill', tempDir);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('drifted');
+      expect(result.stdout).toContain('---'); // Diff header
+      expect(result.stdout).toContain('+++'); // Diff header
+      expect(result.stdout).toContain('@@'); // Hunk header
+    });
+
+    it('should show full diff when rendered file does not exist', async () => {
+      // Don't render, so rendered file doesn't exist
+      const result = kspecFull('skill diff test-skill', tempDir);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('drifted');
+      expect(result.stdout).toContain('+'); // All lines are additions
+    });
+
+    it('should error when skill not found', async () => {
+      const result = kspecFull('skill diff nonexistent', tempDir);
+      expect(result.exitCode).not.toBe(0);
+      expect(result.stderr).toContain('Skill not found');
+    });
+
+    it('should output JSON with diff lines', async () => {
+      kspecFull('skill render', tempDir);
+
+      // Modify rendered file
+      const renderedPath = path.join(tempDir, '.claude', 'skills', 'test-skill', 'SKILL.md');
+      const content = await fs.readFile(renderedPath, 'utf-8');
+      await fs.writeFile(renderedPath, content.replace('test content', 'changed'), 'utf-8');
+
+      const result = kspecJson<{ id: string; hasDiff: boolean; diff: string[] }>(
+        'skill diff test-skill',
+        tempDir
+      );
+
+      expect(result.id).toBe('test-skill');
+      expect(result.hasDiff).toBe(true);
+      expect(result.diff).toBeInstanceOf(Array);
+      expect(result.diff.length).toBeGreaterThan(0);
+      expect(result.diff.some((line) => line.startsWith('---'))).toBe(true);
+      expect(result.diff.some((line) => line.startsWith('+++'))).toBe(true);
+    });
+
+    it('should return empty diff array when in sync', async () => {
+      kspecFull('skill render', tempDir);
+
+      const result = kspecJson<{ id: string; hasDiff: boolean; diff: string[] }>(
+        'skill diff test-skill',
+        tempDir
+      );
+
+      expect(result.hasDiff).toBe(false);
+      expect(result.diff).toEqual([]);
     });
   });
 });


### PR DESCRIPTION
## Summary

- Added `kspec skill status` command showing table of skills with sync status (in-sync, drifted, not-rendered)
- Added `kspec skill diff @skill` command showing unified diff between rendered and source content  
- Updated `kspec skill render` to accept positional ref argument (`kspec skill render @skill-id`)

## Acceptance Criteria Coverage

- **ac-1**: `kspec skill render` shows summary of created/updated/skipped files ✅
- **ac-2**: `kspec skill render @skill-id` renders only that skill ✅
- **ac-3**: `kspec skill status` shows table with sync status ✅
- **ac-4**: `kspec skill diff @skill` shows unified diff when content differs ✅

## Test plan

- [x] All 33 skill rendering tests pass
- [x] All 68 skill CLI tests pass
- [x] Status command shows correct sync state (in-sync, drifted, not-rendered)
- [x] Diff command shows unified diff with proper coloring
- [x] Positional ref argument works for render command

Task: @implement-skill-render-cli
Spec: @skill-render-cli

🤖 Generated with [Claude Code](https://claude.ai/code)