### PR TITLE
feat: implement package distribution for templates

### DIFF
--- a/src/parser/shadow.ts
+++ b/src/parser/shadow.ts
@@ -13,7 +13,11 @@ import { exec, execSync } from "node:child_process";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { promisify } from "node:util";
+import { fileURLToPath } from "node:url";
 import { isBatchMode } from "../cli/batch-context.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 const execAsync = promisify(exec);
 
@@ -1055,11 +1059,21 @@ items: []
 }
 
 /**
+ * Get the kspec package root directory.
+ * Navigates from dist/parser/ to package root.
+ */
+function getPackageRoot(): string {
+  return path.resolve(__dirname, "..", "..");
+}
+
+/**
  * Install pre-commit hook to protect kspec-meta branch.
  * Hook prevents direct commits to shadow branch unless KSPEC_SHADOW_COMMIT=1.
  *
  * Note: Git worktrees use hooks from the main .git/hooks directory (via commondir),
  * not from .git/worktrees/-kspec/hooks. So we install to main hooks directory.
+ *
+ * The hook source is located in the kspec package's templates/hooks/ directory.
  *
  * @param projectRoot Git repository root
  * @returns true if hook was installed, false if already exists
@@ -1067,10 +1081,13 @@ items: []
 async function installShadowHook(projectRoot: string): Promise<boolean> {
   const hooksDir = path.join(projectRoot, ".git", "hooks");
   const hookPath = path.join(hooksDir, "pre-commit");
-  const sourceHookPath = path.join(projectRoot, "hooks", "pre-commit");
+
+  // Look for hook in package templates directory
+  const packageRoot = getPackageRoot();
+  const sourceHookPath = path.join(packageRoot, "templates", "hooks", "pre-commit");
 
   try {
-    // Check if source hook exists
+    // Check if source hook exists in package templates
     try {
       await fs.access(sourceHookPath);
     } catch {
@@ -1087,7 +1104,7 @@ async function installShadowHook(projectRoot: string): Promise<boolean> {
       // Hook doesn't exist - install it
     }
 
-    // Copy hook from source
+    // Copy hook from package templates
     const hookContent = await fs.readFile(sourceHookPath, "utf-8");
     await fs.writeFile(hookPath, hookContent, { mode: 0o755 });
     return true;

--- a/templates/hooks/pre-commit
+++ b/templates/hooks/pre-commit
@@ -1,0 +1,34 @@
+#!/bin/sh
+#
+# kspec-meta branch protection hook
+#
+# This hook prevents direct commits to the kspec-meta shadow branch.
+# All modifications to spec/task files should go through the kspec CLI,
+# which will set KSPEC_SHADOW_COMMIT=1 to authorize commits.
+#
+# Installation: This hook is automatically installed during 'kspec init'
+# into .git/hooks/pre-commit
+
+# Get current branch name
+BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+
+# Check if we're on kspec-meta branch
+if [ "$BRANCH" = "kspec-meta" ]; then
+  # Allow if KSPEC_SHADOW_COMMIT is set (authorized by CLI)
+  if [ "$KSPEC_SHADOW_COMMIT" != "1" ]; then
+    echo "ERROR: Direct commits to kspec-meta branch are not allowed."
+    echo ""
+    echo "The kspec-meta branch is managed by the kspec CLI."
+    echo "Use kspec commands to modify specs and tasks:"
+    echo ""
+    echo "  kspec task start @ref"
+    echo "  kspec task note @ref \"description\""
+    echo "  kspec task complete @ref --reason \"done\""
+    echo "  kspec item add --title \"New item\""
+    echo ""
+    echo "All kspec operations automatically commit to the shadow branch."
+    exit 1
+  fi
+fi
+
+exit 0

--- a/tests/package-distribution.test.ts
+++ b/tests/package-distribution.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Tests for package distribution - ensuring templates/ directory is properly
+ * included in the npm package with all required subdirectories and content.
+ *
+ * AC: @package-distribution ac-1 - templates/ directory included in npm pack
+ * AC: @package-distribution ac-2 - templates/ contains skills/, agents-sections/, hooks/
+ * AC: @package-distribution ac-3 - kspec skill install-core finds templates
+ * AC: @package-distribution ac-4 - pre-commit hook source file included
+ */
+
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { describe, it, expect } from 'vitest';
+
+// Package root directory (where templates/ lives)
+const PACKAGE_ROOT = path.resolve(__dirname, '..');
+
+describe('Package Distribution', () => {
+  // AC: @package-distribution ac-1
+  describe('templates/ directory exists in package root', () => {
+    it('templates/ directory exists', async () => {
+      const templatesPath = path.join(PACKAGE_ROOT, 'templates');
+      const stats = await fs.stat(templatesPath);
+      expect(stats.isDirectory()).toBe(true);
+    });
+  });
+
+  // AC: @package-distribution ac-2
+  describe('templates/ contains required subdirectories', () => {
+    it('contains skills/ subdirectory', async () => {
+      const skillsPath = path.join(PACKAGE_ROOT, 'templates', 'skills');
+      const stats = await fs.stat(skillsPath);
+      expect(stats.isDirectory()).toBe(true);
+    });
+
+    it('contains agents-sections/ subdirectory', async () => {
+      const agentsSectionsPath = path.join(PACKAGE_ROOT, 'templates', 'agents-sections');
+      const stats = await fs.stat(agentsSectionsPath);
+      expect(stats.isDirectory()).toBe(true);
+    });
+
+    it('contains hooks/ subdirectory', async () => {
+      const hooksPath = path.join(PACKAGE_ROOT, 'templates', 'hooks');
+      const stats = await fs.stat(hooksPath);
+      expect(stats.isDirectory()).toBe(true);
+    });
+  });
+
+  // AC: @package-distribution ac-3
+  describe('skills/ contains core skill content', () => {
+    it('contains manifest.yaml with core skill definitions', async () => {
+      const manifestPath = path.join(PACKAGE_ROOT, 'templates', 'skills', 'manifest.yaml');
+      const content = await fs.readFile(manifestPath, 'utf-8');
+      expect(content).toContain('skills:');
+    });
+
+    it('contains at least one core skill directory', async () => {
+      const skillsPath = path.join(PACKAGE_ROOT, 'templates', 'skills');
+      const entries = await fs.readdir(skillsPath, { withFileTypes: true });
+      const skillDirs = entries.filter(e => e.isDirectory() && !e.name.startsWith('.'));
+      expect(skillDirs.length).toBeGreaterThan(0);
+    });
+
+    it('kspec-help skill has SKILL.md content', async () => {
+      const skillMdPath = path.join(PACKAGE_ROOT, 'templates', 'skills', 'kspec-help', 'SKILL.md');
+      const content = await fs.readFile(skillMdPath, 'utf-8');
+      expect(content.length).toBeGreaterThan(0);
+      expect(content).toContain('kspec');
+    });
+  });
+
+  // AC: @package-distribution ac-4
+  describe('hooks/ contains pre-commit hook source', () => {
+    it('pre-commit hook file exists', async () => {
+      const preCommitPath = path.join(PACKAGE_ROOT, 'templates', 'hooks', 'pre-commit');
+      const stats = await fs.stat(preCommitPath);
+      expect(stats.isFile()).toBe(true);
+    });
+
+    it('pre-commit hook contains kspec-meta branch protection', async () => {
+      const preCommitPath = path.join(PACKAGE_ROOT, 'templates', 'hooks', 'pre-commit');
+      const content = await fs.readFile(preCommitPath, 'utf-8');
+      expect(content).toContain('kspec-meta');
+      expect(content).toContain('KSPEC_SHADOW_COMMIT');
+    });
+
+    it('pre-commit hook is a valid shell script', async () => {
+      const preCommitPath = path.join(PACKAGE_ROOT, 'templates', 'hooks', 'pre-commit');
+      const content = await fs.readFile(preCommitPath, 'utf-8');
+      expect(content.startsWith('#!/bin/sh') || content.startsWith('#!/bin/bash')).toBe(true);
+    });
+  });
+
+  describe('agents-sections/ contains markdown templates', () => {
+    it('contains markdown template files', async () => {
+      const sectionsPath = path.join(PACKAGE_ROOT, 'templates', 'agents-sections');
+      const entries = await fs.readdir(sectionsPath);
+      const mdFiles = entries.filter(f => f.endsWith('.md'));
+      expect(mdFiles.length).toBeGreaterThan(0);
+    });
+
+    it('template files are named with numeric prefixes for ordering', async () => {
+      const sectionsPath = path.join(PACKAGE_ROOT, 'templates', 'agents-sections');
+      const entries = await fs.readdir(sectionsPath);
+      const mdFiles = entries.filter(f => f.endsWith('.md'));
+      // All files should start with two digits and a dash
+      for (const file of mdFiles) {
+        expect(file).toMatch(/^\d{2}-/);
+      }
+    });
+  });
+
+  describe('package.json files field includes templates', () => {
+    it('package.json files array includes templates', async () => {
+      const packageJsonPath = path.join(PACKAGE_ROOT, 'package.json');
+      const content = await fs.readFile(packageJsonPath, 'utf-8');
+      const pkg = JSON.parse(content);
+      expect(pkg.files).toContain('templates');
+    });
+  });
+});

--- a/tests/shadow.test.ts
+++ b/tests/shadow.test.ts
@@ -764,9 +764,11 @@ describe('Shadow Branch', () => {
           path.join(worktreeDir, tasksFile),
           '\n# Local change\n'
         );
+        // Must set KSPEC_SHADOW_COMMIT=1 to authorize commit to shadow branch
         execSync('git add -A && git commit -m "Local change"', {
           cwd: worktreeDir,
           stdio: 'pipe',
+          env: { ...process.env, KSPEC_SHADOW_COMMIT: '1' },
         });
       }
 
@@ -1157,13 +1159,12 @@ describe('Shadow Branch', () => {
   });
 
   // Shadow hook installation and authorization tests
+  // AC: @package-distribution ac-4 - pre-commit hook source included in package
   describe('installShadowHook', () => {
     it('installs pre-commit hook during shadow initialization', async () => {
-      // Setup: Create source hook file
-      const hooksSourceDir = path.join(testDir, 'hooks');
-      const sourceHookPath = path.join(hooksSourceDir, 'pre-commit');
-      await fs.mkdir(hooksSourceDir, { recursive: true });
-      await fs.writeFile(sourceHookPath, '#!/bin/sh\necho "test hook"\nexit 0\n', { mode: 0o755 });
+      // The pre-commit hook is now loaded from the package templates directory
+      // (templates/hooks/pre-commit), not from the project root.
+      // This test verifies that the hook from the package gets installed.
 
       // Initialize git repo with initial commit
       execSync('git init', { cwd: testDir, stdio: 'pipe' });
@@ -1172,7 +1173,7 @@ describe('Shadow Branch', () => {
       await fs.writeFile(path.join(testDir, 'README.md'), '# Test');
       execSync('git add . && git commit -m "initial"', { cwd: testDir, stdio: 'pipe' });
 
-      // Initialize shadow - should install hook
+      // Initialize shadow - should install hook from package templates
       const result = await initializeShadow(testDir);
       expect(result.success).toBe(true);
 
@@ -1180,7 +1181,9 @@ describe('Shadow Branch', () => {
       const installedHookPath = path.join(testDir, '.git', 'hooks', 'pre-commit');
       try {
         const hookContent = await fs.readFile(installedHookPath, 'utf-8');
-        expect(hookContent).toBe('#!/bin/sh\necho "test hook"\nexit 0\n');
+        // Hook should contain the kspec-meta branch protection logic
+        expect(hookContent).toContain('kspec-meta branch protection');
+        expect(hookContent).toContain('KSPEC_SHADOW_COMMIT');
 
         // Verify hook is executable
         const stats = await fs.stat(installedHookPath);
@@ -1191,15 +1194,8 @@ describe('Shadow Branch', () => {
     });
 
     it('blocks unauthorized commits to shadow branch', async () => {
-      // Setup with real kspec pre-commit hook
-      const realHookPath = path.resolve(__dirname, '../hooks/pre-commit');
-      const hooksSourceDir = path.join(testDir, 'hooks');
-      const sourceHookPath = path.join(hooksSourceDir, 'pre-commit');
-
-      await fs.mkdir(hooksSourceDir, { recursive: true });
-      // Copy the real hook
-      const realHookContent = await fs.readFile(realHookPath, 'utf-8');
-      await fs.writeFile(sourceHookPath, realHookContent, { mode: 0o755 });
+      // The pre-commit hook is now loaded from the package templates directory.
+      // This test verifies the hook blocks unauthorized commits to the shadow branch.
 
       // Initialize git repo
       execSync('git init', { cwd: testDir, stdio: 'pipe' });


### PR DESCRIPTION
## Summary
- Create `templates/hooks/` directory containing pre-commit hook source file
- Update `installShadowHook` in `shadow.ts` to load hook from package templates directory instead of project root (works when kspec is installed as npm package)
- Add 13 tests for package distribution covering all 4 ACs
- Fix `shadow.test.ts` to use `KSPEC_SHADOW_COMMIT` env var for authorized commits

## Test plan
- [x] `npm pack --dry-run` shows templates/ directory with all subdirectories
- [x] All 13 package distribution tests pass
- [x] Core skill install tests still pass (ac-3 coverage)
- [x] Shadow branch tests pass with updated hook behavior

Task: @implement-package-distribution
Spec: @package-distribution

🤖 Generated with [Claude Code](https://claude.ai/code)