### PR TITLE
feat: implement core skill update command

### DIFF
--- a/src/cli/commands/skill.ts
+++ b/src/cli/commands/skill.ts
@@ -15,6 +15,10 @@
  * AC: @core-skill-install ac-3 - custom skills skipped with message
  * AC: @core-skill-install ac-4 - --force overwrites custom forks
  * AC: @core-skill-install ac-5 - version matches kspec package version
+ *
+ * AC: @core-skill-update ac-1 - skill content and version updated when version differs
+ * AC: @core-skill-update ac-2 - skill skipped when already at current version
+ * AC: @core-skill-update ac-3 - skills with origin custom/project not touched
  */
 
 import * as crypto from "node:crypto";
@@ -1315,6 +1319,174 @@ export function registerSkillCommands(program: Command): void {
         process.exit(EXIT_CODES.ERROR);
       }
     });
+
+  // AC: @core-skill-update - kspec skill update
+  markMutating(skill.command("update"))
+    .description(
+      "Update core skills to match the installed kspec package version"
+    )
+    .option("--dry-run", "Show what would be updated without making changes")
+    .action(async (options) => {
+      try {
+        const ctx = await initContext();
+
+        if (!ctx.manifestPath) {
+          error(errors.project.noKspecProject);
+          console.log(
+            chalk.gray("Try: kspec init to initialize a kspec project")
+          );
+          process.exit(EXIT_CODES.ERROR);
+        }
+
+        const metaCtx = await loadMetaContext(ctx);
+        const dryRun = options.dryRun || false;
+        const results: CoreSkillUpdateResult[] = [];
+
+        // Get kspec package version
+        const kspecVersion = getKspecPackageVersion();
+
+        // Load core skills manifest to get current content
+        const coreSkillsManifest = loadCoreSkillsManifest();
+        const coreSkillsMap = new Map(
+          coreSkillsManifest.map((s) => [s.id, s])
+        );
+
+        // AC: @core-skill-update ac-3 - Only process skills with origin core
+        const coreSkills = metaCtx.skills.filter((s) => s.origin === "core");
+
+        for (const skill of coreSkills) {
+          // AC: @core-skill-update ac-2 - Skip if already at current version
+          if (skill.version === kspecVersion) {
+            results.push({
+              id: skill.id,
+              action: "skipped",
+              reason: "already at current version",
+              currentVersion: skill.version,
+            });
+            continue;
+          }
+
+          // Check if skill exists in core manifest
+          const coreSkill = coreSkillsMap.get(skill.id);
+          if (!coreSkill) {
+            results.push({
+              id: skill.id,
+              action: "skipped",
+              reason: "not found in core skills manifest",
+              currentVersion: skill.version,
+            });
+            continue;
+          }
+
+          // AC: @core-skill-update ac-1 - Update content and version
+          const oldVersion = skill.version;
+
+          if (!dryRun) {
+            // Update skill metadata with new version
+            skill.version = kspecVersion;
+            skill.name = coreSkill.name;
+            if (coreSkill.description) {
+              skill.description = coreSkill.description;
+            }
+            if (coreSkill.platforms) {
+              skill.platforms = coreSkill.platforms;
+            }
+
+            // Save updated metadata
+            await saveMetaItem(ctx, skill, "skill");
+
+            // Update SKILL.md content from templates
+            const sourceContent = loadCoreSkillContent(skill.id);
+            if (sourceContent) {
+              const targetPath = getSkillContentPath(ctx, skill.id);
+              await fs.writeFile(targetPath, sourceContent, "utf-8");
+            }
+          }
+
+          results.push({
+            id: skill.id,
+            action: "updated",
+            previousVersion: oldVersion,
+            newVersion: kspecVersion,
+          });
+        }
+
+        // Commit changes if not dry run and there are updates
+        if (!dryRun && results.some((r) => r.action === "updated")) {
+          await commitIfShadow(
+            ctx.shadow,
+            "skill-update",
+            `${results.filter((r) => r.action === "updated").length} core skills`
+          );
+        }
+
+        // Output results
+        output(
+          {
+            dry_run: dryRun,
+            kspec_version: kspecVersion,
+            results,
+          },
+          () => {
+            if (dryRun) {
+              console.log(chalk.yellow("DRY RUN - No changes made"));
+              console.log();
+            }
+
+            console.log(`kspec version: ${kspecVersion}`);
+            console.log();
+
+            const updated = results.filter((r) => r.action === "updated");
+            const skipped = results.filter((r) => r.action === "skipped");
+
+            if (updated.length > 0) {
+              console.log(chalk.green(`Updated: ${updated.length} skill(s)`));
+              for (const r of updated) {
+                console.log(
+                  `  ${chalk.green("~")} ${r.id}: ${r.previousVersion || "unknown"} → ${r.newVersion}`
+                );
+              }
+            }
+
+            if (skipped.length > 0) {
+              console.log(chalk.gray(`Skipped: ${skipped.length} skill(s)`));
+              for (const r of skipped) {
+                console.log(
+                  `  ${chalk.gray("-")} ${r.id}: ${r.reason}${r.currentVersion ? ` (v${r.currentVersion})` : ""}`
+                );
+              }
+            }
+
+            console.log();
+            if (dryRun) {
+              console.log(
+                chalk.yellow("No changes were made. Run without --dry-run to apply.")
+              );
+            } else if (updated.length > 0) {
+              success(`Updated ${updated.length} core skill(s)`);
+            } else {
+              console.log(chalk.gray("No skills needed updating"));
+            }
+          }
+        );
+      } catch (err) {
+        error("Failed to update core skills", err);
+        process.exit(EXIT_CODES.ERROR);
+      }
+    });
+}
+
+/**
+ * Result of updating a single core skill
+ * AC: @core-skill-update
+ */
+interface CoreSkillUpdateResult {
+  id: string;
+  action: "updated" | "skipped";
+  previousVersion?: string;
+  newVersion?: string;
+  currentVersion?: string;
+  reason?: string;
 }
 
 /**

--- a/tests/core-skill-update.test.ts
+++ b/tests/core-skill-update.test.ts
@@ -1,0 +1,286 @@
+/**
+ * Tests for Core Skill Update
+ * AC: @core-skill-update ac-1 through ac-3
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import {
+  kspec as kspecFull,
+  kspecJson,
+  setupTempFixtures,
+  cleanupTempDir,
+  initGitRepo,
+} from './helpers/cli';
+
+describe('Core Skill Update', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await setupTempFixtures();
+    await initGitRepo(tempDir);
+  });
+
+  afterEach(async () => {
+    await cleanupTempDir(tempDir);
+  });
+
+  // AC: @core-skill-update ac-1
+  describe('ac-1: Skill content and version updated when version differs', () => {
+    it('should update skill version when package version differs', async () => {
+      // Install core skills
+      kspecFull('skill install-core', tempDir);
+
+      // Get current version
+      const { getKspecPackageVersion } = await import('../src/cli/commands/skill.js');
+      const packageVersion = getKspecPackageVersion();
+
+      // Manually set skill to an older version
+      kspecFull('skill set @kspec-help --skill-version 0.0.1', tempDir);
+
+      // Verify version changed
+      let skills = kspecJson<{ id: string; version?: string }[]>('skill list', tempDir);
+      expect(skills.find((s) => s.id === 'kspec-help')?.version).toBe('0.0.1');
+
+      // Run update
+      const result = kspecFull('skill update', tempDir);
+      expect(result.stdout).toContain('Updated');
+      expect(result.stdout).toContain('kspec-help');
+      expect(result.stdout).toContain('0.0.1');
+      expect(result.stdout).toContain(packageVersion);
+
+      // Verify version is now package version
+      skills = kspecJson<{ id: string; version?: string }[]>('skill list', tempDir);
+      expect(skills.find((s) => s.id === 'kspec-help')?.version).toBe(packageVersion);
+    });
+
+    it('should update SKILL.md content when version differs', async () => {
+      // Install core skills
+      kspecFull('skill install-core', tempDir);
+
+      // Manually set skill to an older version
+      kspecFull('skill set @kspec-help --skill-version 0.0.1', tempDir);
+
+      // Modify SKILL.md content
+      const skillMdPath = path.join(tempDir, 'skills', 'kspec-help', 'SKILL.md');
+      await fs.writeFile(skillMdPath, '# Old Content\n\nThis is old content.\n', 'utf-8');
+
+      // Run update
+      kspecFull('skill update', tempDir);
+
+      // Verify content was restored from templates
+      const content = await fs.readFile(skillMdPath, 'utf-8');
+      expect(content).toContain('# kspec Help');
+      expect(content).not.toContain('Old Content');
+    });
+
+    it('should show version transition in output', async () => {
+      kspecFull('skill install-core', tempDir);
+      kspecFull('skill set @kspec-help --skill-version 0.0.1', tempDir);
+
+      const result = kspecFull('skill update', tempDir);
+
+      // Should show "0.0.1 → X.Y.Z"
+      expect(result.stdout).toMatch(/0\.0\.1\s*→\s*\d+\.\d+\.\d+/);
+    });
+  });
+
+  // AC: @core-skill-update ac-2
+  describe('ac-2: Skill skipped when already at current version', () => {
+    it('should skip skills already at current package version', async () => {
+      // Install core skills (will have current package version)
+      kspecFull('skill install-core', tempDir);
+
+      // Run update - should skip because version already matches
+      const result = kspecFull('skill update', tempDir);
+
+      expect(result.stdout).toContain('Skipped');
+      expect(result.stdout).toContain('kspec-help');
+      expect(result.stdout).toContain('already at current version');
+    });
+
+    it('should not show "Updated" when all skills are current', async () => {
+      kspecFull('skill install-core', tempDir);
+      const result = kspecFull('skill update', tempDir);
+
+      expect(result.stdout).not.toContain('Updated:');
+      expect(result.stdout).toContain('No skills needed updating');
+    });
+
+    it('should report skipped reason in JSON output', async () => {
+      kspecFull('skill install-core', tempDir);
+
+      const result = kspecJson<{
+        results: { id: string; action: string; reason?: string }[];
+      }>('skill update', tempDir);
+
+      const kspecHelp = result.results.find((r) => r.id === 'kspec-help');
+      expect(kspecHelp?.action).toBe('skipped');
+      expect(kspecHelp?.reason).toContain('already at current version');
+    });
+  });
+
+  // AC: @core-skill-update ac-3
+  describe('ac-3: Skills with origin custom/project not touched', () => {
+    it('should not process skills with origin "project"', async () => {
+      // Create a project-origin skill
+      kspecFull(
+        'skill add --id my-skill --name "My Skill" --description "My project skill" --origin project',
+        tempDir
+      );
+
+      // Run update
+      const result = kspecFull('skill update', tempDir);
+
+      // Should not mention my-skill at all (not even as skipped)
+      expect(result.stdout).not.toContain('my-skill');
+
+      // Verify skill is unchanged
+      const skills = kspecJson<{ id: string; origin: string }[]>('skill list', tempDir);
+      expect(skills.find((s) => s.id === 'my-skill')?.origin).toBe('project');
+    });
+
+    it('should not process skills with origin "local"', async () => {
+      // Create a local-origin skill
+      kspecFull(
+        'skill add --id local-skill --name "Local Skill" --description "Local only" --origin local',
+        tempDir
+      );
+
+      // Run update
+      const result = kspecFull('skill update', tempDir);
+
+      // Should not mention local-skill
+      expect(result.stdout).not.toContain('local-skill');
+    });
+
+    it('should only process skills with origin "core"', async () => {
+      // Install core skill
+      kspecFull('skill install-core', tempDir);
+
+      // Add a project skill with same ID pattern
+      kspecFull(
+        'skill add --id my-helper --name "Helper" --description "Project helper" --origin project',
+        tempDir
+      );
+
+      // Set core skill to old version
+      kspecFull('skill set @kspec-help --skill-version 0.0.1', tempDir);
+
+      // Run update
+      const result = kspecFull('skill update', tempDir);
+
+      // Should only show kspec-help (core) being updated
+      expect(result.stdout).toContain('kspec-help');
+      expect(result.stdout).not.toContain('my-helper');
+    });
+  });
+
+  // Dry run support
+  describe('dry-run support', () => {
+    it('should not make changes with --dry-run', async () => {
+      kspecFull('skill install-core', tempDir);
+      kspecFull('skill set @kspec-help --skill-version 0.0.1', tempDir);
+
+      const result = kspecFull('skill update --dry-run', tempDir);
+
+      expect(result.stdout).toContain('DRY RUN');
+      expect(result.stdout).toContain('No changes were made');
+
+      // Verify version was NOT updated
+      const skills = kspecJson<{ id: string; version?: string }[]>('skill list', tempDir);
+      expect(skills.find((s) => s.id === 'kspec-help')?.version).toBe('0.0.1');
+    });
+
+    it('should show what would be updated with --dry-run', async () => {
+      kspecFull('skill install-core', tempDir);
+      kspecFull('skill set @kspec-help --skill-version 0.0.1', tempDir);
+
+      const result = kspecFull('skill update --dry-run', tempDir);
+
+      expect(result.stdout).toContain('Updated');
+      expect(result.stdout).toContain('kspec-help');
+    });
+  });
+
+  // JSON output support
+  describe('JSON output', () => {
+    it('should return JSON with results array', async () => {
+      kspecFull('skill install-core', tempDir);
+      kspecFull('skill set @kspec-help --skill-version 0.0.1', tempDir);
+
+      const result = kspecJson<{ results: { id: string; action: string }[] }>(
+        'skill update',
+        tempDir
+      );
+
+      expect(result.results).toBeDefined();
+      expect(Array.isArray(result.results)).toBe(true);
+      expect(result.results.length).toBeGreaterThan(0);
+
+      const kspecHelp = result.results.find((r) => r.id === 'kspec-help');
+      expect(kspecHelp?.action).toBe('updated');
+    });
+
+    it('should include dry_run field in JSON output', async () => {
+      kspecFull('skill install-core', tempDir);
+
+      const result = kspecJson<{ dry_run: boolean; results: unknown[] }>(
+        'skill update --dry-run',
+        tempDir
+      );
+
+      expect(result.dry_run).toBe(true);
+    });
+
+    it('should include kspec_version in JSON output', async () => {
+      kspecFull('skill install-core', tempDir);
+
+      const result = kspecJson<{ kspec_version: string }>(
+        'skill update',
+        tempDir
+      );
+
+      expect(result.kspec_version).toBeDefined();
+      expect(result.kspec_version).toMatch(/^\d+\.\d+\.\d+/);
+    });
+
+    it('should include version info in update results', async () => {
+      kspecFull('skill install-core', tempDir);
+      kspecFull('skill set @kspec-help --skill-version 0.0.1', tempDir);
+
+      const result = kspecJson<{
+        results: { id: string; previousVersion?: string; newVersion?: string }[];
+      }>('skill update', tempDir);
+
+      const kspecHelp = result.results.find((r) => r.id === 'kspec-help');
+      expect(kspecHelp?.previousVersion).toBe('0.0.1');
+      expect(kspecHelp?.newVersion).toMatch(/^\d+\.\d+\.\d+/);
+    });
+  });
+
+  // Edge cases
+  describe('edge cases', () => {
+    it('should handle no core skills installed', async () => {
+      const result = kspecFull('skill update', tempDir);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('No skills needed updating');
+    });
+
+    it('should skip core skill not in manifest', async () => {
+      // Install a core skill, then rename it to something not in manifest
+      kspecFull(
+        'skill add --id fake-core --name "Fake Core" --description "Not in manifest" --origin core --skill-version 0.0.1',
+        tempDir
+      );
+
+      const result = kspecFull('skill update', tempDir);
+
+      expect(result.stdout).toContain('Skipped');
+      expect(result.stdout).toContain('fake-core');
+      expect(result.stdout).toContain('not found in core skills manifest');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add `kspec skill update` command to refresh core skills from the installed kspec package version
- Only updates skills with origin `core` whose version differs from the package version
- Skips skills already at current version and does not touch custom/project origin skills

## Acceptance Criteria Coverage

- **ac-1**: When core skill version differs from kspec package version, content and version are updated
- **ac-2**: Core skills already at current package version are skipped  
- **ac-3**: Skills with origin custom/project are not touched (only origin 'core' processed)

## Test Plan

- [x] 17 tests added in `tests/core-skill-update.test.ts`
- [x] Tests cover all 3 ACs
- [x] Tests cover dry-run mode
- [x] Tests cover JSON output
- [x] Tests cover edge cases (no core skills, skill not in manifest)
- [x] Full test suite passes (2562 passed)

Task: @implement-core-skill-update
Spec: @core-skill-update

🤖 Generated with [Claude Code](https://claude.ai/code)