### PR TITLE
feat: implement claude code renderer extended frontmatter

### DIFF
--- a/src/parser/skill-render.ts
+++ b/src/parser/skill-render.ts
@@ -143,14 +143,67 @@ export interface RenderSkillOptions {
 export const KSPEC_MANAGED_MARKER = "<!-- kspec-managed -->";
 
 /**
+ * Convert snake_case to kebab-case for Claude Code frontmatter keys
+ * AC: @claude-code-renderer-extended ac-8 - snake_case to kebab-case conversion
+ */
+function toKebabCase(str: string): string {
+  return str.replace(/_/g, "-");
+}
+
+/**
  * Generate YAML frontmatter for a skill.
  * AC: @claude-code-renderer ac-2 - YAML frontmatter with name and description fields
+ * AC: @claude-code-renderer-extended ac-1 - portable fields (license, allowed-tools)
+ * AC: @claude-code-renderer-extended ac-2 - user-invocable from platform_config
+ * AC: @claude-code-renderer-extended ac-3 - context and agent from platform_config
+ * AC: @claude-code-renderer-extended ac-4 - disable-model-invocation from platform_config
+ * AC: @claude-code-renderer-extended ac-5 - only portable fields when no platform_config
+ * AC: @claude-code-renderer-extended ac-8 - snake_case to kebab-case conversion
  */
 export function generateFrontmatter(skill: LoadedSkill): string {
   const frontmatter: Record<string, unknown> = {
     name: skill.id,
     description: skill.description || skill.name,
   };
+
+  // AC: @claude-code-renderer-extended ac-1 - Add portable fields
+  if (skill.license) {
+    frontmatter.license = skill.license;
+  }
+  if (skill.allowed_tools && skill.allowed_tools.length > 0) {
+    frontmatter["allowed-tools"] = skill.allowed_tools;
+  }
+  if (skill.compatibility) {
+    frontmatter.compatibility = skill.compatibility;
+  }
+
+  // AC: @claude-code-renderer-extended ac-2, ac-3, ac-4 - Add Claude Code platform fields
+  const claudeCodeConfig = skill.platform_config?.claude_code;
+  if (claudeCodeConfig) {
+    // AC: @claude-code-renderer-extended ac-2 - user_invocable
+    if (claudeCodeConfig.user_invocable !== undefined) {
+      frontmatter["user-invocable"] = claudeCodeConfig.user_invocable;
+    }
+    // AC: @claude-code-renderer-extended ac-4 - disable_model_invocation
+    if (claudeCodeConfig.disable_model_invocation !== undefined) {
+      frontmatter["disable-model-invocation"] = claudeCodeConfig.disable_model_invocation;
+    }
+    // AC: @claude-code-renderer-extended ac-3 - context and agent
+    if (claudeCodeConfig.context) {
+      frontmatter.context = claudeCodeConfig.context;
+    }
+    if (claudeCodeConfig.agent) {
+      frontmatter.agent = claudeCodeConfig.agent;
+    }
+    // Other Claude Code fields
+    if (claudeCodeConfig.model) {
+      frontmatter.model = claudeCodeConfig.model;
+    }
+    if (claudeCodeConfig.argument_hint) {
+      frontmatter["argument-hint"] = claudeCodeConfig.argument_hint;
+    }
+  }
+
   return `---\n${yaml.stringify(frontmatter).trim()}\n---`;
 }
 
@@ -315,6 +368,70 @@ async function directoriesEqual(src: string, dest: string): Promise<boolean> {
   }
 }
 
+// ============================================================================
+// Supporting Directories (AC: @platform-renderer-trait ac-3, @claude-code-renderer-extended ac-7)
+// ============================================================================
+
+/** Known supporting directory names */
+const SUPPORTING_DIRS = ["references", "scripts", "assets", "docs"] as const;
+
+/**
+ * Copy supporting directories from source skill to rendered output
+ * AC: @platform-renderer-trait ac-3 - Supporting directories copied to platform output
+ * AC: @claude-code-renderer-extended ac-7 - references/, scripts/, assets/ copied
+ */
+async function copySupportingDirectories(
+  sourceSkillDir: string,
+  targetSkillDir: string,
+  dryRun: boolean
+): Promise<Record<string, "created" | "updated" | "unchanged" | "skipped">> {
+  const results: Record<string, "created" | "updated" | "unchanged" | "skipped"> = {};
+
+  for (const dirName of SUPPORTING_DIRS) {
+    const sourceDir = path.join(sourceSkillDir, dirName);
+    const targetDir = path.join(targetSkillDir, dirName);
+
+    try {
+      const stats = await fs.stat(sourceDir);
+      if (!stats.isDirectory()) {
+        results[dirName] = "skipped";
+        continue;
+      }
+
+      // Check if target exists
+      let targetExists = false;
+      try {
+        await fs.stat(targetDir);
+        targetExists = true;
+      } catch {
+        // Target doesn't exist
+      }
+
+      if (!targetExists) {
+        results[dirName] = "created";
+      } else {
+        // Compare directories
+        const equal = await directoriesEqual(sourceDir, targetDir);
+        results[dirName] = equal ? "unchanged" : "updated";
+      }
+
+      // Apply changes
+      if (!dryRun && results[dirName] !== "unchanged") {
+        if (targetExists) {
+          await fs.rm(targetDir, { recursive: true, force: true });
+        }
+        await fs.mkdir(targetDir, { recursive: true });
+        await copyDirectory(sourceDir, targetDir);
+      }
+    } catch {
+      // Source directory doesn't exist
+      results[dirName] = "skipped";
+    }
+  }
+
+  return results;
+}
+
 /**
  * Render a skill to Claude Code format.
  *
@@ -413,44 +530,16 @@ export async function renderClaudeCodeSkill(
     }
   }
 
-  // Handle docs directory
-  const sourceDocsDir = path.join(ctx.specDir, "skills", skill.id, "docs");
-  const targetDocsDir = path.join(targetDir, "docs");
-  let docsAction: "created" | "updated" | "unchanged" | "skipped" = "skipped";
+  // AC: @claude-code-renderer-extended ac-7 - Copy supporting directories (references/, scripts/, assets/, docs/)
+  const sourceSkillDir = path.join(ctx.specDir, "skills", skill.id);
+  const supportingDirsAction = await copySupportingDirectories(
+    sourceSkillDir,
+    targetDir,
+    dryRun
+  );
 
-  try {
-    const stats = await fs.stat(sourceDocsDir);
-    if (stats.isDirectory()) {
-      // Check if target docs exist and compare
-      let targetDocsExist = false;
-      try {
-        await fs.stat(targetDocsDir);
-        targetDocsExist = true;
-      } catch {
-        // Target docs don't exist
-      }
-
-      if (!targetDocsExist) {
-        docsAction = "created";
-      } else {
-        // Compare directories
-        const equal = await directoriesEqual(sourceDocsDir, targetDocsDir);
-        docsAction = equal ? "unchanged" : "updated";
-      }
-
-      // Apply changes
-      if (!dryRun && docsAction !== "unchanged") {
-        // Remove existing docs and copy fresh
-        if (targetDocsExist) {
-          await fs.rm(targetDocsDir, { recursive: true, force: true });
-        }
-        await fs.mkdir(targetDocsDir, { recursive: true });
-        await copyDirectory(sourceDocsDir, targetDocsDir);
-      }
-    }
-  } catch {
-    // No source docs directory
-  }
+  // For backward compatibility, also expose docsAction
+  const docsAction = supportingDirsAction.docs || "skipped";
 
   return {
     id: skill.id,
@@ -488,6 +577,7 @@ export function getPlatformRenderHashPath(specDir: string, skillId: string, plat
 /**
  * Read the stored render hash for a skill on a specific platform
  * AC: @platform-renderer-trait ac-6 - Read per-platform hash
+ * AC: @claude-code-renderer-extended ac-6 - fallback to legacy hash
  */
 export async function readPlatformRenderHash(
   specDir: string,
@@ -501,6 +591,36 @@ export async function readPlatformRenderHash(
   } catch {
     // Fall back to legacy hash (non-platform-specific)
     return readRenderHash(specDir, skillId);
+  }
+}
+
+/**
+ * Migrate legacy .render-hash to platform-specific .render-hash-<platform>
+ * AC: @claude-code-renderer-extended ac-6 - hash migration
+ */
+export async function migrateLegacyRenderHash(
+  specDir: string,
+  skillId: string,
+  platform: string
+): Promise<boolean> {
+  const legacyHashPath = getRenderHashPath(specDir, skillId);
+  const platformHashPath = getPlatformRenderHashPath(specDir, skillId, platform);
+
+  try {
+    // Check if platform-specific hash already exists
+    await fs.access(platformHashPath);
+    return false; // Already migrated
+  } catch {
+    // Platform-specific doesn't exist, check for legacy
+  }
+
+  try {
+    const legacyHash = await fs.readFile(legacyHashPath, "utf-8");
+    // Write to platform-specific location
+    await writePlatformRenderHash(specDir, skillId, platform, legacyHash.trim());
+    return true; // Migrated successfully
+  } catch {
+    return false; // No legacy hash to migrate
   }
 }
 
@@ -542,6 +662,9 @@ export async function checkPlatformSkillDrift(
     return "not-rendered";
   }
 
+  // AC: @claude-code-renderer-extended ac-6 - Migrate legacy hash if needed
+  await migrateLegacyRenderHash(specDir, skillId, platform);
+
   // Get stored hash (try platform-specific first, then fall back to legacy)
   const storedHash = await readPlatformRenderHash(specDir, skillId, platform);
   if (!storedHash) {
@@ -565,69 +688,6 @@ function getPlatformDefaultOutputDir(platform: string): string {
     default:
       return `.${platform}/skills`;
   }
-}
-
-// ============================================================================
-// Supporting Directories (AC: @platform-renderer-trait ac-3)
-// ============================================================================
-
-/** Known supporting directory names */
-const SUPPORTING_DIRS = ["references", "scripts", "assets", "docs"] as const;
-
-/**
- * Copy supporting directories from source skill to rendered output
- * AC: @platform-renderer-trait ac-3 - Supporting directories copied to platform output
- */
-async function copySupportingDirectories(
-  sourceSkillDir: string,
-  targetSkillDir: string,
-  dryRun: boolean
-): Promise<Record<string, "created" | "updated" | "unchanged" | "skipped">> {
-  const results: Record<string, "created" | "updated" | "unchanged" | "skipped"> = {};
-
-  for (const dirName of SUPPORTING_DIRS) {
-    const sourceDir = path.join(sourceSkillDir, dirName);
-    const targetDir = path.join(targetSkillDir, dirName);
-
-    try {
-      const stats = await fs.stat(sourceDir);
-      if (!stats.isDirectory()) {
-        results[dirName] = "skipped";
-        continue;
-      }
-
-      // Check if target exists
-      let targetExists = false;
-      try {
-        await fs.stat(targetDir);
-        targetExists = true;
-      } catch {
-        // Target doesn't exist
-      }
-
-      if (!targetExists) {
-        results[dirName] = "created";
-      } else {
-        // Compare directories
-        const equal = await directoriesEqual(sourceDir, targetDir);
-        results[dirName] = equal ? "unchanged" : "updated";
-      }
-
-      // Apply changes
-      if (!dryRun && results[dirName] !== "unchanged") {
-        if (targetExists) {
-          await fs.rm(targetDir, { recursive: true, force: true });
-        }
-        await fs.mkdir(targetDir, { recursive: true });
-        await copyDirectory(sourceDir, targetDir);
-      }
-    } catch {
-      // Source directory doesn't exist
-      results[dirName] = "skipped";
-    }
-  }
-
-  return results;
 }
 
 // ============================================================================

--- a/tests/skill-rendering.test.ts
+++ b/tests/skill-rendering.test.ts
@@ -896,3 +896,392 @@ describe('Skill Drift Detection', () => {
     });
   });
 });
+
+/**
+ * Tests for Extended Frontmatter in Claude Code Renderer
+ * AC: @claude-code-renderer-extended ac-1 through ac-8
+ */
+describe('Claude Code Renderer - Extended Frontmatter', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await setupTempFixtures();
+    await initGitRepo(tempDir);
+  });
+
+  afterEach(async () => {
+    await cleanupTempDir(tempDir);
+  });
+
+  // AC: @claude-code-renderer-extended ac-1
+  describe('ac-1: Portable fields (license, allowed-tools) in frontmatter', () => {
+    it('should include license field when skill has license', async () => {
+      // Create skill with license
+      const result = kspecFull(
+        'skill add --id licensed-skill --name "Licensed Skill" --description "A skill with license" --platform claude-code',
+        tempDir
+      );
+      expect(result.exitCode).toBe(0);
+
+      // Manually update meta.yaml to add license field (proper indentation with 4 spaces)
+      const metaPath = path.join(tempDir, 'kynetic.meta.yaml');
+      let metaContent = await fs.readFile(metaPath, 'utf-8');
+      metaContent = metaContent.replace(
+        /id: licensed-skill\n/,
+        'id: licensed-skill\n    license: MIT\n'
+      );
+      await fs.writeFile(metaPath, metaContent, 'utf-8');
+
+      // Write content
+      const skillMdPath = path.join(tempDir, 'skills', 'licensed-skill', 'SKILL.md');
+      await fs.writeFile(skillMdPath, '# Licensed Skill\n\nContent.\n', 'utf-8');
+
+      // Render
+      kspecFull('skill render', tempDir);
+
+      // Check frontmatter
+      const renderedPath = path.join(tempDir, '.claude', 'skills', 'licensed-skill', 'SKILL.md');
+      const renderedContent = await fs.readFile(renderedPath, 'utf-8');
+      expect(renderedContent).toContain('license: MIT');
+    });
+
+    it('should include allowed-tools when skill has allowed_tools', async () => {
+      // Create skill
+      kspecFull(
+        'skill add --id tools-skill --name "Tools Skill" --description "A skill with tools" --platform claude-code',
+        tempDir
+      );
+
+      // Replace the empty allowed_tools array with actual tools
+      const metaPath = path.join(tempDir, 'kynetic.meta.yaml');
+      let metaContent = await fs.readFile(metaPath, 'utf-8');
+      // The skill add command creates: allowed_tools: []
+      // Replace that with our array
+      metaContent = metaContent.replace(
+        /    allowed_tools: \[\]/,
+        '    allowed_tools:\n      - Bash\n      - Read'
+      );
+      await fs.writeFile(metaPath, metaContent, 'utf-8');
+
+      // Write content
+      const skillMdPath = path.join(tempDir, 'skills', 'tools-skill', 'SKILL.md');
+      await fs.writeFile(skillMdPath, '# Tools Skill\n\nContent.\n', 'utf-8');
+
+      // Render
+      kspecFull('skill render', tempDir);
+
+      // Check frontmatter
+      const renderedPath = path.join(tempDir, '.claude', 'skills', 'tools-skill', 'SKILL.md');
+      const renderedContent = await fs.readFile(renderedPath, 'utf-8');
+      expect(renderedContent).toContain('allowed-tools:');
+      expect(renderedContent).toContain('- Bash');
+      expect(renderedContent).toContain('- Read');
+    });
+  });
+
+  // AC: @claude-code-renderer-extended ac-2
+  describe('ac-2: user-invocable from platform_config.claude_code', () => {
+    it('should include user-invocable: false when configured', async () => {
+      kspecFull(
+        'skill add --id ui-skill --name "UI Skill" --description "A skill" --platform claude-code',
+        tempDir
+      );
+
+      // Update meta.yaml with platform_config (proper indentation)
+      const metaPath = path.join(tempDir, 'kynetic.meta.yaml');
+      let metaContent = await fs.readFile(metaPath, 'utf-8');
+      metaContent = metaContent.replace(
+        /id: ui-skill\n/,
+        'id: ui-skill\n    platform_config:\n      claude_code:\n        user_invocable: false\n'
+      );
+      await fs.writeFile(metaPath, metaContent, 'utf-8');
+
+      const skillMdPath = path.join(tempDir, 'skills', 'ui-skill', 'SKILL.md');
+      await fs.writeFile(skillMdPath, '# UI Skill\n', 'utf-8');
+
+      kspecFull('skill render', tempDir);
+
+      const renderedPath = path.join(tempDir, '.claude', 'skills', 'ui-skill', 'SKILL.md');
+      const renderedContent = await fs.readFile(renderedPath, 'utf-8');
+      expect(renderedContent).toContain('user-invocable: false');
+    });
+  });
+
+  // AC: @claude-code-renderer-extended ac-3
+  describe('ac-3: context and agent from platform_config.claude_code', () => {
+    it('should include context: fork and agent when configured', async () => {
+      kspecFull(
+        'skill add --id ctx-skill --name "Context Skill" --description "A skill" --platform claude-code',
+        tempDir
+      );
+
+      const metaPath = path.join(tempDir, 'kynetic.meta.yaml');
+      let metaContent = await fs.readFile(metaPath, 'utf-8');
+      metaContent = metaContent.replace(
+        /id: ctx-skill\n/,
+        'id: ctx-skill\n    platform_config:\n      claude_code:\n        context: fork\n        agent: test-agent\n'
+      );
+      await fs.writeFile(metaPath, metaContent, 'utf-8');
+
+      const skillMdPath = path.join(tempDir, 'skills', 'ctx-skill', 'SKILL.md');
+      await fs.writeFile(skillMdPath, '# Context Skill\n', 'utf-8');
+
+      kspecFull('skill render', tempDir);
+
+      const renderedPath = path.join(tempDir, '.claude', 'skills', 'ctx-skill', 'SKILL.md');
+      const renderedContent = await fs.readFile(renderedPath, 'utf-8');
+      expect(renderedContent).toContain('context: fork');
+      expect(renderedContent).toContain('agent: test-agent');
+    });
+  });
+
+  // AC: @claude-code-renderer-extended ac-4
+  describe('ac-4: disable-model-invocation from platform_config', () => {
+    it('should include disable-model-invocation: true when configured', async () => {
+      kspecFull(
+        'skill add --id dmi-skill --name "DMI Skill" --description "A skill" --platform claude-code',
+        tempDir
+      );
+
+      const metaPath = path.join(tempDir, 'kynetic.meta.yaml');
+      let metaContent = await fs.readFile(metaPath, 'utf-8');
+      metaContent = metaContent.replace(
+        /id: dmi-skill\n/,
+        'id: dmi-skill\n    platform_config:\n      claude_code:\n        disable_model_invocation: true\n'
+      );
+      await fs.writeFile(metaPath, metaContent, 'utf-8');
+
+      const skillMdPath = path.join(tempDir, 'skills', 'dmi-skill', 'SKILL.md');
+      await fs.writeFile(skillMdPath, '# DMI Skill\n', 'utf-8');
+
+      kspecFull('skill render', tempDir);
+
+      const renderedPath = path.join(tempDir, '.claude', 'skills', 'dmi-skill', 'SKILL.md');
+      const renderedContent = await fs.readFile(renderedPath, 'utf-8');
+      expect(renderedContent).toContain('disable-model-invocation: true');
+    });
+  });
+
+  // AC: @claude-code-renderer-extended ac-5
+  describe('ac-5: Only portable fields when no platform_config.claude_code', () => {
+    it('should only include name, description, and portable fields when no platform_config', async () => {
+      kspecFull(
+        'skill add --id simple-skill --name "Simple Skill" --description "A simple skill" --platform claude-code',
+        tempDir
+      );
+
+      // Add license but no platform_config (proper indentation)
+      const metaPath = path.join(tempDir, 'kynetic.meta.yaml');
+      let metaContent = await fs.readFile(metaPath, 'utf-8');
+      metaContent = metaContent.replace(
+        /id: simple-skill\n/,
+        'id: simple-skill\n    license: Apache-2.0\n'
+      );
+      await fs.writeFile(metaPath, metaContent, 'utf-8');
+
+      const skillMdPath = path.join(tempDir, 'skills', 'simple-skill', 'SKILL.md');
+      await fs.writeFile(skillMdPath, '# Simple Skill\n', 'utf-8');
+
+      kspecFull('skill render', tempDir);
+
+      const renderedPath = path.join(tempDir, '.claude', 'skills', 'simple-skill', 'SKILL.md');
+      const renderedContent = await fs.readFile(renderedPath, 'utf-8');
+
+      // Should have name, description, and license
+      expect(renderedContent).toContain('name: simple-skill');
+      expect(renderedContent).toContain('description: A simple skill');
+      expect(renderedContent).toContain('license: Apache-2.0');
+
+      // Should NOT have platform-specific fields
+      expect(renderedContent).not.toContain('user-invocable');
+      expect(renderedContent).not.toContain('disable-model-invocation');
+      expect(renderedContent).not.toContain('context:');
+      expect(renderedContent).not.toContain('agent:');
+    });
+  });
+
+  // AC: @claude-code-renderer-extended ac-6
+  describe('ac-6: Hash migration from .render-hash to .render-hash-claude-code', () => {
+    it('should migrate legacy .render-hash to .render-hash-claude-code on platform drift check', async () => {
+      kspecFull(
+        'skill add --id migrate-skill --name "Migrate Skill" --description "A skill" --platform claude-code',
+        tempDir
+      );
+
+      const skillMdPath = path.join(tempDir, 'skills', 'migrate-skill', 'SKILL.md');
+      await fs.writeFile(skillMdPath, '# Migrate Skill\n', 'utf-8');
+
+      // Render to create the file with legacy hash
+      kspecFull('skill render', tempDir);
+
+      // The CLI render creates .render-hash (legacy)
+      const legacyHashPath = path.join(tempDir, 'skills', 'migrate-skill', '.render-hash');
+      const platformHashPath = path.join(tempDir, 'skills', 'migrate-skill', '.render-hash-claude-code');
+
+      // Verify legacy hash exists
+      const hash = await fs.readFile(legacyHashPath, 'utf-8');
+      expect(hash.trim()).toBeTruthy();
+
+      // Import the platform drift check function and run it directly
+      // This simulates when the new platform renderer is used
+      const { checkPlatformSkillDrift } = await import('../src/parser/skill-render');
+      await checkPlatformSkillDrift(
+        path.join(tempDir, 'skills', '..'), // specDir
+        tempDir,                             // projectRoot
+        'migrate-skill',
+        'claude-code'
+      );
+
+      // After platform drift check, the platform-specific hash should be created from migration
+      const migratedHash = await fs.readFile(platformHashPath, 'utf-8');
+      expect(migratedHash.trim()).toBe(hash.trim());
+    });
+
+    it('should read legacy hash as fallback when platform-specific hash does not exist', async () => {
+      kspecFull(
+        'skill add --id fallback-skill --name "Fallback Skill" --description "A skill" --platform claude-code',
+        tempDir
+      );
+
+      const skillMdPath = path.join(tempDir, 'skills', 'fallback-skill', 'SKILL.md');
+      await fs.writeFile(skillMdPath, '# Fallback Skill\n', 'utf-8');
+
+      // Render
+      kspecFull('skill render', tempDir);
+
+      // The CLI render only creates .render-hash (legacy)
+      // Status should show in-sync because it reads the legacy hash
+      const status = kspecFull('skill status', tempDir);
+      expect(status.stdout).toContain('in-sync');
+    });
+  });
+
+  // AC: @claude-code-renderer-extended ac-7
+  describe('ac-7: Supporting directories (references/, scripts/, assets/) copied', () => {
+    it('should copy references/ directory to rendered output', async () => {
+      kspecFull(
+        'skill add --id ref-skill --name "Ref Skill" --description "A skill" --platform claude-code',
+        tempDir
+      );
+
+      const skillDir = path.join(tempDir, 'skills', 'ref-skill');
+      await fs.writeFile(path.join(skillDir, 'SKILL.md'), '# Ref Skill\n', 'utf-8');
+
+      // Create references directory
+      const refsDir = path.join(skillDir, 'references');
+      await fs.mkdir(refsDir, { recursive: true });
+      await fs.writeFile(path.join(refsDir, 'api.md'), '# API Reference\n', 'utf-8');
+
+      kspecFull('skill render', tempDir);
+
+      // Check references copied
+      const renderedRefsDir = path.join(tempDir, '.claude', 'skills', 'ref-skill', 'references');
+      const refContent = await fs.readFile(path.join(renderedRefsDir, 'api.md'), 'utf-8');
+      expect(refContent).toContain('# API Reference');
+    });
+
+    it('should copy scripts/ directory to rendered output', async () => {
+      kspecFull(
+        'skill add --id scripts-skill --name "Scripts Skill" --description "A skill" --platform claude-code',
+        tempDir
+      );
+
+      const skillDir = path.join(tempDir, 'skills', 'scripts-skill');
+      await fs.writeFile(path.join(skillDir, 'SKILL.md'), '# Scripts Skill\n', 'utf-8');
+
+      // Create scripts directory
+      const scriptsDir = path.join(skillDir, 'scripts');
+      await fs.mkdir(scriptsDir, { recursive: true });
+      await fs.writeFile(path.join(scriptsDir, 'helper.sh'), '#!/bin/bash\necho "Hello"\n', 'utf-8');
+
+      kspecFull('skill render', tempDir);
+
+      // Check scripts copied
+      const renderedScriptsDir = path.join(tempDir, '.claude', 'skills', 'scripts-skill', 'scripts');
+      const scriptContent = await fs.readFile(path.join(renderedScriptsDir, 'helper.sh'), 'utf-8');
+      expect(scriptContent).toContain('#!/bin/bash');
+    });
+
+    it('should copy assets/ directory to rendered output', async () => {
+      kspecFull(
+        'skill add --id assets-skill --name "Assets Skill" --description "A skill" --platform claude-code',
+        tempDir
+      );
+
+      const skillDir = path.join(tempDir, 'skills', 'assets-skill');
+      await fs.writeFile(path.join(skillDir, 'SKILL.md'), '# Assets Skill\n', 'utf-8');
+
+      // Create assets directory
+      const assetsDir = path.join(skillDir, 'assets');
+      await fs.mkdir(assetsDir, { recursive: true });
+      await fs.writeFile(path.join(assetsDir, 'data.json'), '{"key": "value"}', 'utf-8');
+
+      kspecFull('skill render', tempDir);
+
+      // Check assets copied
+      const renderedAssetsDir = path.join(tempDir, '.claude', 'skills', 'assets-skill', 'assets');
+      const assetContent = await fs.readFile(path.join(renderedAssetsDir, 'data.json'), 'utf-8');
+      expect(assetContent).toContain('"key": "value"');
+    });
+  });
+
+  // AC: @claude-code-renderer-extended ac-8
+  describe('ac-8: snake_case to kebab-case conversion in frontmatter', () => {
+    it('should convert disable_model_invocation to disable-model-invocation', async () => {
+      kspecFull(
+        'skill add --id case-skill --name "Case Skill" --description "A skill" --platform claude-code',
+        tempDir
+      );
+
+      const metaPath = path.join(tempDir, 'kynetic.meta.yaml');
+      let metaContent = await fs.readFile(metaPath, 'utf-8');
+      metaContent = metaContent.replace(
+        /id: case-skill\n/,
+        'id: case-skill\n    platform_config:\n      claude_code:\n        disable_model_invocation: true\n        user_invocable: false\n'
+      );
+      await fs.writeFile(metaPath, metaContent, 'utf-8');
+
+      const skillMdPath = path.join(tempDir, 'skills', 'case-skill', 'SKILL.md');
+      await fs.writeFile(skillMdPath, '# Case Skill\n', 'utf-8');
+
+      kspecFull('skill render', tempDir);
+
+      const renderedPath = path.join(tempDir, '.claude', 'skills', 'case-skill', 'SKILL.md');
+      const renderedContent = await fs.readFile(renderedPath, 'utf-8');
+
+      // Should use kebab-case in frontmatter
+      expect(renderedContent).toContain('disable-model-invocation: true');
+      expect(renderedContent).toContain('user-invocable: false');
+
+      // Should NOT have snake_case
+      expect(renderedContent).not.toContain('disable_model_invocation');
+      expect(renderedContent).not.toContain('user_invocable');
+    });
+
+    it('should convert argument_hint to argument-hint', async () => {
+      kspecFull(
+        'skill add --id hint-skill --name "Hint Skill" --description "A skill" --platform claude-code',
+        tempDir
+      );
+
+      const metaPath = path.join(tempDir, 'kynetic.meta.yaml');
+      let metaContent = await fs.readFile(metaPath, 'utf-8');
+      metaContent = metaContent.replace(
+        /id: hint-skill\n/,
+        'id: hint-skill\n    platform_config:\n      claude_code:\n        argument_hint: "<task-ref>"\n'
+      );
+      await fs.writeFile(metaPath, metaContent, 'utf-8');
+
+      const skillMdPath = path.join(tempDir, 'skills', 'hint-skill', 'SKILL.md');
+      await fs.writeFile(skillMdPath, '# Hint Skill\n', 'utf-8');
+
+      kspecFull('skill render', tempDir);
+
+      const renderedPath = path.join(tempDir, '.claude', 'skills', 'hint-skill', 'SKILL.md');
+      const renderedContent = await fs.readFile(renderedPath, 'utf-8');
+
+      expect(renderedContent).toContain('argument-hint:');
+      expect(renderedContent).not.toContain('argument_hint');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Extended `generateFrontmatter()` to include portable Agent Skills fields (license, allowed-tools, compatibility) and Claude Code platform fields (user-invocable, disable-model-invocation, context, agent, model, argument-hint)
- Updated `renderClaudeCodeSkill()` to copy ALL supporting directories (references/, scripts/, assets/, docs/) instead of just docs/
- Implemented hash migration from `.render-hash` to `.render-hash-claude-code` with fallback support

## Test plan

- [x] Run `npm test -- tests/skill-rendering.test.ts` - 61 tests pass
- [x] All 8 acceptance criteria have test coverage (13 new tests)
- [x] Full test suite passes (2675 tests pass, 1 unrelated failure in daemon-executable.test.ts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)