### PR TITLE
feat: implement Claude Code skill renderer library function

### DIFF
--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -10,6 +10,7 @@ export * from "./meta.js";
 export * from "./plans.js";
 export * from "./refs.js";
 export * from "./shadow.js";
+export * from "./skill-render.js";
 export * from "./traits.js";
 export * from "./validate.js";
 export * from "./yaml.js";

--- a/src/parser/skill-render.ts
+++ b/src/parser/skill-render.ts
@@ -1,0 +1,285 @@
+/**
+ * Claude Code Skill Renderer
+ *
+ * Platform-specific renderer for Claude Code. Reads from .kspec/skills/<id>/SKILL.md,
+ * writes to .claude/skills/<id>/SKILL.md with YAML frontmatter (name, description).
+ * Does NOT auto-commit to main branch — leaves files unstaged.
+ *
+ * AC: @claude-code-renderer ac-1 - renderClaudeCodeSkill creates .claude/skills/<id>/SKILL.md with YAML frontmatter
+ * AC: @claude-code-renderer ac-2 - rendered output has YAML frontmatter delimiters with name and description fields
+ * AC: @claude-code-renderer ac-3 - skill body content appears verbatim below frontmatter
+ * AC: @claude-code-renderer ac-4 - rendered files appear as unstaged changes on main branch
+ */
+
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import yaml from "yaml";
+import type { KspecContext } from "./yaml.js";
+import { loadSkillContent, type LoadedSkill } from "./meta.js";
+
+/**
+ * Result of rendering a skill to Claude Code format
+ */
+export interface ClaudeCodeRenderResult {
+  /** Skill ID */
+  id: string;
+  /** Action taken: created, updated, or unchanged */
+  action: "created" | "updated" | "unchanged";
+  /** Path to the rendered SKILL.md file */
+  path: string;
+  /** Action taken on docs directory */
+  docsAction?: "created" | "updated" | "unchanged" | "skipped";
+}
+
+/**
+ * Options for rendering a skill
+ */
+export interface RenderSkillOptions {
+  /** If true, don't write files, just return what would be done */
+  dryRun?: boolean;
+}
+
+/**
+ * Marker comment that identifies skill directories managed by kspec
+ */
+export const KSPEC_MANAGED_MARKER = "<!-- kspec-managed -->";
+
+/**
+ * Generate YAML frontmatter for a skill.
+ * AC: @claude-code-renderer ac-2 - YAML frontmatter with name and description fields
+ */
+function generateFrontmatter(skill: LoadedSkill): string {
+  const frontmatter: Record<string, unknown> = {
+    name: skill.id,
+    description: skill.description || skill.name,
+  };
+  return `---\n${yaml.stringify(frontmatter).trim()}\n---`;
+}
+
+/**
+ * Get the target directory for rendered skills on main branch.
+ * Returns .claude/skills/<id>/ path.
+ */
+function getRenderedSkillPath(projectRoot: string, skillId: string): string {
+  return path.join(projectRoot, ".claude", "skills", skillId);
+}
+
+/**
+ * Check if two contents are equal (for idempotency check)
+ */
+function contentsEqual(a: string, b: string): boolean {
+  return a.trim() === b.trim();
+}
+
+/**
+ * Recursively copy a directory
+ */
+async function copyDirectory(src: string, dest: string): Promise<void> {
+  const entries = await fs.readdir(src, { withFileTypes: true });
+
+  for (const entry of entries) {
+    const srcPath = path.join(src, entry.name);
+    const destPath = path.join(dest, entry.name);
+
+    if (entry.isDirectory()) {
+      await fs.mkdir(destPath, { recursive: true });
+      await copyDirectory(srcPath, destPath);
+    } else {
+      await fs.copyFile(srcPath, destPath);
+    }
+  }
+}
+
+/**
+ * Recursively check if two directories have the same contents
+ */
+async function directoriesEqual(src: string, dest: string): Promise<boolean> {
+  try {
+    const srcEntries = await fs.readdir(src, { withFileTypes: true });
+    const destEntries = await fs.readdir(dest, { withFileTypes: true });
+
+    // Different number of entries = not equal
+    if (srcEntries.length !== destEntries.length) {
+      return false;
+    }
+
+    // Create a map of dest entries for quick lookup
+    const destMap = new Map(destEntries.map((e) => [e.name, e]));
+
+    for (const srcEntry of srcEntries) {
+      const destEntry = destMap.get(srcEntry.name);
+      if (!destEntry) {
+        return false;
+      }
+
+      const srcPath = path.join(src, srcEntry.name);
+      const destPath = path.join(dest, srcEntry.name);
+
+      if (srcEntry.isDirectory() && destEntry.isDirectory()) {
+        if (!(await directoriesEqual(srcPath, destPath))) {
+          return false;
+        }
+      } else if (srcEntry.isFile() && destEntry.isFile()) {
+        const srcContent = await fs.readFile(srcPath, "utf-8");
+        const destContent = await fs.readFile(destPath, "utf-8");
+        if (!contentsEqual(srcContent, destContent)) {
+          return false;
+        }
+      } else {
+        // Type mismatch
+        return false;
+      }
+    }
+
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Render a skill to Claude Code format.
+ *
+ * Reads skill content from .kspec/skills/<id>/SKILL.md and writes to
+ * .claude/skills/<id>/SKILL.md with YAML frontmatter containing name and description.
+ *
+ * AC: @claude-code-renderer ac-1 - Creates .claude/skills/<id>/SKILL.md with YAML frontmatter
+ * AC: @claude-code-renderer ac-2 - YAML frontmatter has name and description fields
+ * AC: @claude-code-renderer ac-3 - Skill body content appears verbatim below frontmatter
+ * AC: @claude-code-renderer ac-4 - Files are written to disk as unstaged changes (no git commit)
+ *
+ * @param ctx - Kspec context with specDir pointing to .kspec/
+ * @param projectRoot - Root directory of the project (where .claude/ will be created)
+ * @param skill - The skill to render
+ * @param options - Render options (dryRun, etc.)
+ * @returns Result indicating what action was taken
+ */
+export async function renderClaudeCodeSkill(
+  ctx: KspecContext,
+  projectRoot: string,
+  skill: LoadedSkill,
+  options: RenderSkillOptions = {},
+): Promise<ClaudeCodeRenderResult> {
+  const dryRun = options.dryRun ?? false;
+  const targetDir = getRenderedSkillPath(projectRoot, skill.id);
+  const targetSkillMd = path.join(targetDir, "SKILL.md");
+
+  // AC: @claude-code-renderer ac-3 - Load source content verbatim
+  const sourceContent = await loadSkillContent(ctx, skill);
+
+  if (!sourceContent) {
+    // No source content, but skill exists in meta - create placeholder
+    const frontmatter = generateFrontmatter(skill);
+    const renderedContent = `${frontmatter}\n${KSPEC_MANAGED_MARKER}\n\n# ${skill.name}\n\n${skill.description || ""}\n`;
+
+    // AC: @claude-code-renderer ac-4 - Write to disk (unstaged)
+    if (!dryRun) {
+      await fs.mkdir(targetDir, { recursive: true });
+      await fs.writeFile(targetSkillMd, renderedContent, "utf-8");
+    }
+
+    return {
+      id: skill.id,
+      action: "created",
+      path: targetSkillMd,
+    };
+  }
+
+  // AC: @claude-code-renderer ac-2 - Generate frontmatter with name and description
+  const frontmatter = generateFrontmatter(skill);
+
+  // Check if source already has frontmatter - if so, strip it
+  const frontmatterMatch = sourceContent.match(/^---\n[\s\S]*?\n---\n?/);
+  const contentWithoutFrontmatter = frontmatterMatch
+    ? sourceContent.slice(frontmatterMatch[0].length)
+    : sourceContent;
+
+  // AC: @claude-code-renderer ac-1, ac-3 - Build rendered content with frontmatter + verbatim body
+  const renderedContent = `${frontmatter}\n${KSPEC_MANAGED_MARKER}\n${contentWithoutFrontmatter}`;
+
+  // Check if target exists and compare for idempotency
+  let targetExists = false;
+  let targetContent = "";
+  try {
+    targetContent = await fs.readFile(targetSkillMd, "utf-8");
+    targetExists = true;
+  } catch {
+    // Target doesn't exist
+  }
+
+  // Determine action based on comparison
+  let action: "created" | "updated" | "unchanged";
+
+  if (!targetExists) {
+    action = "created";
+  } else if (contentsEqual(renderedContent, targetContent)) {
+    action = "unchanged";
+  } else {
+    action = "updated";
+  }
+
+  // AC: @claude-code-renderer ac-4 - Apply changes to disk (no git commit)
+  if (!dryRun && action !== "unchanged") {
+    await fs.mkdir(targetDir, { recursive: true });
+    await fs.writeFile(targetSkillMd, renderedContent, "utf-8");
+  }
+
+  // Handle docs directory
+  const sourceDocsDir = path.join(ctx.specDir, "skills", skill.id, "docs");
+  const targetDocsDir = path.join(targetDir, "docs");
+  let docsAction: "created" | "updated" | "unchanged" | "skipped" = "skipped";
+
+  try {
+    const stats = await fs.stat(sourceDocsDir);
+    if (stats.isDirectory()) {
+      // Check if target docs exist and compare
+      let targetDocsExist = false;
+      try {
+        await fs.stat(targetDocsDir);
+        targetDocsExist = true;
+      } catch {
+        // Target docs don't exist
+      }
+
+      if (!targetDocsExist) {
+        docsAction = "created";
+      } else {
+        // Compare directories
+        const equal = await directoriesEqual(sourceDocsDir, targetDocsDir);
+        docsAction = equal ? "unchanged" : "updated";
+      }
+
+      // Apply changes
+      if (!dryRun && docsAction !== "unchanged") {
+        // Remove existing docs and copy fresh
+        if (targetDocsExist) {
+          await fs.rm(targetDocsDir, { recursive: true, force: true });
+        }
+        await fs.mkdir(targetDocsDir, { recursive: true });
+        await copyDirectory(sourceDocsDir, targetDocsDir);
+      }
+    }
+  } catch {
+    // No source docs directory
+  }
+
+  return {
+    id: skill.id,
+    action,
+    path: targetSkillMd,
+    docsAction,
+  };
+}
+
+/**
+ * Check if a skill directory is managed by kspec.
+ * Looks for the KSPEC_MANAGED_MARKER in the SKILL.md file.
+ */
+export async function isKspecManagedSkill(skillMdPath: string): Promise<boolean> {
+  try {
+    const content = await fs.readFile(skillMdPath, "utf-8");
+    return content.includes(KSPEC_MANAGED_MARKER);
+  } catch {
+    return false;
+  }
+}

--- a/tests/claude-code-renderer.test.ts
+++ b/tests/claude-code-renderer.test.ts
@@ -1,0 +1,342 @@
+/**
+ * Tests for Claude Code Skill Renderer
+ * AC: @claude-code-renderer ac-1 through ac-4
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import {
+  kspec as kspecFull,
+  setupTempFixtures,
+  cleanupTempDir,
+  initGitRepo,
+} from "./helpers/cli";
+import {
+  renderClaudeCodeSkill,
+  KSPEC_MANAGED_MARKER,
+  loadMetaContext,
+  initContext,
+} from "../src/parser/index";
+
+describe("Claude Code Skill Renderer", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await setupTempFixtures();
+    await initGitRepo(tempDir);
+
+    // Create a test skill with known content
+    const result = kspecFull(
+      'skill add --id task-work --name "Task Work Skill" --description "A skill for task work" --platform claude-code',
+      tempDir
+    );
+    if (result.exitCode !== 0) {
+      throw new Error(`skill add failed: ${result.stderr || result.stdout}`);
+    }
+
+    // Write custom content to the skill's SKILL.md
+    const skillMdPath = path.join(tempDir, "skills", "task-work", "SKILL.md");
+    await fs.writeFile(
+      skillMdPath,
+      "# Task Work Session\n\nStructured workflow for working on tasks.\n",
+      "utf-8"
+    );
+  });
+
+  afterEach(async () => {
+    await cleanupTempDir(tempDir);
+  });
+
+  // AC: @claude-code-renderer ac-1
+  describe("ac-1: renderClaudeCodeSkill creates .claude/skills/<id>/SKILL.md with YAML frontmatter", () => {
+    it("should create SKILL.md with YAML frontmatter when called", async () => {
+      // Get context and skill
+      const ctx = await initContext(tempDir);
+      const metaCtx = await loadMetaContext(ctx);
+      const skill = metaCtx.skills.find((s) => s.id === "task-work");
+      expect(skill).toBeDefined();
+
+      // Call renderClaudeCodeSkill
+      const result = await renderClaudeCodeSkill(ctx, tempDir, skill!);
+
+      // Verify file was created
+      expect(result.action).toBe("created");
+      expect(result.path).toBe(
+        path.join(tempDir, ".claude", "skills", "task-work", "SKILL.md")
+      );
+
+      // Verify content has YAML frontmatter
+      const content = await fs.readFile(result.path, "utf-8");
+      expect(content).toMatch(/^---\n/);
+      expect(content).toContain("---");
+    });
+
+    it("should create file at correct path .claude/skills/task-work/SKILL.md", async () => {
+      const ctx = await initContext(tempDir);
+      const metaCtx = await loadMetaContext(ctx);
+      const skill = metaCtx.skills.find((s) => s.id === "task-work");
+
+      await renderClaudeCodeSkill(ctx, tempDir, skill!);
+
+      // Verify directory structure
+      const expectedPath = path.join(
+        tempDir,
+        ".claude",
+        "skills",
+        "task-work",
+        "SKILL.md"
+      );
+      const stats = await fs.stat(expectedPath);
+      expect(stats.isFile()).toBe(true);
+    });
+  });
+
+  // AC: @claude-code-renderer ac-2
+  describe("ac-2: rendered output has YAML frontmatter delimiters with name and description fields", () => {
+    it("should have YAML frontmatter with name field", async () => {
+      const ctx = await initContext(tempDir);
+      const metaCtx = await loadMetaContext(ctx);
+      const skill = metaCtx.skills.find((s) => s.id === "task-work");
+
+      const result = await renderClaudeCodeSkill(ctx, tempDir, skill!);
+      const content = await fs.readFile(result.path, "utf-8");
+
+      // Check frontmatter has name field
+      expect(content).toContain("name: task-work");
+    });
+
+    it("should have YAML frontmatter with description field", async () => {
+      const ctx = await initContext(tempDir);
+      const metaCtx = await loadMetaContext(ctx);
+      const skill = metaCtx.skills.find((s) => s.id === "task-work");
+
+      const result = await renderClaudeCodeSkill(ctx, tempDir, skill!);
+      const content = await fs.readFile(result.path, "utf-8");
+
+      // Check frontmatter has description field
+      expect(content).toContain("description: A skill for task work");
+    });
+
+    it("should have YAML frontmatter delimiters (--- at start and end)", async () => {
+      const ctx = await initContext(tempDir);
+      const metaCtx = await loadMetaContext(ctx);
+      const skill = metaCtx.skills.find((s) => s.id === "task-work");
+
+      const result = await renderClaudeCodeSkill(ctx, tempDir, skill!);
+      const content = await fs.readFile(result.path, "utf-8");
+
+      // Check frontmatter delimiters
+      expect(content.startsWith("---\n")).toBe(true);
+
+      // Count frontmatter delimiters - should have exactly 2 (opening and closing)
+      const delimiterMatches = content.match(/^---$/gm);
+      expect(delimiterMatches?.length).toBe(2);
+    });
+  });
+
+  // AC: @claude-code-renderer ac-3
+  describe("ac-3: skill body content from source appears verbatim below frontmatter", () => {
+    it("should include source content verbatim below frontmatter", async () => {
+      const ctx = await initContext(tempDir);
+      const metaCtx = await loadMetaContext(ctx);
+      const skill = metaCtx.skills.find((s) => s.id === "task-work");
+
+      const result = await renderClaudeCodeSkill(ctx, tempDir, skill!);
+      const content = await fs.readFile(result.path, "utf-8");
+
+      // Check that source content is present
+      expect(content).toContain("# Task Work Session");
+      expect(content).toContain("Structured workflow for working on tasks.");
+    });
+
+    it("should preserve source content exactly (not modify it)", async () => {
+      // Write source with specific formatting
+      const sourceContent =
+        "# Task Work Session\n\n## Quick Start\n\n```bash\nkspec workflow start\n```\n";
+      const skillMdPath = path.join(tempDir, "skills", "task-work", "SKILL.md");
+      await fs.writeFile(skillMdPath, sourceContent, "utf-8");
+
+      const ctx = await initContext(tempDir);
+      const metaCtx = await loadMetaContext(ctx);
+      const skill = metaCtx.skills.find((s) => s.id === "task-work");
+
+      const result = await renderClaudeCodeSkill(ctx, tempDir, skill!);
+      const content = await fs.readFile(result.path, "utf-8");
+
+      // Source content should appear exactly as written (after frontmatter + marker)
+      expect(content).toContain(sourceContent);
+    });
+
+    it("should strip existing frontmatter from source and replace with generated", async () => {
+      // Write source with existing frontmatter
+      const skillMdPath = path.join(tempDir, "skills", "task-work", "SKILL.md");
+      await fs.writeFile(
+        skillMdPath,
+        '---\nname: old-name\ndescription: old description\n---\n\n# Actual Content\n',
+        "utf-8"
+      );
+
+      const ctx = await initContext(tempDir);
+      const metaCtx = await loadMetaContext(ctx);
+      const skill = metaCtx.skills.find((s) => s.id === "task-work");
+
+      const result = await renderClaudeCodeSkill(ctx, tempDir, skill!);
+      const content = await fs.readFile(result.path, "utf-8");
+
+      // Should have new frontmatter values
+      expect(content).toContain("name: task-work");
+      expect(content).toContain("description: A skill for task work");
+
+      // Should NOT have old values
+      expect(content).not.toContain("name: old-name");
+      expect(content).not.toContain("old description");
+
+      // Should have the actual content
+      expect(content).toContain("# Actual Content");
+
+      // Should have exactly 2 frontmatter delimiters (not 4)
+      const delimiterMatches = content.match(/^---$/gm);
+      expect(delimiterMatches?.length).toBe(2);
+    });
+  });
+
+  // AC: @claude-code-renderer ac-4
+  describe("ac-4: rendered files appear as unstaged changes on main branch", () => {
+    it("should leave rendered files as unstaged changes (not committed)", async () => {
+      const ctx = await initContext(tempDir);
+      const metaCtx = await loadMetaContext(ctx);
+      const skill = metaCtx.skills.find((s) => s.id === "task-work");
+
+      await renderClaudeCodeSkill(ctx, tempDir, skill!);
+
+      // Check git status - file should be untracked or modified
+      // Use -u to show individual files in untracked directories
+      const { execSync } = await import("node:child_process");
+      const gitStatus = execSync("git status --porcelain -u", {
+        cwd: tempDir,
+        encoding: "utf-8",
+      });
+
+      // The rendered file (or its directory) should appear in git status as new/untracked
+      // Git may show either the full path or the directory, depending on config
+      expect(gitStatus).toMatch(/\.claude/);
+    });
+
+    it("should NOT auto-commit rendered files", async () => {
+      const ctx = await initContext(tempDir);
+      const metaCtx = await loadMetaContext(ctx);
+      const skill = metaCtx.skills.find((s) => s.id === "task-work");
+
+      // Create an initial commit so we have a HEAD
+      const { execSync } = await import("node:child_process");
+      execSync("git add -A && git commit -m 'Initial commit'", {
+        cwd: tempDir,
+        encoding: "utf-8",
+      });
+
+      // Get commit count before
+      const commitsBefore = execSync("git rev-list --count HEAD", {
+        cwd: tempDir,
+        encoding: "utf-8",
+      }).trim();
+
+      await renderClaudeCodeSkill(ctx, tempDir, skill!);
+
+      // Get commit count after
+      const commitsAfter = execSync("git rev-list --count HEAD", {
+        cwd: tempDir,
+        encoding: "utf-8",
+      }).trim();
+
+      // Should have same number of commits (no auto-commit)
+      expect(commitsAfter).toBe(commitsBefore);
+    });
+
+    it("should write to main branch working directory not shadow branch", async () => {
+      const ctx = await initContext(tempDir);
+      const metaCtx = await loadMetaContext(ctx);
+      const skill = metaCtx.skills.find((s) => s.id === "task-work");
+
+      const result = await renderClaudeCodeSkill(ctx, tempDir, skill!);
+
+      // The path should be under project root .claude/, not .kspec/
+      expect(result.path).toContain(".claude/skills/task-work/SKILL.md");
+      expect(result.path).not.toContain(".kspec");
+
+      // Verify the file exists at the expected location
+      const renderedPath = path.join(
+        tempDir,
+        ".claude",
+        "skills",
+        "task-work",
+        "SKILL.md"
+      );
+      const stats = await fs.stat(renderedPath);
+      expect(stats.isFile()).toBe(true);
+    });
+  });
+
+  // Additional tests for library behavior
+  describe("Library function behavior", () => {
+    it("should support dry run mode", async () => {
+      const ctx = await initContext(tempDir);
+      const metaCtx = await loadMetaContext(ctx);
+      const skill = metaCtx.skills.find((s) => s.id === "task-work");
+
+      // Call with dry run
+      const result = await renderClaudeCodeSkill(ctx, tempDir, skill!, {
+        dryRun: true,
+      });
+
+      // Should report what would be done
+      expect(result.action).toBe("created");
+
+      // But file should NOT exist
+      await expect(fs.access(result.path)).rejects.toThrow();
+    });
+
+    it("should be idempotent (return unchanged on second call)", async () => {
+      const ctx = await initContext(tempDir);
+      const metaCtx = await loadMetaContext(ctx);
+      const skill = metaCtx.skills.find((s) => s.id === "task-work");
+
+      // First call
+      const result1 = await renderClaudeCodeSkill(ctx, tempDir, skill!);
+      expect(result1.action).toBe("created");
+
+      // Second call
+      const result2 = await renderClaudeCodeSkill(ctx, tempDir, skill!);
+      expect(result2.action).toBe("unchanged");
+    });
+
+    it("should return updated when source content changes", async () => {
+      const ctx = await initContext(tempDir);
+      const metaCtx = await loadMetaContext(ctx);
+      const skill = metaCtx.skills.find((s) => s.id === "task-work");
+
+      // First render
+      const result1 = await renderClaudeCodeSkill(ctx, tempDir, skill!);
+      expect(result1.action).toBe("created");
+
+      // Modify source
+      const skillMdPath = path.join(tempDir, "skills", "task-work", "SKILL.md");
+      await fs.writeFile(skillMdPath, "# Updated Content\n", "utf-8");
+
+      // Second render
+      const result2 = await renderClaudeCodeSkill(ctx, tempDir, skill!);
+      expect(result2.action).toBe("updated");
+    });
+
+    it("should include kspec-managed marker in output", async () => {
+      const ctx = await initContext(tempDir);
+      const metaCtx = await loadMetaContext(ctx);
+      const skill = metaCtx.skills.find((s) => s.id === "task-work");
+
+      const result = await renderClaudeCodeSkill(ctx, tempDir, skill!);
+      const content = await fs.readFile(result.path, "utf-8");
+
+      expect(content).toContain(KSPEC_MANAGED_MARKER);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `renderClaudeCodeSkill()` library function for rendering skills to Claude Code format
- Platform-specific renderer that reads from `.kspec/skills/<id>/SKILL.md` and writes to `.claude/skills/<id>/SKILL.md`
- Generated YAML frontmatter with name and description fields
- Does NOT auto-commit — leaves files unstaged for manual review

## Acceptance Criteria Coverage

- **ac-1**: `renderClaudeCodeSkill` creates `.claude/skills/<id>/SKILL.md` with YAML frontmatter ✅
- **ac-2**: Rendered output has YAML frontmatter delimiters with name and description fields ✅
- **ac-3**: Skill body content from source appears verbatim below frontmatter ✅
- **ac-4**: Rendered files appear as unstaged changes on main branch ✅

## Test plan

- [x] 15 new tests in `tests/claude-code-renderer.test.ts` covering all 4 ACs
- [x] Tests verify frontmatter generation, content preservation, git status behavior
- [x] Tests verify dry run mode and idempotent behavior
- [x] All existing skill rendering tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)