### PR TITLE
feat: implement platform renderer contract

### DIFF
--- a/src/parser/skill-render.ts
+++ b/src/parser/skill-render.ts
@@ -1,9 +1,10 @@
 /**
- * Claude Code Skill Renderer
+ * Platform Skill Renderers
  *
- * Platform-specific renderer for Claude Code. Reads from .kspec/skills/<id>/SKILL.md,
- * writes to .claude/skills/<id>/SKILL.md with YAML frontmatter (name, description).
- * Does NOT auto-commit to main branch — leaves files unstaged.
+ * Defines the contract for platform-specific skill renderers and provides
+ * the Claude Code implementation. Each renderer writes platform-specific output
+ * (SKILL.md with frontmatter, sidecar config files, supporting directories)
+ * to a configurable output directory.
  *
  * AC: @claude-code-renderer ac-1 - renderClaudeCodeSkill creates .claude/skills/<id>/SKILL.md with YAML frontmatter
  * AC: @claude-code-renderer ac-2 - rendered output has YAML frontmatter delimiters with name and description fields
@@ -15,6 +16,13 @@
  * AC: @skill-drift-detection ac-5 - Render hash stored in .kspec/skills/<id>/.render-hash
  *
  * AC: @consolidate-skill-render ac-3 - hash/drift functions exported from this module
+ *
+ * AC: @platform-renderer-trait ac-1 - platform-specific output files written to configured output directory
+ * AC: @platform-renderer-trait ac-2 - PlatformRenderResult returned with id, platform, action, paths
+ * AC: @platform-renderer-trait ac-3 - supporting directories (references/, scripts/, assets/) copied
+ * AC: @platform-renderer-trait ac-4 - dryRun mode: no files written, result reflects what would happen
+ * AC: @platform-renderer-trait ac-5 - custom outputDir goes to custom path instead of platform default
+ * AC: @platform-renderer-trait ac-6 - per-platform render hash written to .render-hash-<platform>
  */
 
 import * as crypto from "node:crypto";
@@ -24,8 +32,86 @@ import yaml from "yaml";
 import type { KspecContext } from "./yaml.js";
 import { loadSkillContent, type LoadedSkill } from "./meta.js";
 
+// ============================================================================
+// Platform Renderer Contract (AC: @platform-renderer-trait)
+// ============================================================================
+
+/**
+ * Status of drift detection for a rendered skill
+ * AC: @platform-renderer-trait ac-2
+ */
+export type DriftStatus = "not-rendered" | "in-sync" | "drifted" | "no-hash";
+
+/**
+ * Result of rendering a skill to a specific platform
+ * AC: @platform-renderer-trait ac-2
+ */
+export interface PlatformRenderResult {
+  /** Skill ID */
+  id: string;
+  /** Platform this result is for */
+  platform: string;
+  /** Action taken: created, updated, unchanged, or skipped */
+  action: "created" | "updated" | "unchanged" | "skipped";
+  /** Paths to all output files */
+  paths: string[];
+  /** Actions taken on supporting directories (references/, scripts/, assets/, docs/) */
+  supportingDirsAction?: Record<string, "created" | "updated" | "unchanged" | "skipped">;
+  /** Reason if action is skipped */
+  skipReason?: string;
+}
+
+/**
+ * Options for rendering a skill to a platform
+ * AC: @platform-renderer-trait ac-4, ac-5
+ */
+export interface PlatformRenderOptions {
+  /** If true, don't write files, just return what would be done */
+  dryRun?: boolean;
+  /** If true, store a hash of the rendered content for drift detection */
+  storeHash?: boolean;
+  /** Custom output directory (overrides platform default) */
+  outputDir?: string;
+}
+
+/**
+ * Contract for platform-specific skill renderers
+ * AC: @platform-renderer-trait ac-1, ac-2
+ */
+export interface PlatformRenderer {
+  /** Platform identifier (e.g., "claude-code", "codex") */
+  platform: string;
+  /** Default output directory relative to project root (e.g., ".claude/skills") */
+  defaultOutputDir: string;
+  /**
+   * Render a skill to platform-specific output
+   * AC: @platform-renderer-trait ac-1, ac-2, ac-3, ac-4, ac-5
+   */
+  render(
+    ctx: KspecContext,
+    projectRoot: string,
+    skill: LoadedSkill,
+    options?: PlatformRenderOptions
+  ): Promise<PlatformRenderResult>;
+  /**
+   * Check if a rendered skill has drifted from its source
+   * AC: @platform-renderer-trait ac-6
+   */
+  checkDrift(
+    specDir: string,
+    projectRoot: string,
+    skillId: string,
+    options?: { outputDir?: string }
+  ): Promise<DriftStatus>;
+}
+
+// ============================================================================
+// Backward Compatibility Types
+// ============================================================================
+
 /**
  * Result of rendering a skill to Claude Code format
+ * @deprecated Use PlatformRenderResult instead
  */
 export interface ClaudeCodeRenderResult {
   /** Skill ID */
@@ -40,12 +126,15 @@ export interface ClaudeCodeRenderResult {
 
 /**
  * Options for rendering a skill
+ * @deprecated Use PlatformRenderOptions instead
  */
 export interface RenderSkillOptions {
   /** If true, don't write files, just return what would be done */
   dryRun?: boolean;
   /** If true, store a hash of the rendered content for drift detection */
   storeHash?: boolean;
+  /** Custom output directory (overrides platform default) */
+  outputDir?: string;
 }
 
 /**
@@ -382,4 +471,313 @@ export async function isKspecManagedSkill(skillMdPath: string): Promise<boolean>
   } catch {
     return false;
   }
+}
+
+// ============================================================================
+// Per-Platform Hash Functions (AC: @platform-renderer-trait ac-6)
+// ============================================================================
+
+/**
+ * Get the path to the per-platform render hash file for a skill
+ * AC: @platform-renderer-trait ac-6 - Per-platform hash stored in .render-hash-<platform>
+ */
+export function getPlatformRenderHashPath(specDir: string, skillId: string, platform: string): string {
+  return path.join(specDir, "skills", skillId, `.render-hash-${platform}`);
+}
+
+/**
+ * Read the stored render hash for a skill on a specific platform
+ * AC: @platform-renderer-trait ac-6 - Read per-platform hash
+ */
+export async function readPlatformRenderHash(
+  specDir: string,
+  skillId: string,
+  platform: string
+): Promise<string | null> {
+  try {
+    const hashPath = getPlatformRenderHashPath(specDir, skillId, platform);
+    const content = await fs.readFile(hashPath, "utf-8");
+    return content.trim();
+  } catch {
+    // Fall back to legacy hash (non-platform-specific)
+    return readRenderHash(specDir, skillId);
+  }
+}
+
+/**
+ * Write the render hash for a skill on a specific platform
+ * AC: @platform-renderer-trait ac-6 - Store per-platform hash in .render-hash-<platform>
+ */
+export async function writePlatformRenderHash(
+  specDir: string,
+  skillId: string,
+  platform: string,
+  hash: string
+): Promise<void> {
+  const hashPath = getPlatformRenderHashPath(specDir, skillId, platform);
+  await fs.mkdir(path.dirname(hashPath), { recursive: true });
+  await fs.writeFile(hashPath, hash + "\n", "utf-8");
+}
+
+/**
+ * Check if a rendered skill has drifted from its last render for a specific platform
+ * AC: @platform-renderer-trait ac-6 - Platform-specific drift detection
+ */
+export async function checkPlatformSkillDrift(
+  specDir: string,
+  projectRoot: string,
+  skillId: string,
+  platform: string,
+  outputDir?: string
+): Promise<DriftStatus> {
+  // Determine the output directory - use custom or platform default
+  const platformOutputDir = outputDir || getPlatformDefaultOutputDir(platform);
+  const renderedPath = path.join(projectRoot, platformOutputDir, skillId, "SKILL.md");
+
+  // Check if rendered file exists
+  let renderedContent: string;
+  try {
+    renderedContent = await fs.readFile(renderedPath, "utf-8");
+  } catch {
+    return "not-rendered";
+  }
+
+  // Get stored hash (try platform-specific first, then fall back to legacy)
+  const storedHash = await readPlatformRenderHash(specDir, skillId, platform);
+  if (!storedHash) {
+    return "no-hash";
+  }
+
+  // Compare hashes
+  const currentHash = computeContentHash(renderedContent);
+  return currentHash === storedHash ? "in-sync" : "drifted";
+}
+
+/**
+ * Get the default output directory for a platform
+ */
+function getPlatformDefaultOutputDir(platform: string): string {
+  switch (platform) {
+    case "claude-code":
+      return ".claude/skills";
+    case "codex":
+      return ".agents/skills";
+    default:
+      return `.${platform}/skills`;
+  }
+}
+
+// ============================================================================
+// Supporting Directories (AC: @platform-renderer-trait ac-3)
+// ============================================================================
+
+/** Known supporting directory names */
+const SUPPORTING_DIRS = ["references", "scripts", "assets", "docs"] as const;
+
+/**
+ * Copy supporting directories from source skill to rendered output
+ * AC: @platform-renderer-trait ac-3 - Supporting directories copied to platform output
+ */
+async function copySupportingDirectories(
+  sourceSkillDir: string,
+  targetSkillDir: string,
+  dryRun: boolean
+): Promise<Record<string, "created" | "updated" | "unchanged" | "skipped">> {
+  const results: Record<string, "created" | "updated" | "unchanged" | "skipped"> = {};
+
+  for (const dirName of SUPPORTING_DIRS) {
+    const sourceDir = path.join(sourceSkillDir, dirName);
+    const targetDir = path.join(targetSkillDir, dirName);
+
+    try {
+      const stats = await fs.stat(sourceDir);
+      if (!stats.isDirectory()) {
+        results[dirName] = "skipped";
+        continue;
+      }
+
+      // Check if target exists
+      let targetExists = false;
+      try {
+        await fs.stat(targetDir);
+        targetExists = true;
+      } catch {
+        // Target doesn't exist
+      }
+
+      if (!targetExists) {
+        results[dirName] = "created";
+      } else {
+        // Compare directories
+        const equal = await directoriesEqual(sourceDir, targetDir);
+        results[dirName] = equal ? "unchanged" : "updated";
+      }
+
+      // Apply changes
+      if (!dryRun && results[dirName] !== "unchanged") {
+        if (targetExists) {
+          await fs.rm(targetDir, { recursive: true, force: true });
+        }
+        await fs.mkdir(targetDir, { recursive: true });
+        await copyDirectory(sourceDir, targetDir);
+      }
+    } catch {
+      // Source directory doesn't exist
+      results[dirName] = "skipped";
+    }
+  }
+
+  return results;
+}
+
+// ============================================================================
+// Claude Code Renderer (implements PlatformRenderer)
+// ============================================================================
+
+/**
+ * Claude Code platform renderer implementation
+ * AC: @platform-renderer-trait ac-1 through ac-6
+ */
+export const claudeCodeRenderer: PlatformRenderer = {
+  platform: "claude-code",
+  defaultOutputDir: ".claude/skills",
+
+  async render(
+    ctx: KspecContext,
+    projectRoot: string,
+    skill: LoadedSkill,
+    options: PlatformRenderOptions = {}
+  ): Promise<PlatformRenderResult> {
+    const dryRun = options.dryRun ?? false;
+    const storeHash = options.storeHash ?? false;
+    // AC: @platform-renderer-trait ac-5 - Custom outputDir support
+    const outputDir = options.outputDir || this.defaultOutputDir;
+
+    const targetDir = path.join(projectRoot, outputDir, skill.id);
+    const targetSkillMd = path.join(targetDir, "SKILL.md");
+    const paths: string[] = [];
+
+    // Load source content
+    const sourceContent = await loadSkillContent(ctx, skill);
+
+    let renderedContent: string;
+    if (!sourceContent) {
+      // No source content - create placeholder
+      const frontmatter = generateFrontmatter(skill);
+      renderedContent = `${frontmatter}\n${KSPEC_MANAGED_MARKER}\n\n# ${skill.name}\n\n${skill.description || ""}\n`;
+    } else {
+      // Generate frontmatter and combine with content
+      const frontmatter = generateFrontmatter(skill);
+      const frontmatterMatch = sourceContent.match(/^---\n[\s\S]*?\n---\n?/);
+      const contentWithoutFrontmatter = frontmatterMatch
+        ? sourceContent.slice(frontmatterMatch[0].length)
+        : sourceContent;
+      renderedContent = `${frontmatter}\n${KSPEC_MANAGED_MARKER}\n${contentWithoutFrontmatter}`;
+    }
+
+    // Check if target exists and compare for idempotency
+    let targetExists = false;
+    let targetContent = "";
+    try {
+      targetContent = await fs.readFile(targetSkillMd, "utf-8");
+      targetExists = true;
+    } catch {
+      // Target doesn't exist
+    }
+
+    // Determine action based on comparison
+    let action: "created" | "updated" | "unchanged" | "skipped";
+    if (!targetExists) {
+      action = "created";
+    } else if (contentsEqual(renderedContent, targetContent)) {
+      action = "unchanged";
+    } else {
+      action = "updated";
+    }
+
+    // AC: @platform-renderer-trait ac-4 - dryRun: no files written
+    // AC: @platform-renderer-trait ac-1 - Write platform-specific output
+    if (!dryRun && action !== "unchanged") {
+      await fs.mkdir(targetDir, { recursive: true });
+      await fs.writeFile(targetSkillMd, renderedContent, "utf-8");
+    }
+
+    paths.push(targetSkillMd);
+
+    // AC: @platform-renderer-trait ac-6 - Store per-platform hash
+    if (!dryRun && storeHash && action !== "unchanged") {
+      const hash = computeContentHash(renderedContent);
+      await writePlatformRenderHash(ctx.specDir, skill.id, this.platform, hash);
+      // Also write legacy hash for backward compatibility
+      await writeRenderHash(ctx.specDir, skill.id, hash);
+    }
+
+    // AC: @platform-renderer-trait ac-3 - Copy supporting directories
+    const sourceSkillDir = path.join(ctx.specDir, "skills", skill.id);
+    const supportingDirsAction = await copySupportingDirectories(
+      sourceSkillDir,
+      targetDir,
+      dryRun
+    );
+
+    // Add supporting directory paths to output
+    for (const [dirName, dirAction] of Object.entries(supportingDirsAction)) {
+      if (dirAction !== "skipped") {
+        paths.push(path.join(targetDir, dirName));
+      }
+    }
+
+    return {
+      id: skill.id,
+      platform: this.platform,
+      action,
+      paths,
+      supportingDirsAction,
+    };
+  },
+
+  async checkDrift(
+    specDir: string,
+    projectRoot: string,
+    skillId: string,
+    options?: { outputDir?: string }
+  ): Promise<DriftStatus> {
+    return checkPlatformSkillDrift(
+      specDir,
+      projectRoot,
+      skillId,
+      this.platform,
+      options?.outputDir
+    );
+  },
+};
+
+// ============================================================================
+// Renderer Registry
+// ============================================================================
+
+/** Map of platform name to renderer implementation */
+const rendererRegistry: Map<string, PlatformRenderer> = new Map([
+  ["claude-code", claudeCodeRenderer],
+]);
+
+/**
+ * Get the renderer for a specific platform
+ */
+export function getRenderer(platform: string): PlatformRenderer | undefined {
+  return rendererRegistry.get(platform);
+}
+
+/**
+ * Get all registered renderers
+ */
+export function getAllRenderers(): PlatformRenderer[] {
+  return Array.from(rendererRegistry.values());
+}
+
+/**
+ * Register a new platform renderer
+ */
+export function registerRenderer(renderer: PlatformRenderer): void {
+  rendererRegistry.set(renderer.platform, renderer);
 }

--- a/tests/platform-renderer.test.ts
+++ b/tests/platform-renderer.test.ts
@@ -1,0 +1,541 @@
+/**
+ * Tests for Platform Renderer Contract
+ * AC: @platform-renderer-trait ac-1 through ac-6
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import {
+  kspec as kspecFull,
+  setupTempFixtures,
+  cleanupTempDir,
+  initGitRepo,
+} from './helpers/cli';
+import {
+  claudeCodeRenderer,
+  getRenderer,
+  getAllRenderers,
+  registerRenderer,
+  getPlatformRenderHashPath,
+  readPlatformRenderHash,
+  writePlatformRenderHash,
+  checkPlatformSkillDrift,
+  type PlatformRenderer,
+  type PlatformRenderResult,
+  type DriftStatus,
+} from '../src/parser/skill-render';
+import { initContext, loadMetaContext } from '../src/parser';
+
+describe('Platform Renderer Contract', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await setupTempFixtures();
+    await initGitRepo(tempDir);
+
+    // Create a test skill
+    const result = kspecFull(
+      'skill add --id test-skill --name "Test Skill" --description "A test skill for rendering" --platform claude-code',
+      tempDir
+    );
+    if (result.exitCode !== 0) {
+      throw new Error(`skill add failed: ${result.stderr || result.stdout}`);
+    }
+
+    // Write custom content to the skill's SKILL.md
+    const skillMdPath = path.join(tempDir, 'skills', 'test-skill', 'SKILL.md');
+    await fs.writeFile(skillMdPath, '# Test Skill\n\nThis is test content.\n', 'utf-8');
+  });
+
+  afterEach(async () => {
+    await cleanupTempDir(tempDir);
+  });
+
+  // AC: @platform-renderer-trait ac-1
+  describe('ac-1: Platform-specific output files written to configured output directory', () => {
+    it('should write output files to the platform default output directory', async () => {
+      const ctx = await initContext(tempDir);
+      const metaCtx = await loadMetaContext(ctx);
+      const skill = metaCtx.skills.find((s) => s.id === 'test-skill')!;
+
+      const result = await claudeCodeRenderer.render(ctx, tempDir, skill);
+
+      // Should write to .claude/skills/<id>/SKILL.md
+      expect(result.paths[0]).toBe(path.join(tempDir, '.claude', 'skills', 'test-skill', 'SKILL.md'));
+
+      // Verify file exists
+      const content = await fs.readFile(result.paths[0], 'utf-8');
+      expect(content).toContain('# Test Skill');
+    });
+
+    it('should use claude-code as the platform identifier', () => {
+      expect(claudeCodeRenderer.platform).toBe('claude-code');
+    });
+
+    it('should have .claude/skills as the default output directory', () => {
+      expect(claudeCodeRenderer.defaultOutputDir).toBe('.claude/skills');
+    });
+  });
+
+  // AC: @platform-renderer-trait ac-2
+  describe('ac-2: PlatformRenderResult returned with id, platform, action, and paths', () => {
+    it('should return result with all required fields', async () => {
+      const ctx = await initContext(tempDir);
+      const metaCtx = await loadMetaContext(ctx);
+      const skill = metaCtx.skills.find((s) => s.id === 'test-skill')!;
+
+      const result = await claudeCodeRenderer.render(ctx, tempDir, skill);
+
+      expect(result.id).toBe('test-skill');
+      expect(result.platform).toBe('claude-code');
+      expect(result.action).toBe('created');
+      expect(result.paths).toBeInstanceOf(Array);
+      expect(result.paths.length).toBeGreaterThan(0);
+    });
+
+    it('should return unchanged action when file already matches', async () => {
+      const ctx = await initContext(tempDir);
+      const metaCtx = await loadMetaContext(ctx);
+      const skill = metaCtx.skills.find((s) => s.id === 'test-skill')!;
+
+      // First render
+      await claudeCodeRenderer.render(ctx, tempDir, skill);
+
+      // Second render - should be unchanged
+      const result = await claudeCodeRenderer.render(ctx, tempDir, skill);
+
+      expect(result.action).toBe('unchanged');
+    });
+
+    it('should return updated action when source changes', async () => {
+      const ctx = await initContext(tempDir);
+      const metaCtx = await loadMetaContext(ctx);
+      const skill = metaCtx.skills.find((s) => s.id === 'test-skill')!;
+
+      // First render
+      await claudeCodeRenderer.render(ctx, tempDir, skill);
+
+      // Modify source
+      const skillMdPath = path.join(tempDir, 'skills', 'test-skill', 'SKILL.md');
+      await fs.writeFile(skillMdPath, '# Test Skill\n\nUpdated content.\n', 'utf-8');
+
+      // Second render
+      const result = await claudeCodeRenderer.render(ctx, tempDir, skill);
+
+      expect(result.action).toBe('updated');
+    });
+  });
+
+  // AC: @platform-renderer-trait ac-3
+  describe('ac-3: Supporting directories copied to platform output', () => {
+    it('should copy docs directory when present', async () => {
+      // Create docs directory
+      const docsDir = path.join(tempDir, 'skills', 'test-skill', 'docs');
+      await fs.mkdir(docsDir, { recursive: true });
+      await fs.writeFile(path.join(docsDir, 'guide.md'), '# Guide\n', 'utf-8');
+
+      const ctx = await initContext(tempDir);
+      const metaCtx = await loadMetaContext(ctx);
+      const skill = metaCtx.skills.find((s) => s.id === 'test-skill')!;
+
+      const result = await claudeCodeRenderer.render(ctx, tempDir, skill);
+
+      // Check that docs action is tracked
+      expect(result.supportingDirsAction).toBeDefined();
+      expect(result.supportingDirsAction!.docs).toBe('created');
+
+      // Verify docs were copied
+      const targetDocsPath = path.join(tempDir, '.claude', 'skills', 'test-skill', 'docs', 'guide.md');
+      const content = await fs.readFile(targetDocsPath, 'utf-8');
+      expect(content).toContain('# Guide');
+    });
+
+    it('should copy references directory when present', async () => {
+      // Create references directory
+      const refsDir = path.join(tempDir, 'skills', 'test-skill', 'references');
+      await fs.mkdir(refsDir, { recursive: true });
+      await fs.writeFile(path.join(refsDir, 'api.md'), '# API Reference\n', 'utf-8');
+
+      const ctx = await initContext(tempDir);
+      const metaCtx = await loadMetaContext(ctx);
+      const skill = metaCtx.skills.find((s) => s.id === 'test-skill')!;
+
+      const result = await claudeCodeRenderer.render(ctx, tempDir, skill);
+
+      expect(result.supportingDirsAction!.references).toBe('created');
+
+      // Verify references were copied
+      const targetRefsPath = path.join(tempDir, '.claude', 'skills', 'test-skill', 'references', 'api.md');
+      const content = await fs.readFile(targetRefsPath, 'utf-8');
+      expect(content).toContain('# API Reference');
+    });
+
+    it('should copy scripts directory when present', async () => {
+      // Create scripts directory
+      const scriptsDir = path.join(tempDir, 'skills', 'test-skill', 'scripts');
+      await fs.mkdir(scriptsDir, { recursive: true });
+      await fs.writeFile(path.join(scriptsDir, 'helper.sh'), '#!/bin/bash\necho "hello"\n', 'utf-8');
+
+      const ctx = await initContext(tempDir);
+      const metaCtx = await loadMetaContext(ctx);
+      const skill = metaCtx.skills.find((s) => s.id === 'test-skill')!;
+
+      const result = await claudeCodeRenderer.render(ctx, tempDir, skill);
+
+      expect(result.supportingDirsAction!.scripts).toBe('created');
+
+      // Verify scripts were copied
+      const targetScriptsPath = path.join(tempDir, '.claude', 'skills', 'test-skill', 'scripts', 'helper.sh');
+      const content = await fs.readFile(targetScriptsPath, 'utf-8');
+      expect(content).toContain('#!/bin/bash');
+    });
+
+    it('should copy assets directory when present', async () => {
+      // Create assets directory
+      const assetsDir = path.join(tempDir, 'skills', 'test-skill', 'assets');
+      await fs.mkdir(assetsDir, { recursive: true });
+      await fs.writeFile(path.join(assetsDir, 'config.json'), '{"key": "value"}\n', 'utf-8');
+
+      const ctx = await initContext(tempDir);
+      const metaCtx = await loadMetaContext(ctx);
+      const skill = metaCtx.skills.find((s) => s.id === 'test-skill')!;
+
+      const result = await claudeCodeRenderer.render(ctx, tempDir, skill);
+
+      expect(result.supportingDirsAction!.assets).toBe('created');
+
+      // Verify assets were copied
+      const targetAssetsPath = path.join(tempDir, '.claude', 'skills', 'test-skill', 'assets', 'config.json');
+      const content = await fs.readFile(targetAssetsPath, 'utf-8');
+      expect(content).toContain('"key"');
+    });
+
+    it('should show skipped for directories that do not exist', async () => {
+      const ctx = await initContext(tempDir);
+      const metaCtx = await loadMetaContext(ctx);
+      const skill = metaCtx.skills.find((s) => s.id === 'test-skill')!;
+
+      const result = await claudeCodeRenderer.render(ctx, tempDir, skill);
+
+      expect(result.supportingDirsAction).toBeDefined();
+      expect(result.supportingDirsAction!.references).toBe('skipped');
+      expect(result.supportingDirsAction!.scripts).toBe('skipped');
+      expect(result.supportingDirsAction!.assets).toBe('skipped');
+    });
+
+    it('should include supporting directory paths in result.paths', async () => {
+      // Create docs directory
+      const docsDir = path.join(tempDir, 'skills', 'test-skill', 'docs');
+      await fs.mkdir(docsDir, { recursive: true });
+      await fs.writeFile(path.join(docsDir, 'guide.md'), '# Guide\n', 'utf-8');
+
+      const ctx = await initContext(tempDir);
+      const metaCtx = await loadMetaContext(ctx);
+      const skill = metaCtx.skills.find((s) => s.id === 'test-skill')!;
+
+      const result = await claudeCodeRenderer.render(ctx, tempDir, skill);
+
+      // paths should include both SKILL.md and docs directory
+      expect(result.paths).toContain(path.join(tempDir, '.claude', 'skills', 'test-skill', 'SKILL.md'));
+      expect(result.paths).toContain(path.join(tempDir, '.claude', 'skills', 'test-skill', 'docs'));
+    });
+  });
+
+  // AC: @platform-renderer-trait ac-4
+  describe('ac-4: dryRun mode - no files written, result reflects what would happen', () => {
+    it('should not write files when dryRun is true', async () => {
+      const ctx = await initContext(tempDir);
+      const metaCtx = await loadMetaContext(ctx);
+      const skill = metaCtx.skills.find((s) => s.id === 'test-skill')!;
+
+      const result = await claudeCodeRenderer.render(ctx, tempDir, skill, { dryRun: true });
+
+      expect(result.action).toBe('created');
+
+      // File should NOT exist
+      await expect(
+        fs.access(path.join(tempDir, '.claude', 'skills', 'test-skill', 'SKILL.md'))
+      ).rejects.toThrow();
+    });
+
+    it('should not copy supporting directories when dryRun is true', async () => {
+      // Create docs directory
+      const docsDir = path.join(tempDir, 'skills', 'test-skill', 'docs');
+      await fs.mkdir(docsDir, { recursive: true });
+      await fs.writeFile(path.join(docsDir, 'guide.md'), '# Guide\n', 'utf-8');
+
+      const ctx = await initContext(tempDir);
+      const metaCtx = await loadMetaContext(ctx);
+      const skill = metaCtx.skills.find((s) => s.id === 'test-skill')!;
+
+      const result = await claudeCodeRenderer.render(ctx, tempDir, skill, { dryRun: true });
+
+      expect(result.supportingDirsAction!.docs).toBe('created');
+
+      // Target docs should NOT exist
+      await expect(
+        fs.access(path.join(tempDir, '.claude', 'skills', 'test-skill', 'docs'))
+      ).rejects.toThrow();
+    });
+
+    it('should return correct action for what would happen', async () => {
+      const ctx = await initContext(tempDir);
+      const metaCtx = await loadMetaContext(ctx);
+      const skill = metaCtx.skills.find((s) => s.id === 'test-skill')!;
+
+      // First render (actual)
+      await claudeCodeRenderer.render(ctx, tempDir, skill);
+
+      // Second render dry run - should show unchanged
+      const result = await claudeCodeRenderer.render(ctx, tempDir, skill, { dryRun: true });
+
+      expect(result.action).toBe('unchanged');
+    });
+  });
+
+  // AC: @platform-renderer-trait ac-5
+  describe('ac-5: Custom outputDir goes to custom path instead of platform default', () => {
+    it('should write to custom output directory when specified', async () => {
+      const ctx = await initContext(tempDir);
+      const metaCtx = await loadMetaContext(ctx);
+      const skill = metaCtx.skills.find((s) => s.id === 'test-skill')!;
+
+      const customOutputDir = 'custom/output/skills';
+      const result = await claudeCodeRenderer.render(ctx, tempDir, skill, { outputDir: customOutputDir });
+
+      // Should write to custom directory
+      expect(result.paths[0]).toBe(path.join(tempDir, customOutputDir, 'test-skill', 'SKILL.md'));
+
+      // Verify file exists at custom location
+      const content = await fs.readFile(result.paths[0], 'utf-8');
+      expect(content).toContain('# Test Skill');
+    });
+
+    it('should not write to default directory when custom outputDir specified', async () => {
+      const ctx = await initContext(tempDir);
+      const metaCtx = await loadMetaContext(ctx);
+      const skill = metaCtx.skills.find((s) => s.id === 'test-skill')!;
+
+      await claudeCodeRenderer.render(ctx, tempDir, skill, { outputDir: 'custom/output/skills' });
+
+      // Default location should NOT have the file
+      await expect(
+        fs.access(path.join(tempDir, '.claude', 'skills', 'test-skill', 'SKILL.md'))
+      ).rejects.toThrow();
+    });
+
+    it('should copy supporting directories to custom output directory', async () => {
+      // Create docs directory
+      const docsDir = path.join(tempDir, 'skills', 'test-skill', 'docs');
+      await fs.mkdir(docsDir, { recursive: true });
+      await fs.writeFile(path.join(docsDir, 'guide.md'), '# Guide\n', 'utf-8');
+
+      const ctx = await initContext(tempDir);
+      const metaCtx = await loadMetaContext(ctx);
+      const skill = metaCtx.skills.find((s) => s.id === 'test-skill')!;
+
+      const customOutputDir = 'custom/output/skills';
+      const result = await claudeCodeRenderer.render(ctx, tempDir, skill, { outputDir: customOutputDir });
+
+      expect(result.supportingDirsAction!.docs).toBe('created');
+
+      // Verify docs at custom location
+      const targetDocsPath = path.join(tempDir, customOutputDir, 'test-skill', 'docs', 'guide.md');
+      const content = await fs.readFile(targetDocsPath, 'utf-8');
+      expect(content).toContain('# Guide');
+    });
+  });
+
+  // AC: @platform-renderer-trait ac-6
+  describe('ac-6: Per-platform render hash written to .render-hash-<platform>', () => {
+    it('should write per-platform hash file when storeHash is true', async () => {
+      const ctx = await initContext(tempDir);
+      const metaCtx = await loadMetaContext(ctx);
+      const skill = metaCtx.skills.find((s) => s.id === 'test-skill')!;
+
+      await claudeCodeRenderer.render(ctx, tempDir, skill, { storeHash: true });
+
+      // Check for per-platform hash file
+      const hashPath = getPlatformRenderHashPath(ctx.specDir, 'test-skill', 'claude-code');
+      const hash = await fs.readFile(hashPath, 'utf-8');
+      expect(hash.trim()).toMatch(/^[a-f0-9]{64}$/);
+    });
+
+    it('should also write legacy hash for backward compatibility', async () => {
+      const ctx = await initContext(tempDir);
+      const metaCtx = await loadMetaContext(ctx);
+      const skill = metaCtx.skills.find((s) => s.id === 'test-skill')!;
+
+      await claudeCodeRenderer.render(ctx, tempDir, skill, { storeHash: true });
+
+      // Check for legacy hash file (without platform suffix)
+      const legacyHashPath = path.join(ctx.specDir, 'skills', 'test-skill', '.render-hash');
+      const hash = await fs.readFile(legacyHashPath, 'utf-8');
+      expect(hash.trim()).toMatch(/^[a-f0-9]{64}$/);
+    });
+
+    it('should not write hash when storeHash is false', async () => {
+      const ctx = await initContext(tempDir);
+      const metaCtx = await loadMetaContext(ctx);
+      const skill = metaCtx.skills.find((s) => s.id === 'test-skill')!;
+
+      await claudeCodeRenderer.render(ctx, tempDir, skill, { storeHash: false });
+
+      // Hash file should NOT exist
+      const hashPath = getPlatformRenderHashPath(ctx.specDir, 'test-skill', 'claude-code');
+      await expect(fs.access(hashPath)).rejects.toThrow();
+    });
+
+    it('should checkDrift using per-platform hash', async () => {
+      const ctx = await initContext(tempDir);
+      const metaCtx = await loadMetaContext(ctx);
+      const skill = metaCtx.skills.find((s) => s.id === 'test-skill')!;
+
+      // Render with hash
+      await claudeCodeRenderer.render(ctx, tempDir, skill, { storeHash: true });
+
+      // Check drift - should be in-sync
+      const driftStatus = await claudeCodeRenderer.checkDrift(ctx.specDir, tempDir, 'test-skill');
+      expect(driftStatus).toBe('in-sync');
+    });
+
+    it('should detect drift when rendered file is modified', async () => {
+      const ctx = await initContext(tempDir);
+      const metaCtx = await loadMetaContext(ctx);
+      const skill = metaCtx.skills.find((s) => s.id === 'test-skill')!;
+
+      // Render with hash
+      await claudeCodeRenderer.render(ctx, tempDir, skill, { storeHash: true });
+
+      // Modify the rendered file
+      const renderedPath = path.join(tempDir, '.claude', 'skills', 'test-skill', 'SKILL.md');
+      const content = await fs.readFile(renderedPath, 'utf-8');
+      await fs.writeFile(renderedPath, content + '\n# Manual edit\n', 'utf-8');
+
+      // Check drift - should be drifted
+      const driftStatus = await claudeCodeRenderer.checkDrift(ctx.specDir, tempDir, 'test-skill');
+      expect(driftStatus).toBe('drifted');
+    });
+
+    it('should return not-rendered when file does not exist', async () => {
+      const ctx = await initContext(tempDir);
+
+      const driftStatus = await claudeCodeRenderer.checkDrift(ctx.specDir, tempDir, 'test-skill');
+      expect(driftStatus).toBe('not-rendered');
+    });
+
+    it('should checkDrift with custom outputDir', async () => {
+      const ctx = await initContext(tempDir);
+      const metaCtx = await loadMetaContext(ctx);
+      const skill = metaCtx.skills.find((s) => s.id === 'test-skill')!;
+
+      const customOutputDir = 'custom/output/skills';
+
+      // Render to custom location with hash
+      await claudeCodeRenderer.render(ctx, tempDir, skill, {
+        outputDir: customOutputDir,
+        storeHash: true
+      });
+
+      // Check drift at default location - should be not-rendered
+      const defaultDrift = await claudeCodeRenderer.checkDrift(ctx.specDir, tempDir, 'test-skill');
+      expect(defaultDrift).toBe('not-rendered');
+
+      // Check drift at custom location - should be in-sync
+      const customDrift = await claudeCodeRenderer.checkDrift(ctx.specDir, tempDir, 'test-skill', {
+        outputDir: customOutputDir,
+      });
+      expect(customDrift).toBe('in-sync');
+    });
+  });
+});
+
+describe('Platform Renderer Registry', () => {
+  it('should return claude-code renderer from registry', () => {
+    const renderer = getRenderer('claude-code');
+    expect(renderer).toBeDefined();
+    expect(renderer!.platform).toBe('claude-code');
+  });
+
+  it('should return undefined for unknown platform', () => {
+    const renderer = getRenderer('unknown-platform');
+    expect(renderer).toBeUndefined();
+  });
+
+  it('should return all renderers', () => {
+    const renderers = getAllRenderers();
+    expect(renderers.length).toBeGreaterThan(0);
+    expect(renderers.some((r) => r.platform === 'claude-code')).toBe(true);
+  });
+
+  it('should allow registering custom renderers', () => {
+    const mockRenderer: PlatformRenderer = {
+      platform: 'test-platform',
+      defaultOutputDir: '.test/skills',
+      async render() {
+        return {
+          id: 'test',
+          platform: 'test-platform',
+          action: 'created',
+          paths: [],
+        };
+      },
+      async checkDrift() {
+        return 'not-rendered';
+      },
+    };
+
+    registerRenderer(mockRenderer);
+
+    const retrieved = getRenderer('test-platform');
+    expect(retrieved).toBe(mockRenderer);
+  });
+});
+
+describe('Per-Platform Hash Functions', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await setupTempFixtures();
+    await initGitRepo(tempDir);
+  });
+
+  afterEach(async () => {
+    await cleanupTempDir(tempDir);
+  });
+
+  it('getPlatformRenderHashPath returns correct path', () => {
+    const hashPath = getPlatformRenderHashPath('/path/to/specDir', 'skill-id', 'claude-code');
+    expect(hashPath).toBe('/path/to/specDir/skills/skill-id/.render-hash-claude-code');
+  });
+
+  it('writePlatformRenderHash and readPlatformRenderHash round-trip', async () => {
+    const skillId = 'test-skill';
+    const platform = 'claude-code';
+    const hash = 'abc123def456';
+
+    // Create skills directory
+    await fs.mkdir(path.join(tempDir, 'skills', skillId), { recursive: true });
+
+    await writePlatformRenderHash(tempDir, skillId, platform, hash);
+    const read = await readPlatformRenderHash(tempDir, skillId, platform);
+
+    expect(read).toBe(hash);
+  });
+
+  it('readPlatformRenderHash returns null when file does not exist', async () => {
+    const read = await readPlatformRenderHash(tempDir, 'nonexistent', 'claude-code');
+    expect(read).toBeNull();
+  });
+
+  it('checkPlatformSkillDrift returns not-rendered when rendered file missing', async () => {
+    const result = await checkPlatformSkillDrift(
+      tempDir,
+      tempDir,
+      'nonexistent-skill',
+      'claude-code'
+    );
+    expect(result).toBe('not-rendered');
+  });
+});


### PR DESCRIPTION
## Summary

- Implements the `PlatformRenderer` interface for multi-platform skill rendering
- Defines `PlatformRenderResult` with id, platform, action, paths, and supportingDirsAction fields
- Defines `DriftStatus` type for drift detection states
- Creates renderer registry with `getRenderer()` and `getAllRenderers()`
- Implements `claudeCodeRenderer` supporting all 6 acceptance criteria:
  - **ac-1**: Platform-specific output written to configured directory
  - **ac-2**: PlatformRenderResult returned with all required fields
  - **ac-3**: Supporting directories (references/, scripts/, assets/, docs/) copied
  - **ac-4**: dryRun mode with no file writes
  - **ac-5**: Custom outputDir support
  - **ac-6**: Per-platform hash stored in `.render-hash-<platform>`

## Test plan

- [x] 33 new tests added in `tests/platform-renderer.test.ts`
- [x] All 6 ACs covered with test annotations
- [x] Existing skill rendering tests pass (48 tests)
- [x] Full test suite passes (2617 tests)
- [x] TypeScript build passes

Task: @implement-platform-renderer-contract
Spec: @platform-renderer-trait

🤖 Generated with [Claude Code](https://claude.ai/code)