### PR TITLE
feat: implement core skill installation

### DIFF
--- a/src/cli/commands/skill.ts
+++ b/src/cli/commands/skill.ts
@@ -9,10 +9,17 @@
  * AC: @skill-cli ac-6 - kspec skill get outputs SKILL.md content
  * AC: @skill-cli ac-7 - kspec skill delete --confirm removes meta entry
  * AC: @skill-cli ac-8 - kspec skill delete removes .kspec/skills/<id>/ directory
+ *
+ * AC: @core-skill-install ac-1 - meta entries created with origin core
+ * AC: @core-skill-install ac-2 - content files copied from templates to .kspec/skills/<id>/
+ * AC: @core-skill-install ac-3 - custom skills skipped with message
+ * AC: @core-skill-install ac-4 - --force overwrites custom forks
+ * AC: @core-skill-install ac-5 - version matches kspec package version
  */
 
 import * as crypto from "node:crypto";
 import * as fs from "node:fs/promises";
+import { readFileSync } from "node:fs";
 import * as path from "node:path";
 import chalk from "chalk";
 import Table from "cli-table3";
@@ -1133,6 +1140,270 @@ export function registerSkillCommands(program: Command): void {
         process.exit(EXIT_CODES.ERROR);
       }
     });
+
+  // AC: @core-skill-install - kspec skill install-core
+  markMutating(skill.command("install-core"))
+    .description(
+      "Install core skills from kspec package templates"
+    )
+    .option("--force", "Overwrite custom forks with core versions")
+    .option("--dry-run", "Show what would be installed without making changes")
+    .action(async (options) => {
+      try {
+        const ctx = await initContext();
+
+        if (!ctx.manifestPath) {
+          error(errors.project.noKspecProject);
+          console.log(
+            chalk.gray("Try: kspec init to initialize a kspec project")
+          );
+          process.exit(EXIT_CODES.ERROR);
+        }
+
+        const metaCtx = await loadMetaContext(ctx);
+        const dryRun = options.dryRun || false;
+        const force = options.force || false;
+        const results: CoreSkillInstallResult[] = [];
+
+        // Load core skills manifest
+        const coreSkills = loadCoreSkillsManifest();
+        if (coreSkills.length === 0) {
+          console.log(chalk.yellow("No core skills found in kspec package templates"));
+          return;
+        }
+
+        // Get kspec package version
+        const kspecVersion = getKspecPackageVersion();
+
+        // Process each core skill
+        for (const coreSkill of coreSkills) {
+          // AC: @core-skill-install ac-3 - Check if skill exists with custom origin
+          const existingSkill = metaCtx.skills.find((s) => s.id === coreSkill.id);
+
+          if (existingSkill) {
+            // Check origin - if "custom" or "project" and not forcing, skip
+            if (existingSkill.origin !== "core" && !force) {
+              results.push({
+                id: coreSkill.id,
+                action: "skipped",
+                reason: `existing ${existingSkill.origin} skill (use --force to overwrite)`,
+              });
+              continue;
+            }
+          }
+
+          // AC: @core-skill-install ac-1 - Create/update meta entry with origin core
+          // AC: @core-skill-install ac-5 - Version matches kspec package version
+          const skillData: Skill = {
+            _ulid: existingSkill?._ulid || ulid(),
+            id: coreSkill.id,
+            name: coreSkill.name,
+            description: coreSkill.description,
+            origin: "core",
+            version: kspecVersion,
+            platforms: coreSkill.platforms || ["claude-code"],
+            depends_on: [],
+            tags: ["core"],
+          };
+
+          // Validate with schema
+          const parsed = SkillSchema.safeParse(skillData);
+          if (!parsed.success) {
+            const issues = parsed.error.issues
+              .map((i) => `${i.path.join(".")}: ${i.message}`)
+              .join("; ");
+            results.push({
+              id: coreSkill.id,
+              action: "failed",
+              reason: `validation error: ${issues}`,
+            });
+            continue;
+          }
+
+          const skill: LoadedSkill = { ...parsed.data };
+
+          // Save meta entry (if not dry run)
+          if (!dryRun) {
+            await saveMetaItem(ctx, skill, "skill");
+
+            // AC: @core-skill-install ac-2 - Copy SKILL.md content
+            const sourceContent = loadCoreSkillContent(coreSkill.id);
+            if (sourceContent) {
+              const targetPath = getSkillContentPath(ctx, skill.id);
+              await fs.writeFile(targetPath, sourceContent, "utf-8");
+            }
+          }
+
+          results.push({
+            id: coreSkill.id,
+            action: existingSkill ? "updated" : "created",
+            version: kspecVersion,
+          });
+        }
+
+        // Commit changes if not dry run
+        if (!dryRun && results.some((r) => r.action === "created" || r.action === "updated")) {
+          await commitIfShadow(
+            ctx.shadow,
+            "skill-install-core",
+            `${results.filter((r) => r.action !== "skipped" && r.action !== "failed").length} core skills`
+          );
+        }
+
+        // Output results
+        output(
+          {
+            dry_run: dryRun,
+            results,
+          },
+          () => {
+            if (dryRun) {
+              console.log(chalk.yellow("DRY RUN - No changes made"));
+              console.log();
+            }
+
+            const created = results.filter((r) => r.action === "created");
+            const updated = results.filter((r) => r.action === "updated");
+            const skipped = results.filter((r) => r.action === "skipped");
+            const failed = results.filter((r) => r.action === "failed");
+
+            if (created.length > 0) {
+              console.log(chalk.green(`Created: ${created.length} skill(s)`));
+              for (const r of created) {
+                console.log(`  ${chalk.green("+")} ${r.id} (v${r.version})`);
+              }
+            }
+
+            if (updated.length > 0) {
+              console.log(chalk.blue(`Updated: ${updated.length} skill(s)`));
+              for (const r of updated) {
+                console.log(`  ${chalk.blue("~")} ${r.id} (v${r.version})`);
+              }
+            }
+
+            if (skipped.length > 0) {
+              console.log(chalk.yellow(`Skipped: ${skipped.length} skill(s)`));
+              for (const r of skipped) {
+                console.log(`  ${chalk.yellow("!")} ${r.id}: ${r.reason}`);
+              }
+            }
+
+            if (failed.length > 0) {
+              console.log(chalk.red(`Failed: ${failed.length} skill(s)`));
+              for (const r of failed) {
+                console.log(`  ${chalk.red("x")} ${r.id}: ${r.reason}`);
+              }
+            }
+
+            console.log();
+            if (dryRun) {
+              console.log(
+                chalk.yellow("No changes were made. Run without --dry-run to apply.")
+              );
+            } else {
+              const changedCount = created.length + updated.length;
+              if (changedCount > 0) {
+                success(`Installed ${changedCount} core skill(s)`);
+              } else if (skipped.length > 0) {
+                console.log(chalk.gray("No skills installed (all skipped or failed)"));
+              }
+            }
+          }
+        );
+      } catch (err) {
+        error("Failed to install core skills", err);
+        process.exit(EXIT_CODES.ERROR);
+      }
+    });
+}
+
+/**
+ * Result of installing a single core skill
+ */
+interface CoreSkillInstallResult {
+  id: string;
+  action: "created" | "updated" | "skipped" | "failed";
+  version?: string;
+  reason?: string;
+}
+
+/**
+ * Core skill definition from manifest
+ */
+interface CoreSkillDefinition {
+  id: string;
+  name: string;
+  description?: string;
+  platforms?: string[];
+}
+
+/**
+ * Get the kspec package version from package.json
+ * AC: @core-skill-install ac-5
+ */
+function getKspecPackageVersion(): string {
+  try {
+    // Try to find package.json relative to this module
+    const packagePath = path.resolve(
+      import.meta.dirname || path.dirname(new URL(import.meta.url).pathname),
+      "../../../package.json"
+    );
+    const packageJson = JSON.parse(readFileSync(packagePath, "utf-8"));
+    return packageJson.version || "unknown";
+  } catch {
+    return "unknown";
+  }
+}
+
+/**
+ * Get the templates directory path
+ */
+function getTemplatesDir(): string {
+  // Templates are at <package-root>/templates/skills/
+  return path.resolve(
+    import.meta.dirname || path.dirname(new URL(import.meta.url).pathname),
+    "../../../templates/skills"
+  );
+}
+
+/**
+ * Load core skills manifest from templates/skills/manifest.yaml
+ * AC: @core-skill-install ac-1, ac-2
+ */
+function loadCoreSkillsManifest(): CoreSkillDefinition[] {
+  try {
+    const templatesDir = getTemplatesDir();
+    const manifestPath = path.join(templatesDir, "manifest.yaml");
+    const content = readFileSync(manifestPath, "utf-8");
+    const parsed = yaml.parse(content);
+
+    if (!parsed || !Array.isArray(parsed.skills)) {
+      return [];
+    }
+
+    return parsed.skills.map((s: Record<string, unknown>) => ({
+      id: String(s.id || ""),
+      name: String(s.name || s.id || ""),
+      description: s.description ? String(s.description) : undefined,
+      platforms: Array.isArray(s.platforms) ? s.platforms.map(String) : undefined,
+    })).filter((s: CoreSkillDefinition) => s.id);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Load SKILL.md content for a core skill from templates
+ * AC: @core-skill-install ac-2
+ */
+function loadCoreSkillContent(skillId: string): string | null {
+  try {
+    const templatesDir = getTemplatesDir();
+    const skillMdPath = path.join(templatesDir, skillId, "SKILL.md");
+    return readFileSync(skillMdPath, "utf-8");
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -1751,4 +2022,7 @@ export {
   getSkillSyncStatus,
   getExpectedRenderedContent,
   generateUnifiedDiff,
+  loadCoreSkillsManifest,
+  loadCoreSkillContent,
+  getKspecPackageVersion,
 };

--- a/templates/skills/kspec-help/SKILL.md
+++ b/templates/skills/kspec-help/SKILL.md
@@ -1,0 +1,37 @@
+# kspec Help
+
+Get help with kspec commands and workflows.
+
+## When to Use
+
+Use this skill when:
+- You need to understand kspec commands
+- You want to learn about task and spec workflows
+- You need help with CLI syntax
+
+## Quick Reference
+
+```bash
+# Core commands
+kspec help                    # Show all commands
+kspec help <command>          # Show command help
+kspec task list               # List tasks
+kspec tasks ready             # Show ready tasks
+kspec item list               # List spec items
+
+# Task lifecycle
+kspec task start @ref         # Start working
+kspec task note @ref "..."    # Add note
+kspec task submit @ref        # Submit for review
+kspec task complete @ref      # Mark complete
+
+# Spec management
+kspec item add --title "..."  # Create spec item
+kspec item ac add @ref --given "..." --when "..." --then "..."
+```
+
+## Key Concepts
+
+- **Spec items**: Define WHAT to build (requirements, features)
+- **Tasks**: Track the WORK of building
+- **Shadow branch**: Separate branch for spec/task state

--- a/templates/skills/manifest.yaml
+++ b/templates/skills/manifest.yaml
@@ -1,0 +1,10 @@
+# Core Skills Manifest
+# This file defines the metadata for core skills shipped with kspec.
+# The skill content is in ./<skill-id>/SKILL.md
+
+skills:
+  - id: kspec-help
+    name: Kspec Help
+    description: Get help with kspec commands and workflows
+    platforms:
+      - claude-code

--- a/tests/core-skill-install.test.ts
+++ b/tests/core-skill-install.test.ts
@@ -1,0 +1,266 @@
+/**
+ * Tests for Core Skill Installation
+ * AC: @core-skill-install ac-1 through ac-5
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import {
+  kspec as kspecFull,
+  kspecJson,
+  setupTempFixtures,
+  cleanupTempDir,
+  initGitRepo,
+} from './helpers/cli';
+
+describe('Core Skill Installation', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await setupTempFixtures();
+    await initGitRepo(tempDir);
+  });
+
+  afterEach(async () => {
+    await cleanupTempDir(tempDir);
+  });
+
+  // AC: @core-skill-install ac-1
+  describe('ac-1: Meta entries created with origin core', () => {
+    it('should create skill meta entries with origin "core"', async () => {
+      const result = kspecFull('skill install-core', tempDir);
+      expect(result.exitCode).toBe(0);
+
+      // Check skill was created
+      const skills = kspecJson<{ id: string; origin: string }[]>('skill list', tempDir);
+      const coreSkill = skills.find((s) => s.id === 'kspec-help');
+
+      expect(coreSkill).toBeDefined();
+      expect(coreSkill?.origin).toBe('core');
+    });
+
+    it('should include "core" tag on installed skills', async () => {
+      kspecFull('skill install-core', tempDir);
+
+      const skills = kspecJson<{ id: string; tags?: string[] }[]>('skill list', tempDir);
+      const coreSkill = skills.find((s) => s.id === 'kspec-help');
+
+      expect(coreSkill?.tags).toContain('core');
+    });
+  });
+
+  // AC: @core-skill-install ac-2
+  describe('ac-2: Content files copied to .kspec/skills/<id>/', () => {
+    it('should copy SKILL.md content from templates', async () => {
+      kspecFull('skill install-core', tempDir);
+
+      // Note: In test fixtures (non-shadow mode), skills are at tempDir/skills/ not tempDir/.kspec/skills/
+      const skillMdPath = path.join(tempDir, 'skills', 'kspec-help', 'SKILL.md');
+      const content = await fs.readFile(skillMdPath, 'utf-8');
+
+      // Check content was copied (matches the template content)
+      expect(content).toContain('# kspec Help');
+      expect(content).toContain('Get help with kspec commands');
+    });
+
+    it('should create skill directory if it does not exist', async () => {
+      kspecFull('skill install-core', tempDir);
+
+      const skillDir = path.join(tempDir, 'skills', 'kspec-help');
+      const stat = await fs.stat(skillDir);
+      expect(stat.isDirectory()).toBe(true);
+    });
+  });
+
+  // AC: @core-skill-install ac-3
+  describe('ac-3: Custom skills skipped with message', () => {
+    it('should skip existing custom/project origin skills', async () => {
+      // First create a custom skill with the same ID
+      kspecFull(
+        'skill add --id kspec-help --name "My Custom Help" --description "Custom version" --origin project',
+        tempDir
+      );
+
+      // Try to install core skills
+      const result = kspecFull('skill install-core', tempDir);
+      expect(result.stdout).toContain('Skipped');
+      expect(result.stdout).toContain('kspec-help');
+      expect(result.stdout).toContain('use --force to overwrite');
+
+      // Verify the skill still has project origin
+      const skills = kspecJson<{ id: string; origin: string }[]>('skill list', tempDir);
+      const helpSkill = skills.find((s) => s.id === 'kspec-help');
+      expect(helpSkill?.origin).toBe('project');
+    });
+
+    it('should update existing core origin skills', async () => {
+      // First install core skills
+      kspecFull('skill install-core', tempDir);
+
+      // Install again - should update (not skip)
+      const result = kspecFull('skill install-core', tempDir);
+
+      // It should be "Updated" not "Skipped"
+      expect(result.stdout).toContain('Updated');
+      expect(result.stdout).toContain('kspec-help');
+    });
+  });
+
+  // AC: @core-skill-install ac-4
+  describe('ac-4: --force overwrites custom forks', () => {
+    it('should overwrite custom skills when --force is used', async () => {
+      // First create a custom skill
+      kspecFull(
+        'skill add --id kspec-help --name "My Custom Help" --description "Custom version" --origin project',
+        tempDir
+      );
+
+      // Verify it's project origin
+      let skills = kspecJson<{ id: string; origin: string }[]>('skill list', tempDir);
+      expect(skills.find((s) => s.id === 'kspec-help')?.origin).toBe('project');
+
+      // Install with --force
+      const result = kspecFull('skill install-core --force', tempDir);
+      expect(result.stdout).toContain('Updated');
+      expect(result.stdout).toContain('kspec-help');
+
+      // Verify it's now core origin
+      skills = kspecJson<{ id: string; origin: string }[]>('skill list', tempDir);
+      expect(skills.find((s) => s.id === 'kspec-help')?.origin).toBe('core');
+    });
+
+    it('should update SKILL.md content when --force is used', async () => {
+      // Create custom skill with custom content
+      kspecFull(
+        'skill add --id kspec-help --name "My Custom Help" --description "Custom version" --origin project',
+        tempDir
+      );
+
+      const skillMdPath = path.join(tempDir, 'skills', 'kspec-help', 'SKILL.md');
+      await fs.writeFile(skillMdPath, '# Custom Content\n\nThis is my custom content.\n', 'utf-8');
+
+      // Install with --force
+      kspecFull('skill install-core --force', tempDir);
+
+      // Verify content was overwritten with core content
+      const content = await fs.readFile(skillMdPath, 'utf-8');
+      expect(content).toContain('# kspec Help');
+      expect(content).not.toContain('Custom Content');
+    });
+  });
+
+  // AC: @core-skill-install ac-5
+  describe('ac-5: Version matches kspec package version', () => {
+    it('should set skill version to kspec package version', async () => {
+      kspecFull('skill install-core', tempDir);
+
+      const skills = kspecJson<{ id: string; version?: string }[]>('skill list', tempDir);
+      const coreSkill = skills.find((s) => s.id === 'kspec-help');
+
+      expect(coreSkill?.version).toBeDefined();
+      // Version should be a semver-like string (e.g., "0.1.2")
+      expect(coreSkill?.version).toMatch(/^\d+\.\d+\.\d+/);
+    });
+
+    it('should show version in install output', async () => {
+      const result = kspecFull('skill install-core', tempDir);
+
+      // Should show "(vX.Y.Z)" in output
+      expect(result.stdout).toMatch(/\(v\d+\.\d+\.\d+\)/);
+    });
+  });
+
+  // Dry run support
+  describe('dry-run support', () => {
+    it('should not make changes with --dry-run', async () => {
+      const result = kspecFull('skill install-core --dry-run', tempDir);
+
+      expect(result.stdout).toContain('DRY RUN');
+      expect(result.stdout).toContain('No changes were made');
+
+      // Verify skill was NOT created
+      const skills = kspecJson<{ id: string }[]>('skill list', tempDir);
+      const coreSkill = skills.find((s) => s.id === 'kspec-help');
+      expect(coreSkill).toBeUndefined();
+    });
+
+    it('should show what would be installed with --dry-run', async () => {
+      const result = kspecFull('skill install-core --dry-run', tempDir);
+
+      expect(result.stdout).toContain('Created: 1 skill(s)');
+      expect(result.stdout).toContain('kspec-help');
+    });
+  });
+
+  // JSON output support
+  describe('JSON output', () => {
+    it('should return JSON with results array', async () => {
+      const result = kspecJson<{ results: { id: string; action: string }[] }>(
+        'skill install-core',
+        tempDir
+      );
+
+      expect(result.results).toBeDefined();
+      expect(Array.isArray(result.results)).toBe(true);
+      expect(result.results.length).toBeGreaterThan(0);
+
+      const kspecHelp = result.results.find((r) => r.id === 'kspec-help');
+      expect(kspecHelp).toBeDefined();
+      expect(kspecHelp?.action).toBe('created');
+    });
+
+    it('should include dry_run field in JSON output', async () => {
+      const result = kspecJson<{ dry_run: boolean; results: unknown[] }>(
+        'skill install-core --dry-run',
+        tempDir
+      );
+
+      expect(result.dry_run).toBe(true);
+    });
+  });
+});
+
+describe('Core Skills Manifest Loading', () => {
+  it('should load core skills from templates/skills/manifest.yaml', async () => {
+    // Import the function for direct testing
+    const { loadCoreSkillsManifest } = await import('../src/cli/commands/skill.js');
+
+    const skills = loadCoreSkillsManifest();
+
+    expect(skills.length).toBeGreaterThan(0);
+
+    const kspecHelp = skills.find((s) => s.id === 'kspec-help');
+    expect(kspecHelp).toBeDefined();
+    expect(kspecHelp?.name).toBe('Kspec Help');
+    expect(kspecHelp?.description).toContain('help');
+    expect(kspecHelp?.platforms).toContain('claude-code');
+  });
+
+  it('should load SKILL.md content for core skills', async () => {
+    const { loadCoreSkillContent } = await import('../src/cli/commands/skill.js');
+
+    const content = loadCoreSkillContent('kspec-help');
+
+    expect(content).not.toBeNull();
+    expect(content).toContain('# kspec Help');
+  });
+
+  it('should return null for non-existent skill content', async () => {
+    const { loadCoreSkillContent } = await import('../src/cli/commands/skill.js');
+
+    const content = loadCoreSkillContent('non-existent-skill');
+
+    expect(content).toBeNull();
+  });
+
+  it('should return kspec package version', async () => {
+    const { getKspecPackageVersion } = await import('../src/cli/commands/skill.js');
+
+    const version = getKspecPackageVersion();
+
+    expect(version).toBeDefined();
+    expect(version).not.toBe('unknown');
+    expect(version).toMatch(/^\d+\.\d+\.\d+/);
+  });
+});


### PR DESCRIPTION
## Summary

- Added `kspec skill install-core` command to copy core skill definitions from the kspec npm package templates/ directory into a project
- Created templates/skills/ structure with manifest.yaml and initial kspec-help skill
- All 5 acceptance criteria implemented:
  - ac-1: Meta entries created with origin "core" and "core" tag
  - ac-2: SKILL.md content copied from templates to .kspec/skills/<id>/
  - ac-3: Custom/project skills skipped with message (not overwritten)
  - ac-4: --force flag overwrites custom forks with core versions
  - ac-5: Version matches kspec package version

## Test plan

- [x] Run `npm test -- tests/core-skill-install.test.ts` - 18 tests pass
- [x] Verify `kspec skill install-core --dry-run` shows expected output
- [x] Verify installed skills have origin "core" and version matching package.json
- [x] Verify custom skills are not overwritten without --force
- [x] Verify --force overwrites custom skills

Task: @implement-core-skill-installation
Spec: @core-skill-install

🤖 Generated with [Claude Code](https://claude.ai/code)