### PR TITLE
feat: implement skill drift detection with hash-based comparison

### DIFF
--- a/src/cli/commands/skill.ts
+++ b/src/cli/commands/skill.ts
@@ -11,6 +11,7 @@
  * AC: @skill-cli ac-8 - kspec skill delete removes .kspec/skills/<id>/ directory
  */
 
+import * as crypto from "node:crypto";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import chalk from "chalk";
@@ -703,6 +704,7 @@ export function registerSkillCommands(program: Command): void {
 
   // AC: @skill-rendering ac-1 through ac-5 - kspec skill render
   // AC: @skill-render-cli ac-1, ac-2 - kspec skill render / kspec skill render @skill-id
+  // AC: @skill-drift-detection ac-3, ac-4 - drift handling with --force
   // AC: @trait-dry-run - supports --dry-run
   // AC: @trait-error-guidance - provides error guidance
   skill
@@ -712,6 +714,7 @@ export function registerSkillCommands(program: Command): void {
     )
     .option("--clean", "Remove orphaned managed skill directories")
     .option("--dry-run", "Show what would be changed without applying")
+    .option("--force", "Overwrite drifted skill files (manually edited)")
     .option("--skill <id>", "Render only a specific skill (deprecated, use positional arg)")
     .action(async (ref: string | undefined, options) => {
       try {
@@ -729,6 +732,7 @@ export function registerSkillCommands(program: Command): void {
         // Use rootDir (project root), not specDir (which is .kspec/ in shadow mode)
         const projectRoot = ctx.rootDir;
         const dryRun = options.dryRun || false;
+        const force = options.force || false;
         const results: SkillRenderResult[] = [];
         const cleanResults: CleanResult[] = [];
 
@@ -763,7 +767,30 @@ export function registerSkillCommands(program: Command): void {
         }
 
         // Render each skill
+        // AC: @skill-drift-detection ac-3, ac-4 - Check drift and skip without --force
         for (const skill of skillsToRender) {
+          // Check for drift before rendering
+          const driftStatus = await checkSkillDrift(ctx.specDir, projectRoot, skill.id);
+
+          // AC: @skill-drift-detection ac-3 - Skip drifted skills without --force
+          if (driftStatus === "drifted" && !force) {
+            const renderedPath = path.join(
+              projectRoot,
+              ".claude",
+              "skills",
+              skill.id,
+              "SKILL.md"
+            );
+            results.push({
+              id: skill.id,
+              action: "skipped",
+              path: renderedPath,
+              skipReason: "drifted (use --force to overwrite)",
+            });
+            continue;
+          }
+
+          // AC: @skill-drift-detection ac-4 - Render (overwrite) when --force is used
           const result = await renderSkill(ctx, projectRoot, skill, dryRun);
           results.push(result);
         }
@@ -834,6 +861,8 @@ export function registerSkillCommands(program: Command): void {
             const created = results.filter((r) => r.action === "created");
             const updated = results.filter((r) => r.action === "updated");
             const unchanged = results.filter((r) => r.action === "unchanged");
+            // AC: @skill-drift-detection ac-3 - Track skipped drifted skills
+            const skippedDrifted = results.filter((r) => r.action === "skipped");
 
             if (created.length > 0) {
               console.log(chalk.green(`Created: ${created.length} skill(s)`));
@@ -851,6 +880,17 @@ export function registerSkillCommands(program: Command): void {
 
             if (unchanged.length > 0 && results.length <= 10) {
               console.log(chalk.gray(`Unchanged: ${unchanged.length} skill(s)`));
+            }
+
+            // AC: @skill-drift-detection ac-3 - Show warning for skipped drifted skills
+            if (skippedDrifted.length > 0) {
+              console.log();
+              console.log(chalk.yellow(`Skipped: ${skippedDrifted.length} drifted skill(s)`));
+              for (const r of skippedDrifted) {
+                console.log(`  ${chalk.yellow("!")} ${r.id}: ${r.skipReason || "drifted"}`);
+              }
+              console.log();
+              console.log(chalk.yellow("Use --force to overwrite drifted skills"));
             }
 
             // Clean results
@@ -1166,12 +1206,15 @@ const KSPEC_MANAGED_MARKER = "<!-- kspec-managed -->";
 
 /**
  * Result of rendering a single skill
+ * AC: @skill-drift-detection ac-3 - Includes "skipped" action for drifted skills
  */
 interface SkillRenderResult {
   id: string;
-  action: "created" | "updated" | "unchanged";
+  action: "created" | "updated" | "unchanged" | "skipped";
   path: string;
   docsAction?: "created" | "updated" | "unchanged" | "skipped";
+  /** Reason why skill was skipped */
+  skipReason?: string;
 }
 
 /**
@@ -1214,6 +1257,82 @@ async function isKspecManaged(skillMdPath: string): Promise<boolean> {
   } catch {
     return false;
   }
+}
+
+/**
+ * Compute SHA256 hash of content
+ * AC: @skill-drift-detection ac-5 - Hash computation for render tracking
+ */
+function computeContentHash(content: string): string {
+  return crypto.createHash("sha256").update(content, "utf-8").digest("hex");
+}
+
+/**
+ * Get the path to the render hash file for a skill
+ * AC: @skill-drift-detection ac-5 - Hash stored in .kspec/skills/<id>/.render-hash
+ */
+function getRenderHashPath(specDir: string, skillId: string): string {
+  return path.join(specDir, "skills", skillId, ".render-hash");
+}
+
+/**
+ * Read the stored render hash for a skill
+ * AC: @skill-drift-detection ac-5 - Read hash from .kspec/skills/<id>/.render-hash
+ */
+async function readRenderHash(specDir: string, skillId: string): Promise<string | null> {
+  try {
+    const hashPath = getRenderHashPath(specDir, skillId);
+    const content = await fs.readFile(hashPath, "utf-8");
+    return content.trim();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Write the render hash for a skill
+ * AC: @skill-drift-detection ac-5 - Store hash in .kspec/skills/<id>/.render-hash
+ */
+async function writeRenderHash(specDir: string, skillId: string, hash: string): Promise<void> {
+  const hashPath = getRenderHashPath(specDir, skillId);
+  await fs.mkdir(path.dirname(hashPath), { recursive: true });
+  await fs.writeFile(hashPath, hash + "\n", "utf-8");
+}
+
+/**
+ * Check if a rendered skill has drifted from its last render
+ * AC: @skill-drift-detection ac-1, ac-2 - Drift detection via hash comparison
+ *
+ * Returns:
+ * - "not-rendered": Rendered file doesn't exist
+ * - "in-sync": Rendered file matches stored hash
+ * - "drifted": Rendered file differs from stored hash (manually edited)
+ * - "no-hash": Rendered file exists but no stored hash (first render or hash deleted)
+ */
+async function checkSkillDrift(
+  specDir: string,
+  projectRoot: string,
+  skillId: string
+): Promise<"not-rendered" | "in-sync" | "drifted" | "no-hash"> {
+  const renderedPath = path.join(projectRoot, ".claude", "skills", skillId, "SKILL.md");
+
+  // Check if rendered file exists
+  let renderedContent: string;
+  try {
+    renderedContent = await fs.readFile(renderedPath, "utf-8");
+  } catch {
+    return "not-rendered";
+  }
+
+  // Get stored hash
+  const storedHash = await readRenderHash(specDir, skillId);
+  if (!storedHash) {
+    return "no-hash";
+  }
+
+  // Compare hashes
+  const currentHash = computeContentHash(renderedContent);
+  return currentHash === storedHash ? "in-sync" : "drifted";
 }
 
 /**
@@ -1295,6 +1414,9 @@ async function renderSkill(
     if (!dryRun) {
       await fs.mkdir(targetDir, { recursive: true });
       await fs.writeFile(targetSkillMd, renderedContent, "utf-8");
+      // AC: @skill-drift-detection ac-5 - Store hash of rendered output
+      const hash = computeContentHash(renderedContent);
+      await writeRenderHash(ctx.specDir, skill.id, hash);
     }
 
     return {
@@ -1342,6 +1464,9 @@ async function renderSkill(
   if (!dryRun && action !== "unchanged") {
     await fs.mkdir(targetDir, { recursive: true });
     await fs.writeFile(targetSkillMd, renderedContent, "utf-8");
+    // AC: @skill-drift-detection ac-5 - Store hash of rendered output
+    const hash = computeContentHash(renderedContent);
+    await writeRenderHash(ctx.specDir, skill.id, hash);
   }
 
   // Handle docs directory
@@ -1405,30 +1530,46 @@ interface SkillStatusResult {
 /**
  * Get the sync status of a skill
  * AC: @skill-render-cli ac-3
+ * AC: @skill-drift-detection ac-1, ac-2 - Uses hash-based drift detection
  */
 async function getSkillSyncStatus(
   ctx: KspecContext,
   projectRoot: string,
   skill: LoadedSkill
 ): Promise<SkillStatusResult> {
-  const expectedContent = await getExpectedRenderedContent(ctx, skill);
-  const renderedPath = path.join(
-    projectRoot,
-    ".claude",
-    "skills",
-    skill.id,
-    "SKILL.md"
-  );
+  // AC: @skill-drift-detection ac-1, ac-2 - Use hash-based drift detection
+  const driftStatus = await checkSkillDrift(ctx.specDir, projectRoot, skill.id);
 
-  let actualContent = "";
-  let status: "in-sync" | "drifted" | "not-rendered" = "not-rendered";
-
-  try {
-    actualContent = await fs.readFile(renderedPath, "utf-8");
-    status = contentsEqual(expectedContent, actualContent) ? "in-sync" : "drifted";
-  } catch {
-    // File doesn't exist
-    status = "not-rendered";
+  // Map drift status to sync status
+  let status: "in-sync" | "drifted" | "not-rendered";
+  switch (driftStatus) {
+    case "in-sync":
+      status = "in-sync";
+      break;
+    case "drifted":
+      status = "drifted";
+      break;
+    case "not-rendered":
+      status = "not-rendered";
+      break;
+    case "no-hash":
+      // No hash stored - need to check if content matches expected
+      // (handles edge case where skill was rendered before hash tracking was added)
+      const expectedContent = await getExpectedRenderedContent(ctx, skill);
+      const renderedPath = path.join(
+        projectRoot,
+        ".claude",
+        "skills",
+        skill.id,
+        "SKILL.md"
+      );
+      try {
+        const actualContent = await fs.readFile(renderedPath, "utf-8");
+        status = contentsEqual(expectedContent, actualContent) ? "in-sync" : "drifted";
+      } catch {
+        status = "not-rendered";
+      }
+      break;
   }
 
   // Check docs status

--- a/tests/skill-rendering.test.ts
+++ b/tests/skill-rendering.test.ts
@@ -593,3 +593,306 @@ describe('Skill Render CLI', () => {
     });
   });
 });
+
+/**
+ * Tests for Skill Drift Detection
+ * AC: @skill-drift-detection ac-1 through ac-5
+ */
+describe('Skill Drift Detection', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await setupTempFixtures();
+    await initGitRepo(tempDir);
+
+    // Create a test skill
+    const result = kspecFull(
+      'skill add --id test-skill --name "Test Skill" --description "A test skill" --platform claude-code',
+      tempDir
+    );
+    if (result.exitCode !== 0) {
+      throw new Error(`skill add failed: ${result.stderr || result.stdout}`);
+    }
+
+    // Write custom content to the skill's SKILL.md
+    const skillMdPath = path.join(tempDir, 'skills', 'test-skill', 'SKILL.md');
+    await fs.writeFile(skillMdPath, '# Test Skill\n\nThis is test content.\n', 'utf-8');
+  });
+
+  afterEach(async () => {
+    await cleanupTempDir(tempDir);
+  });
+
+  // AC: @skill-drift-detection ac-1
+  describe('ac-1: Skill shows as in sync when not manually edited', () => {
+    it('should show in-sync after rendering', async () => {
+      kspecFull('skill render', tempDir);
+
+      const result = kspecFull('skill status', tempDir);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('test-skill');
+      expect(result.stdout).toContain('in-sync');
+    });
+
+    it('should show in-sync on re-render without changes', async () => {
+      kspecFull('skill render', tempDir);
+      kspecFull('skill render', tempDir);
+
+      const result = kspecFull('skill status', tempDir);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('in-sync');
+    });
+  });
+
+  // AC: @skill-drift-detection ac-2
+  describe('ac-2: Skill shows as drifted when manually edited', () => {
+    it('should show drifted after manual edit to rendered file', async () => {
+      // Render the skill
+      kspecFull('skill render', tempDir);
+
+      // Manually edit the rendered file
+      const renderedPath = path.join(tempDir, '.claude', 'skills', 'test-skill', 'SKILL.md');
+      const content = await fs.readFile(renderedPath, 'utf-8');
+      await fs.writeFile(renderedPath, content + '\n\n# Manually Added Section\n', 'utf-8');
+
+      const result = kspecFull('skill status', tempDir);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('test-skill');
+      expect(result.stdout).toContain('drifted');
+    });
+
+    it('should show drifted with the file path in message', async () => {
+      kspecFull('skill render', tempDir);
+
+      // Manually edit
+      const renderedPath = path.join(tempDir, '.claude', 'skills', 'test-skill', 'SKILL.md');
+      const content = await fs.readFile(renderedPath, 'utf-8');
+      await fs.writeFile(renderedPath, content + '\nEdited.\n', 'utf-8');
+
+      const result = kspecFull('skill status', tempDir);
+      expect(result.stdout).toContain('drifted');
+      expect(result.stdout).toContain("run 'kspec skill render' to sync");
+    });
+  });
+
+  // AC: @skill-drift-detection ac-3
+  describe('ac-3: Drifted skill is skipped without --force', () => {
+    it('should skip drifted skill with warning when rendering without --force', async () => {
+      // First render
+      kspecFull('skill render', tempDir);
+
+      // Manually edit the rendered file
+      const renderedPath = path.join(tempDir, '.claude', 'skills', 'test-skill', 'SKILL.md');
+      const originalContent = await fs.readFile(renderedPath, 'utf-8');
+      const editedContent = originalContent + '\n\n# Manually Added\n';
+      await fs.writeFile(renderedPath, editedContent, 'utf-8');
+
+      // Try to render again without --force
+      const result = kspecFull('skill render', tempDir);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Skipped');
+      expect(result.stdout).toContain('drifted');
+      expect(result.stdout).toContain('--force to overwrite');
+
+      // Verify the file was NOT overwritten
+      const afterContent = await fs.readFile(renderedPath, 'utf-8');
+      expect(afterContent).toBe(editedContent);
+      expect(afterContent).toContain('# Manually Added');
+    });
+
+    it('should show skip reason in JSON output', async () => {
+      kspecFull('skill render', tempDir);
+
+      // Edit the file
+      const renderedPath = path.join(tempDir, '.claude', 'skills', 'test-skill', 'SKILL.md');
+      const content = await fs.readFile(renderedPath, 'utf-8');
+      await fs.writeFile(renderedPath, content + '\nEdited.\n', 'utf-8');
+
+      const result = kspecJson<{
+        rendered: Array<{ id: string; action: string; skipReason?: string }>;
+      }>('skill render', tempDir);
+
+      expect(result.rendered[0].action).toBe('skipped');
+      expect(result.rendered[0].skipReason).toContain('drifted');
+    });
+  });
+
+  // AC: @skill-drift-detection ac-4
+  describe('ac-4: Drifted skill is overwritten with --force', () => {
+    it('should overwrite drifted skill when using --force', async () => {
+      // First render
+      kspecFull('skill render', tempDir);
+
+      // Get the original content
+      const renderedPath = path.join(tempDir, '.claude', 'skills', 'test-skill', 'SKILL.md');
+      const originalContent = await fs.readFile(renderedPath, 'utf-8');
+
+      // Manually edit the rendered file
+      await fs.writeFile(renderedPath, originalContent + '\n\n# Manually Added\n', 'utf-8');
+
+      // Verify it's drifted
+      let status = kspecFull('skill status', tempDir);
+      expect(status.stdout).toContain('drifted');
+
+      // Render with --force
+      const result = kspecFull('skill render --force', tempDir);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Updated');
+      expect(result.stdout).toContain('test-skill');
+
+      // Verify the file was overwritten
+      const afterContent = await fs.readFile(renderedPath, 'utf-8');
+      expect(afterContent).not.toContain('# Manually Added');
+      expect(afterContent.trim()).toBe(originalContent.trim());
+
+      // Verify status is now in-sync
+      status = kspecFull('skill status', tempDir);
+      expect(status.stdout).toContain('in-sync');
+    });
+
+    it('should update hash after force overwrite', async () => {
+      kspecFull('skill render', tempDir);
+
+      // Edit the file
+      const renderedPath = path.join(tempDir, '.claude', 'skills', 'test-skill', 'SKILL.md');
+      const content = await fs.readFile(renderedPath, 'utf-8');
+      await fs.writeFile(renderedPath, content + '\nEdited.\n', 'utf-8');
+
+      // Force render
+      kspecFull('skill render --force', tempDir);
+
+      // Status should be in-sync (hash was updated)
+      const status = kspecFull('skill status', tempDir);
+      expect(status.stdout).toContain('in-sync');
+    });
+  });
+
+  // AC: @skill-drift-detection ac-5
+  describe('ac-5: Render hash is stored in .kspec/skills/<id>/.render-hash', () => {
+    it('should create .render-hash file after successful render', async () => {
+      kspecFull('skill render', tempDir);
+
+      // Check if hash file exists
+      // In test fixtures, skills are stored in tempDir/skills/ not tempDir/.kspec/skills/
+      const hashPath = path.join(tempDir, 'skills', 'test-skill', '.render-hash');
+      const hashContent = await fs.readFile(hashPath, 'utf-8');
+
+      expect(hashContent.trim()).toBeTruthy();
+      // SHA256 hashes are 64 hex characters
+      expect(hashContent.trim()).toMatch(/^[a-f0-9]{64}$/);
+    });
+
+    it('should update .render-hash on subsequent renders', async () => {
+      // First render
+      kspecFull('skill render', tempDir);
+
+      const hashPath = path.join(tempDir, 'skills', 'test-skill', '.render-hash');
+      const firstHash = await fs.readFile(hashPath, 'utf-8');
+
+      // Modify source content
+      const skillMdPath = path.join(tempDir, 'skills', 'test-skill', 'SKILL.md');
+      await fs.writeFile(skillMdPath, '# Test Skill\n\nUpdated content.\n', 'utf-8');
+
+      // Second render
+      kspecFull('skill render', tempDir);
+
+      const secondHash = await fs.readFile(hashPath, 'utf-8');
+
+      // Hashes should be different
+      expect(secondHash.trim()).not.toBe(firstHash.trim());
+    });
+
+    it('should not create .render-hash during dry run', async () => {
+      kspecFull('skill render --dry-run', tempDir);
+
+      const hashPath = path.join(tempDir, 'skills', 'test-skill', '.render-hash');
+      await expect(fs.access(hashPath)).rejects.toThrow();
+    });
+
+    it('should use hash to detect drift, not content comparison', async () => {
+      // Render the skill
+      kspecFull('skill render', tempDir);
+
+      // Get the rendered content
+      const renderedPath = path.join(tempDir, '.claude', 'skills', 'test-skill', 'SKILL.md');
+      const content = await fs.readFile(renderedPath, 'utf-8');
+
+      // Manually edit the rendered file but put back original content after
+      await fs.writeFile(renderedPath, content + '\nTemporary edit.\n', 'utf-8');
+
+      // Even if we restore content, hash won't match original since file was overwritten
+      // Actually, let's test the opposite - modify source but not rendered
+      // The status should still show in-sync because hash matches
+
+      // For this test, we check that modifying rendered file (even slightly) breaks hash match
+      await fs.writeFile(renderedPath, content + ' ', 'utf-8'); // Add trailing space
+
+      const status = kspecFull('skill status', tempDir);
+      expect(status.stdout).toContain('drifted');
+    });
+  });
+
+  describe('Edge cases', () => {
+    it('should handle missing hash file gracefully (legacy renders)', async () => {
+      // Render the skill
+      kspecFull('skill render', tempDir);
+
+      // Delete the hash file to simulate legacy render
+      const hashPath = path.join(tempDir, 'skills', 'test-skill', '.render-hash');
+      await fs.rm(hashPath);
+
+      // Status should fall back to content comparison
+      const status = kspecFull('skill status', tempDir);
+      expect(status.stdout).toContain('in-sync');
+    });
+
+    it('should allow rendering non-drifted skills normally', async () => {
+      // First render
+      kspecFull('skill render', tempDir);
+
+      // Modify source content (not rendered file)
+      const skillMdPath = path.join(tempDir, 'skills', 'test-skill', 'SKILL.md');
+      await fs.writeFile(skillMdPath, '# Test Skill\n\nUpdated source content.\n', 'utf-8');
+
+      // Render again - should work without --force because file isn't drifted
+      const result = kspecFull('skill render', tempDir);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Updated');
+      expect(result.stdout).not.toContain('Skipped');
+
+      // Verify update was applied
+      const renderedPath = path.join(tempDir, '.claude', 'skills', 'test-skill', 'SKILL.md');
+      const renderedContent = await fs.readFile(renderedPath, 'utf-8');
+      expect(renderedContent).toContain('Updated source content');
+    });
+
+    it('should handle multiple skills with mixed drift states', async () => {
+      // Add another skill
+      kspecFull(
+        'skill add --id another-skill --name "Another Skill" --description "Another test" --platform claude-code',
+        tempDir
+      );
+      const anotherSkillMd = path.join(tempDir, 'skills', 'another-skill', 'SKILL.md');
+      await fs.writeFile(anotherSkillMd, '# Another Skill\n\nAnother content.\n', 'utf-8');
+
+      // Render both skills
+      kspecFull('skill render', tempDir);
+
+      // Edit only the first skill's rendered file
+      const renderedPath = path.join(tempDir, '.claude', 'skills', 'test-skill', 'SKILL.md');
+      const content = await fs.readFile(renderedPath, 'utf-8');
+      await fs.writeFile(renderedPath, content + '\nEdited.\n', 'utf-8');
+
+      // Render without --force - should skip test-skill but render another-skill
+      const result = kspecFull('skill render', tempDir);
+      expect(result.stdout).toContain('Skipped');
+      expect(result.stdout).toContain('test-skill');
+      expect(result.stdout).toContain('Unchanged'); // another-skill
+
+      // With --force - should update both
+      const forceResult = kspecFull('skill render --force', tempDir);
+      expect(forceResult.stdout).toContain('Updated');
+      expect(forceResult.stdout).toContain('test-skill');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Implement hash-based drift detection for rendered skills to detect manual edits
- Add SHA256 hash storage in `.kspec/skills/<id>/.render-hash` after successful render
- Add `--force` option to overwrite drifted skill files
- Skip drifted skills with warning when rendering without `--force`
- Update `kspec skill status` to use hash-based drift detection

## Changes
- Added `computeContentHash()` function using SHA256
- Added `readRenderHash()` / `writeRenderHash()` for hash persistence
- Added `checkSkillDrift()` for hash-based drift checking
- Updated render command to check drift and skip/warn without `--force`
- Updated `getSkillSyncStatus()` to use hash comparison
- Added 16 new tests covering all acceptance criteria and edge cases

## Test plan
- [x] All 48 skill rendering tests pass
- [x] Hash file created after render (SHA256 hex format)
- [x] Drifted skills skipped without `--force` with warning message
- [x] Drifted skills overwritten with `--force`
- [x] Status shows in-sync when hash matches, drifted when mismatched
- [x] Legacy renders (no hash file) handled gracefully via content fallback

Task: @implement-skill-drift-detection
Spec: @skill-drift-detection

🤖 Generated with [Claude Code](https://claude.ai/code)