### PR TITLE
feat: implement multi-platform render CLI

### DIFF
--- a/src/cli/commands/skill.ts
+++ b/src/cli/commands/skill.ts
@@ -46,13 +46,19 @@ import {
 import { commitIfShadow } from "../../parser/shadow.js";
 import {
   checkSkillDrift,
+  checkPlatformSkillDrift,
   computeContentHash,
   generateFrontmatter,
   isKspecManagedSkill as isKspecManaged,
   KSPEC_MANAGED_MARKER,
   readRenderHash,
   renderClaudeCodeSkill,
+  getRenderer,
+  getAllRenderers,
   type ClaudeCodeRenderResult,
+  type PlatformRenderer,
+  type PlatformRenderResult,
+  type DriftStatus,
 } from "../../parser/skill-render.js";
 import { SkillSchema, type SkillOrigin } from "../../schema/index.js";
 import { errors } from "../../strings/errors.js";
@@ -777,6 +783,7 @@ export function registerSkillCommands(program: Command): void {
   // AC: @skill-rendering ac-1 through ac-5 - kspec skill render
   // AC: @skill-render-cli ac-1, ac-2 - kspec skill render / kspec skill render @skill-id
   // AC: @skill-drift-detection ac-3, ac-4 - drift handling with --force
+  // AC: @multi-platform-render-cli ac-1 through ac-7 - multi-platform rendering
   // AC: @trait-dry-run - supports --dry-run
   // AC: @trait-error-guidance - provides error guidance
   skill
@@ -787,6 +794,7 @@ export function registerSkillCommands(program: Command): void {
     .option("--clean", "Remove orphaned managed skill directories")
     .option("--dry-run", "Show what would be changed without applying")
     .option("--force", "Overwrite drifted skill files (manually edited)")
+    .option("--output-dir <path>", "Custom output directory (overrides platform default)")
     .option("--skill <id>", "Render only a specific skill (deprecated, use positional arg)")
     .action(async (ref: string | undefined, options) => {
       try {
@@ -805,13 +813,13 @@ export function registerSkillCommands(program: Command): void {
         const projectRoot = ctx.rootDir;
         const dryRun = options.dryRun || false;
         const force = options.force || false;
-        const results: SkillRenderResult[] = [];
+        const customOutputDir = options.outputDir;
+        const results: MultiPlatformRenderResult[] = [];
         const cleanResults: CleanResult[] = [];
+        const warnings: string[] = [];
 
-        // Filter skills by platform (only claude-code for now)
-        let skillsToRender = metaCtx.skills.filter((s) =>
-          s.platforms.includes("claude-code")
-        );
+        // Get all skills (no platform filtering - we'll check per-platform)
+        let skillsToRender = metaCtx.skills;
 
         // AC: @skill-render-cli ac-2 - Filter to specific skill if requested
         // Support both positional ref argument and --skill option
@@ -826,96 +834,150 @@ export function registerSkillCommands(program: Command): void {
           }
           const skill = item as LoadedSkill;
           skillsToRender = skillsToRender.filter((s) => s.id === skill.id);
-          if (skillsToRender.length === 0) {
-            error(`Skill '${skill.id}' does not have claude-code platform`);
-            process.exit(EXIT_CODES.ERROR);
-          }
         }
 
-        // Ensure .claude/skills directory exists
-        const targetSkillsDir = path.join(projectRoot, ".claude", "skills");
-        if (!dryRun) {
-          await fs.mkdir(targetSkillsDir, { recursive: true });
-        }
+        // Track which platforms we're using to create output directories and for clean
+        const usedPlatforms = new Set<string>();
 
-        // Render each skill
-        // AC: @skill-drift-detection ac-3, ac-4 - Check drift and skip without --force
-        // AC: @consolidate-skill-render ac-1 - delegates to renderClaudeCodeSkill from skill-render.ts
+        // AC: @multi-platform-render-cli ac-1, ac-2 - Render each skill to each of its platforms
         for (const skill of skillsToRender) {
-          // Check for drift before rendering
-          const driftStatus = await checkSkillDrift(ctx.specDir, projectRoot, skill.id);
+          for (const platform of skill.platforms) {
+            // Get the renderer for this platform
+            const renderer = getRenderer(platform);
 
-          // AC: @skill-drift-detection ac-3 - Skip drifted skills without --force
-          if (driftStatus === "drifted" && !force) {
-            const renderedPath = path.join(
+            // AC: @multi-platform-render-cli ac-7 - Warn for unregistered platforms
+            if (!renderer) {
+              warnings.push(`${skill.id}: unregistered platform '${platform}' (skipped)`);
+              results.push({
+                id: skill.id,
+                platform,
+                action: "skipped",
+                path: "",
+                skipReason: `unregistered platform '${platform}'`,
+              });
+              continue;
+            }
+
+            usedPlatforms.add(platform);
+
+            // Determine output directory
+            const outputDir = customOutputDir || renderer.defaultOutputDir;
+
+            // Ensure output directory exists
+            const targetSkillsDir = path.join(projectRoot, outputDir);
+            if (!dryRun) {
+              await fs.mkdir(targetSkillsDir, { recursive: true });
+            }
+
+            // Check for drift before rendering
+            // AC: @skill-drift-detection ac-3, ac-4 - Check drift and skip without --force
+            const driftStatus = await renderer.checkDrift(
+              ctx.specDir,
               projectRoot,
-              ".claude",
-              "skills",
               skill.id,
-              "SKILL.md"
+              { outputDir: customOutputDir }
             );
-            results.push({
-              id: skill.id,
-              action: "skipped",
-              path: renderedPath,
-              skipReason: "drifted (use --force to overwrite)",
-            });
-            continue;
-          }
 
-          // AC: @skill-drift-detection ac-4 - Render (overwrite) when --force is used
-          // AC: @consolidate-skill-render ac-1 - use renderClaudeCodeSkill with storeHash
-          const result = await renderClaudeCodeSkill(ctx, projectRoot, skill, {
-            dryRun,
-            storeHash: true,
-          });
-          results.push(result);
+            // AC: @skill-drift-detection ac-3 - Skip drifted skills without --force
+            if (driftStatus === "drifted" && !force) {
+              const renderedPath = path.join(
+                projectRoot,
+                outputDir,
+                skill.id,
+                "SKILL.md"
+              );
+              results.push({
+                id: skill.id,
+                platform,
+                action: "skipped",
+                path: renderedPath,
+                skipReason: "drifted (use --force to overwrite)",
+              });
+              continue;
+            }
+
+            // AC: @skill-drift-detection ac-4 - Render (overwrite) when --force is used
+            // AC: @multi-platform-render-cli ac-4 - Pass custom outputDir to renderer
+            const result = await renderer.render(ctx, projectRoot, skill, {
+              dryRun,
+              storeHash: true,
+              outputDir: customOutputDir,
+            });
+
+            results.push({
+              id: result.id,
+              platform: result.platform,
+              action: result.action,
+              path: result.paths[0] || "",
+              skipReason: result.skipReason,
+            });
+          }
         }
 
-        // Handle --clean: remove orphaned managed skills
+        // Handle --clean: remove orphaned managed skills per platform
         // AC: @skill-rendering ac-4, ac-5
+        // AC: @multi-platform-render-cli ac-5 - Per-platform cleanup
         if (options.clean) {
-          const activeSkillIds = new Set(metaCtx.skills.map((s) => s.id));
-
-          try {
-            const entries = await fs.readdir(targetSkillsDir, {
-              withFileTypes: true,
-            });
-
-            for (const entry of entries) {
-              if (!entry.isDirectory()) continue;
-
-              const skillId = entry.name;
-              const skillDir = path.join(targetSkillsDir, skillId);
-              const skillMdPath = path.join(skillDir, "SKILL.md");
-
-              // Skip if skill still exists in meta
-              if (activeSkillIds.has(skillId)) continue;
-
-              // AC: @skill-rendering ac-4 - Only consider kspec-managed skills
-              const isManaged = await isKspecManaged(skillMdPath);
-
-              if (isManaged) {
-                // AC: @skill-rendering ac-5 - Remove orphaned directory
-                if (!dryRun) {
-                  await fs.rm(skillDir, { recursive: true, force: true });
-                }
-                cleanResults.push({
-                  id: skillId,
-                  path: skillDir,
-                  action: "removed",
-                });
-              } else {
-                cleanResults.push({
-                  id: skillId,
-                  path: skillDir,
-                  action: "skipped",
-                  reason: "Not managed by kspec",
-                });
+          // Build set of active skill IDs per platform
+          const activeSkillIdsByPlatform = new Map<string, Set<string>>();
+          for (const skill of metaCtx.skills) {
+            for (const platform of skill.platforms) {
+              if (!activeSkillIdsByPlatform.has(platform)) {
+                activeSkillIdsByPlatform.set(platform, new Set());
               }
+              activeSkillIdsByPlatform.get(platform)!.add(skill.id);
             }
-          } catch {
-            // No .claude/skills directory, nothing to clean
+          }
+
+          // Clean each platform's output directory
+          const renderers = getAllRenderers();
+          for (const renderer of renderers) {
+            const outputDir = customOutputDir || renderer.defaultOutputDir;
+            const targetSkillsDir = path.join(projectRoot, outputDir);
+            const activeIds = activeSkillIdsByPlatform.get(renderer.platform) || new Set();
+
+            try {
+              const entries = await fs.readdir(targetSkillsDir, {
+                withFileTypes: true,
+              });
+
+              for (const entry of entries) {
+                if (!entry.isDirectory()) continue;
+
+                const skillId = entry.name;
+                const skillDir = path.join(targetSkillsDir, skillId);
+                const skillMdPath = path.join(skillDir, "SKILL.md");
+
+                // Skip if skill still exists in meta for this platform
+                if (activeIds.has(skillId)) continue;
+
+                // AC: @skill-rendering ac-4 - Only consider kspec-managed skills
+                const isManaged = await isKspecManaged(skillMdPath);
+
+                if (isManaged) {
+                  // AC: @skill-rendering ac-5 - Remove orphaned directory
+                  if (!dryRun) {
+                    await fs.rm(skillDir, { recursive: true, force: true });
+                  }
+                  cleanResults.push({
+                    id: skillId,
+                    path: skillDir,
+                    action: "removed",
+                    platform: renderer.platform,
+                  });
+                } else {
+                  cleanResults.push({
+                    id: skillId,
+                    path: skillDir,
+                    action: "skipped",
+                    reason: "Not managed by kspec",
+                    platform: renderer.platform,
+                  });
+                }
+              }
+            } catch {
+              // Output directory doesn't exist, nothing to clean
+            }
           }
         }
 
@@ -926,6 +988,7 @@ export function registerSkillCommands(program: Command): void {
             dry_run: dryRun,
             rendered: results,
             cleaned: cleanResults,
+            warnings,
           },
           () => {
             // AC: @trait-dry-run ac-3 - Clear indication this is a preview
@@ -934,24 +997,39 @@ export function registerSkillCommands(program: Command): void {
               console.log();
             }
 
+            // AC: @multi-platform-render-cli ac-7 - Show warnings for unregistered platforms
+            if (warnings.length > 0) {
+              console.log(chalk.yellow("Warnings:"));
+              for (const warning of warnings) {
+                console.log(`  ${chalk.yellow("!")} ${warning}`);
+              }
+              console.log();
+            }
+
             // Render results
             const created = results.filter((r) => r.action === "created");
             const updated = results.filter((r) => r.action === "updated");
             const unchanged = results.filter((r) => r.action === "unchanged");
             // AC: @skill-drift-detection ac-3 - Track skipped drifted skills
-            const skippedDrifted = results.filter((r) => r.action === "skipped");
+            const skippedDrifted = results.filter(
+              (r) => r.action === "skipped" && r.skipReason?.includes("drifted")
+            );
+            const skippedUnregistered = results.filter(
+              (r) => r.action === "skipped" && r.skipReason?.includes("unregistered")
+            );
 
+            // AC: @multi-platform-render-cli ac-6 - Include Platform column in output
             if (created.length > 0) {
               console.log(chalk.green(`Created: ${created.length} skill(s)`));
               for (const r of created) {
-                console.log(`  ${chalk.green("+")} ${r.id}`);
+                console.log(`  ${chalk.green("+")} ${r.id} ${chalk.gray(`[${r.platform}]`)}`);
               }
             }
 
             if (updated.length > 0) {
               console.log(chalk.blue(`Updated: ${updated.length} skill(s)`));
               for (const r of updated) {
-                console.log(`  ${chalk.blue("~")} ${r.id}`);
+                console.log(`  ${chalk.blue("~")} ${r.id} ${chalk.gray(`[${r.platform}]`)}`);
               }
             }
 
@@ -964,7 +1042,7 @@ export function registerSkillCommands(program: Command): void {
               console.log();
               console.log(chalk.yellow(`Skipped: ${skippedDrifted.length} drifted skill(s)`));
               for (const r of skippedDrifted) {
-                console.log(`  ${chalk.yellow("!")} ${r.id}: ${r.skipReason || "drifted"}`);
+                console.log(`  ${chalk.yellow("!")} ${r.id} ${chalk.gray(`[${r.platform}]`)}: ${r.skipReason || "drifted"}`);
               }
               console.log();
               console.log(chalk.yellow("Use --force to overwrite drifted skills"));
@@ -979,7 +1057,8 @@ export function registerSkillCommands(program: Command): void {
                 console.log();
                 console.log(chalk.red(`Removed: ${removed.length} orphaned skill(s)`));
                 for (const r of removed) {
-                  console.log(`  ${chalk.red("-")} ${r.id}`);
+                  // AC: @multi-platform-render-cli ac-6 - Platform column in clean output
+                  console.log(`  ${chalk.red("-")} ${r.id} ${chalk.gray(`[${r.platform}]`)}`);
                 }
               }
 
@@ -1018,6 +1097,7 @@ export function registerSkillCommands(program: Command): void {
     });
 
   // AC: @skill-render-cli ac-3 - kspec skill status
+  // AC: @multi-platform-render-cli ac-3 - Per-platform status rows
   skill
     .command("status")
     .description("Show sync status of rendered skills")
@@ -1036,30 +1116,46 @@ export function registerSkillCommands(program: Command): void {
         const metaCtx = await loadMetaContext(ctx);
         const projectRoot = ctx.rootDir;
 
-        // Filter skills by platform (only claude-code for now)
-        const skillsToCheck = metaCtx.skills.filter((s) =>
-          s.platforms.includes("claude-code")
-        );
+        // Check all skills (not just claude-code)
+        const skillsToCheck = metaCtx.skills;
 
         if (skillsToCheck.length === 0) {
           console.log(chalk.yellow("No skills found"));
           return;
         }
 
-        const statusResults: SkillStatusResult[] = [];
+        // AC: @multi-platform-render-cli ac-3 - Build status per skill-platform pair
+        const statusResults: MultiPlatformStatusResult[] = [];
 
         for (const skill of skillsToCheck) {
-          const status = await getSkillSyncStatus(ctx, projectRoot, skill);
-          statusResults.push(status);
+          for (const platform of skill.platforms) {
+            const renderer = getRenderer(platform);
+            if (!renderer) {
+              // Unregistered platform - show as not-rendered
+              statusResults.push({
+                id: skill.id,
+                platform,
+                status: "not-rendered",
+                docsStatus: "no-docs",
+                warning: `unregistered platform '${platform}'`,
+              });
+              continue;
+            }
+
+            const status = await getMultiPlatformSyncStatus(ctx, projectRoot, skill, renderer);
+            statusResults.push(status);
+          }
         }
 
         // Output results
         output(
           statusResults,
           () => {
+            // AC: @multi-platform-render-cli ac-3 - Table shows Platform column
             const table = new Table({
               head: [
                 chalk.bold("ID"),
+                chalk.bold("Platform"),
                 chalk.bold("Status"),
                 chalk.bold("Docs"),
               ],
@@ -1086,7 +1182,8 @@ export function registerSkillCommands(program: Command): void {
 
               table.push([
                 result.id,
-                statusColor(result.status),
+                result.platform,
+                statusColor(result.status + (result.warning ? " (!)" : "")),
                 docsStatusColor(result.docsStatus || "-"),
               ]);
             }
@@ -1097,6 +1194,7 @@ export function registerSkillCommands(program: Command): void {
             const inSync = statusResults.filter((r) => r.status === "in-sync").length;
             const drifted = statusResults.filter((r) => r.status === "drifted").length;
             const notRendered = statusResults.filter((r) => r.status === "not-rendered").length;
+            const warnings = statusResults.filter((r) => r.warning).length;
 
             console.log();
             if (drifted > 0) {
@@ -1104,6 +1202,9 @@ export function registerSkillCommands(program: Command): void {
             }
             if (notRendered > 0) {
               console.log(chalk.gray(`${notRendered} skill(s) not rendered`));
+            }
+            if (warnings > 0) {
+              console.log(chalk.yellow(`${warnings} skill(s) with warnings`));
             }
             if (inSync === statusResults.length) {
               console.log(chalk.green("All skills in sync"));
@@ -1778,13 +1879,29 @@ interface SkillRenderResult {
 }
 
 /**
+ * Result of rendering a single skill to a platform
+ * AC: @multi-platform-render-cli ac-6 - Includes platform field
+ */
+interface MultiPlatformRenderResult {
+  id: string;
+  platform: string;
+  action: "created" | "updated" | "unchanged" | "skipped";
+  path: string;
+  /** Reason why skill was skipped */
+  skipReason?: string;
+}
+
+/**
  * Result of a clean operation
+ * AC: @multi-platform-render-cli ac-5 - Includes platform field
  */
 interface CleanResult {
   id: string;
   path: string;
   action: "removed" | "skipped";
   reason?: string;
+  /** Platform this clean result is for */
+  platform?: string;
 }
 
 /**
@@ -1849,6 +1966,18 @@ interface SkillStatusResult {
   id: string;
   status: "in-sync" | "drifted" | "not-rendered";
   docsStatus?: "in-sync" | "drifted" | "not-rendered" | "no-docs";
+}
+
+/**
+ * Result of checking a skill's sync status for a specific platform
+ * AC: @multi-platform-render-cli ac-3
+ */
+interface MultiPlatformStatusResult {
+  id: string;
+  platform: string;
+  status: "in-sync" | "drifted" | "not-rendered";
+  docsStatus?: "in-sync" | "drifted" | "not-rendered" | "no-docs";
+  warning?: string;
 }
 
 /**
@@ -1919,6 +2048,78 @@ async function getSkillSyncStatus(
 
   return {
     id: skill.id,
+    status,
+    docsStatus,
+  };
+}
+
+/**
+ * Get the sync status of a skill for a specific platform
+ * AC: @multi-platform-render-cli ac-3 - Per-platform status checking
+ */
+async function getMultiPlatformSyncStatus(
+  ctx: KspecContext,
+  projectRoot: string,
+  skill: LoadedSkill,
+  renderer: PlatformRenderer
+): Promise<MultiPlatformStatusResult> {
+  // Use the renderer's drift check
+  const driftStatus = await renderer.checkDrift(ctx.specDir, projectRoot, skill.id);
+
+  // Map drift status to sync status
+  let status: "in-sync" | "drifted" | "not-rendered";
+  switch (driftStatus) {
+    case "in-sync":
+      status = "in-sync";
+      break;
+    case "drifted":
+      status = "drifted";
+      break;
+    case "not-rendered":
+      status = "not-rendered";
+      break;
+    case "no-hash":
+      // No hash stored - need to check if content matches expected
+      const renderedPath = path.join(
+        projectRoot,
+        renderer.defaultOutputDir,
+        skill.id,
+        "SKILL.md"
+      );
+      try {
+        await fs.readFile(renderedPath, "utf-8");
+        // File exists but no hash - treat as needing sync
+        status = "drifted";
+      } catch {
+        status = "not-rendered";
+      }
+      break;
+  }
+
+  // Check docs status for this platform
+  const sourceDocsDir = path.join(ctx.specDir, "skills", skill.id, "docs");
+  const targetDocsDir = path.join(projectRoot, renderer.defaultOutputDir, skill.id, "docs");
+  let docsStatus: "in-sync" | "drifted" | "not-rendered" | "no-docs" = "no-docs";
+
+  try {
+    await fs.stat(sourceDocsDir);
+    // Source docs exist, check target
+    try {
+      await fs.stat(targetDocsDir);
+      // Both exist, compare
+      const equal = await directoriesEqual(sourceDocsDir, targetDocsDir);
+      docsStatus = equal ? "in-sync" : "drifted";
+    } catch {
+      docsStatus = "not-rendered";
+    }
+  } catch {
+    // No source docs
+    docsStatus = "no-docs";
+  }
+
+  return {
+    id: skill.id,
+    platform: renderer.platform,
     status,
     docsStatus,
   };

--- a/tests/multi-platform-render-cli.test.ts
+++ b/tests/multi-platform-render-cli.test.ts
@@ -1,0 +1,498 @@
+/**
+ * Tests for Multi-Platform Render CLI
+ * AC: @multi-platform-render-cli ac-1 through ac-7
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import {
+  kspec as kspecFull,
+  kspecOutput as kspec,
+  kspecJson,
+  setupTempFixtures,
+  cleanupTempDir,
+  initGitRepo,
+} from './helpers/cli';
+
+describe('Multi-Platform Render CLI', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await setupTempFixtures();
+    await initGitRepo(tempDir);
+  });
+
+  afterEach(async () => {
+    await cleanupTempDir(tempDir);
+  });
+
+  // AC: @multi-platform-render-cli ac-1
+  describe('ac-1: Skills with multiple platforms render to all platforms', () => {
+    it('should render to both claude-code and codex when skill has both platforms', async () => {
+      // Create a skill with both platforms
+      kspecFull(
+        'skill add --id multi-plat --name "Multi Platform" --description "Test multi-platform" --platform claude-code --platform codex',
+        tempDir
+      );
+
+      const skillMdPath = path.join(tempDir, 'skills', 'multi-plat', 'SKILL.md');
+      await fs.writeFile(skillMdPath, '# Multi Platform Skill\n\nContent here.\n', 'utf-8');
+
+      // Render
+      kspecFull('skill render', tempDir);
+
+      // Check claude-code output
+      const claudeCodePath = path.join(tempDir, '.claude', 'skills', 'multi-plat', 'SKILL.md');
+      const claudeCodeContent = await fs.readFile(claudeCodePath, 'utf-8');
+      expect(claudeCodeContent).toContain('name: multi-plat');
+      expect(claudeCodeContent).toContain('<!-- kspec-managed -->');
+      expect(claudeCodeContent).toContain('# Multi Platform Skill');
+
+      // Check codex output
+      const codexPath = path.join(tempDir, '.agents', 'skills', 'multi-plat', 'SKILL.md');
+      const codexContent = await fs.readFile(codexPath, 'utf-8');
+      expect(codexContent).toContain('name: multi-plat');
+      expect(codexContent).toContain('<!-- kspec-managed -->');
+      expect(codexContent).toContain('# Multi Platform Skill');
+    });
+
+    it('should report results for both platforms', async () => {
+      kspecFull(
+        'skill add --id both-plat --name "Both Platforms" --description "Test" --platform claude-code --platform codex',
+        tempDir
+      );
+
+      const skillMdPath = path.join(tempDir, 'skills', 'both-plat', 'SKILL.md');
+      await fs.writeFile(skillMdPath, '# Both Platforms\n', 'utf-8');
+
+      const result = kspecJson<{
+        rendered: { id: string; platform: string; action: string }[];
+      }>('skill render --json', tempDir);
+
+      // Should have results for both platforms
+      const claudeCodeResult = result.rendered.find(
+        (r) => r.id === 'both-plat' && r.platform === 'claude-code'
+      );
+      const codexResult = result.rendered.find(
+        (r) => r.id === 'both-plat' && r.platform === 'codex'
+      );
+
+      expect(claudeCodeResult).toBeDefined();
+      expect(codexResult).toBeDefined();
+      expect(claudeCodeResult?.action).toBe('created');
+      expect(codexResult?.action).toBe('created');
+    });
+  });
+
+  // AC: @multi-platform-render-cli ac-2
+  describe('ac-2: Skills with only codex platform render only to codex', () => {
+    it('should render only to codex when skill has only codex platform', async () => {
+      kspecFull(
+        'skill add --id codex-only --name "Codex Only" --description "Test" --platform codex',
+        tempDir
+      );
+
+      const skillMdPath = path.join(tempDir, 'skills', 'codex-only', 'SKILL.md');
+      await fs.writeFile(skillMdPath, '# Codex Only\n', 'utf-8');
+
+      kspecFull('skill render', tempDir);
+
+      // Check codex output exists
+      const codexPath = path.join(tempDir, '.agents', 'skills', 'codex-only', 'SKILL.md');
+      const codexContent = await fs.readFile(codexPath, 'utf-8');
+      expect(codexContent).toContain('name: codex-only');
+
+      // Check claude-code output does NOT exist
+      const claudeCodePath = path.join(tempDir, '.claude', 'skills', 'codex-only', 'SKILL.md');
+      await expect(fs.access(claudeCodePath)).rejects.toThrow();
+    });
+
+    it('should only include codex result in JSON output', async () => {
+      kspecFull(
+        'skill add --id codex-only2 --name "Codex Only 2" --description "Test" --platform codex',
+        tempDir
+      );
+
+      const skillMdPath = path.join(tempDir, 'skills', 'codex-only2', 'SKILL.md');
+      await fs.writeFile(skillMdPath, '# Codex Only 2\n', 'utf-8');
+
+      const result = kspecJson<{
+        rendered: { id: string; platform: string }[];
+      }>('skill render --json', tempDir);
+
+      const skillResults = result.rendered.filter((r) => r.id === 'codex-only2');
+      expect(skillResults.length).toBe(1);
+      expect(skillResults[0].platform).toBe('codex');
+    });
+  });
+
+  // AC: @multi-platform-render-cli ac-3
+  describe('ac-3: Status shows per-platform rows', () => {
+    it('should show separate rows for each platform in status', async () => {
+      kspecFull(
+        'skill add --id status-multi --name "Status Multi" --description "Test" --platform claude-code --platform codex',
+        tempDir
+      );
+
+      const skillMdPath = path.join(tempDir, 'skills', 'status-multi', 'SKILL.md');
+      await fs.writeFile(skillMdPath, '# Status Multi\n', 'utf-8');
+
+      // Render to create the files
+      kspecFull('skill render', tempDir);
+
+      // Check status
+      const result = kspecJson<{
+        id: string;
+        platform: string;
+        status: string;
+      }[]>('skill status --json', tempDir);
+
+      const claudeCodeStatus = result.find(
+        (r) => r.id === 'status-multi' && r.platform === 'claude-code'
+      );
+      const codexStatus = result.find(
+        (r) => r.id === 'status-multi' && r.platform === 'codex'
+      );
+
+      expect(claudeCodeStatus).toBeDefined();
+      expect(codexStatus).toBeDefined();
+      expect(claudeCodeStatus?.status).toBe('in-sync');
+      expect(codexStatus?.status).toBe('in-sync');
+    });
+
+    it('should show Platform column in table output', async () => {
+      kspecFull(
+        'skill add --id status-table --name "Status Table" --description "Test" --platform claude-code --platform codex',
+        tempDir
+      );
+
+      const skillMdPath = path.join(tempDir, 'skills', 'status-table', 'SKILL.md');
+      await fs.writeFile(skillMdPath, '# Status Table\n', 'utf-8');
+
+      kspecFull('skill render', tempDir);
+
+      const output = kspec('skill status', tempDir);
+
+      // Should show both platforms
+      expect(output).toContain('claude-code');
+      expect(output).toContain('codex');
+      expect(output).toContain('Platform');
+    });
+  });
+
+  // AC: @multi-platform-render-cli ac-4
+  describe('ac-4: Custom --output-dir overrides platform default', () => {
+    it('should render to custom directory when --output-dir is specified', async () => {
+      kspecFull(
+        'skill add --id custom-out --name "Custom Out" --description "Test" --platform claude-code',
+        tempDir
+      );
+
+      const skillMdPath = path.join(tempDir, 'skills', 'custom-out', 'SKILL.md');
+      await fs.writeFile(skillMdPath, '# Custom Out\n', 'utf-8');
+
+      kspecFull('skill render --output-dir custom/rendered', tempDir);
+
+      // Check custom location
+      const customPath = path.join(tempDir, 'custom', 'rendered', 'custom-out', 'SKILL.md');
+      const content = await fs.readFile(customPath, 'utf-8');
+      expect(content).toContain('name: custom-out');
+
+      // Default location should NOT exist
+      const defaultPath = path.join(tempDir, '.claude', 'skills', 'custom-out', 'SKILL.md');
+      await expect(fs.access(defaultPath)).rejects.toThrow();
+    });
+
+    it('should apply custom output-dir to all platforms when multi-platform', async () => {
+      kspecFull(
+        'skill add --id custom-multi --name "Custom Multi" --description "Test" --platform claude-code --platform codex',
+        tempDir
+      );
+
+      const skillMdPath = path.join(tempDir, 'skills', 'custom-multi', 'SKILL.md');
+      await fs.writeFile(skillMdPath, '# Custom Multi\n', 'utf-8');
+
+      kspecFull('skill render --output-dir shared/output', tempDir);
+
+      // Both should be in the custom directory
+      const claudeCodePath = path.join(tempDir, 'shared', 'output', 'custom-multi', 'SKILL.md');
+      const codexPath = path.join(tempDir, 'shared', 'output', 'custom-multi', 'SKILL.md');
+
+      // Since both use the same output dir, only one file exists (last one wins)
+      // This is expected behavior - custom output-dir means ALL platforms go there
+      const content = await fs.readFile(claudeCodePath, 'utf-8');
+      expect(content).toContain('name: custom-multi');
+    });
+  });
+
+  // AC: @multi-platform-render-cli ac-5
+  describe('ac-5: --clean operates per-platform', () => {
+    it('should clean orphans from each platform directory', async () => {
+      // Create skills for both platforms
+      kspecFull(
+        'skill add --id keep-skill --name "Keep" --description "Test" --platform claude-code --platform codex',
+        tempDir
+      );
+
+      const skillMdPath = path.join(tempDir, 'skills', 'keep-skill', 'SKILL.md');
+      await fs.writeFile(skillMdPath, '# Keep\n', 'utf-8');
+
+      // Render to create the outputs
+      kspecFull('skill render', tempDir);
+
+      // Manually create orphan directories in both locations
+      const orphanClaudePath = path.join(tempDir, '.claude', 'skills', 'orphan-skill', 'SKILL.md');
+      await fs.mkdir(path.dirname(orphanClaudePath), { recursive: true });
+      await fs.writeFile(orphanClaudePath, '---\nname: orphan\ndescription: orphan\n---\n<!-- kspec-managed -->\n# Orphan\n', 'utf-8');
+
+      const orphanCodexPath = path.join(tempDir, '.agents', 'skills', 'orphan-codex', 'SKILL.md');
+      await fs.mkdir(path.dirname(orphanCodexPath), { recursive: true });
+      await fs.writeFile(orphanCodexPath, '---\nname: orphan-codex\ndescription: orphan\n---\n<!-- kspec-managed -->\n# Orphan\n', 'utf-8');
+
+      // Run clean
+      kspecFull('skill render --clean', tempDir);
+
+      // Orphans should be removed
+      await expect(fs.access(path.dirname(orphanClaudePath))).rejects.toThrow();
+      await expect(fs.access(path.dirname(orphanCodexPath))).rejects.toThrow();
+
+      // Keep skill should still exist
+      const keepClaudePath = path.join(tempDir, '.claude', 'skills', 'keep-skill', 'SKILL.md');
+      const keepCodexPath = path.join(tempDir, '.agents', 'skills', 'keep-skill', 'SKILL.md');
+      await expect(fs.access(keepClaudePath)).resolves.toBeUndefined();
+      await expect(fs.access(keepCodexPath)).resolves.toBeUndefined();
+    });
+
+    it('should include platform in clean results JSON', async () => {
+      // Create a skill
+      kspecFull(
+        'skill add --id clean-test --name "Clean" --description "Test" --platform claude-code',
+        tempDir
+      );
+
+      const skillMdPath = path.join(tempDir, 'skills', 'clean-test', 'SKILL.md');
+      await fs.writeFile(skillMdPath, '# Clean\n', 'utf-8');
+      kspecFull('skill render', tempDir);
+
+      // Create orphan
+      const orphanPath = path.join(tempDir, '.claude', 'skills', 'orphan-clean', 'SKILL.md');
+      await fs.mkdir(path.dirname(orphanPath), { recursive: true });
+      await fs.writeFile(orphanPath, '---\nname: orphan\ndescription: orphan\n---\n<!-- kspec-managed -->\n# Orphan\n', 'utf-8');
+
+      const result = kspecJson<{
+        cleaned: { id: string; platform?: string; action: string }[];
+      }>('skill render --clean --json', tempDir);
+
+      const orphanClean = result.cleaned.find((c) => c.id === 'orphan-clean');
+      expect(orphanClean).toBeDefined();
+      expect(orphanClean?.platform).toBe('claude-code');
+      expect(orphanClean?.action).toBe('removed');
+    });
+  });
+
+  // AC: @multi-platform-render-cli ac-6
+  describe('ac-6: Render table includes Platform column', () => {
+    it('should show platform in table output', async () => {
+      kspecFull(
+        'skill add --id table-test --name "Table Test" --description "Test" --platform claude-code --platform codex',
+        tempDir
+      );
+
+      const skillMdPath = path.join(tempDir, 'skills', 'table-test', 'SKILL.md');
+      await fs.writeFile(skillMdPath, '# Table Test\n', 'utf-8');
+
+      const output = kspec('skill render', tempDir);
+
+      // Output should show platform in brackets
+      expect(output).toContain('[claude-code]');
+      expect(output).toContain('[codex]');
+    });
+
+    it('should include platform in JSON output', async () => {
+      kspecFull(
+        'skill add --id json-plat --name "JSON Platform" --description "Test" --platform claude-code --platform codex',
+        tempDir
+      );
+
+      const skillMdPath = path.join(tempDir, 'skills', 'json-plat', 'SKILL.md');
+      await fs.writeFile(skillMdPath, '# JSON Platform\n', 'utf-8');
+
+      const result = kspecJson<{
+        rendered: { id: string; platform: string }[];
+      }>('skill render --json', tempDir);
+
+      for (const r of result.rendered) {
+        expect(r.platform).toBeDefined();
+        expect(['claude-code', 'codex']).toContain(r.platform);
+      }
+    });
+  });
+
+  // AC: @multi-platform-render-cli ac-7
+  describe('ac-7: Unregistered platform shows warning', () => {
+    it('should warn for unregistered platform and skip it', async () => {
+      kspecFull(
+        'skill add --id unreg-plat --name "Unreg Platform" --description "Test" --platform claude-code --platform unknown-platform',
+        tempDir
+      );
+
+      const skillMdPath = path.join(tempDir, 'skills', 'unreg-plat', 'SKILL.md');
+      await fs.writeFile(skillMdPath, '# Unreg Platform\n', 'utf-8');
+
+      const output = kspec('skill render', tempDir);
+
+      // Should show warning
+      expect(output.toLowerCase()).toContain('unregistered');
+      expect(output).toContain('unknown-platform');
+    });
+
+    it('should include warning in JSON output', async () => {
+      kspecFull(
+        'skill add --id json-unreg --name "JSON Unreg" --description "Test" --platform claude-code --platform fake-plat',
+        tempDir
+      );
+
+      const skillMdPath = path.join(tempDir, 'skills', 'json-unreg', 'SKILL.md');
+      await fs.writeFile(skillMdPath, '# JSON Unreg\n', 'utf-8');
+
+      const result = kspecJson<{
+        warnings: string[];
+        rendered: { id: string; platform: string; action: string; skipReason?: string }[];
+      }>('skill render --json', tempDir);
+
+      expect(result.warnings).toBeDefined();
+      expect(result.warnings.some((w) => w.includes('fake-plat'))).toBe(true);
+
+      // Should have skipped result for the unregistered platform
+      const skippedResult = result.rendered.find(
+        (r) => r.id === 'json-unreg' && r.platform === 'fake-plat'
+      );
+      expect(skippedResult).toBeDefined();
+      expect(skippedResult?.action).toBe('skipped');
+      expect(skippedResult?.skipReason).toContain('unregistered');
+    });
+
+    it('should still render to valid platforms when one is unregistered', async () => {
+      kspecFull(
+        'skill add --id partial-valid --name "Partial Valid" --description "Test" --platform claude-code --platform bad-platform',
+        tempDir
+      );
+
+      const skillMdPath = path.join(tempDir, 'skills', 'partial-valid', 'SKILL.md');
+      await fs.writeFile(skillMdPath, '# Partial Valid\n', 'utf-8');
+
+      kspecFull('skill render', tempDir);
+
+      // Claude-code should be rendered
+      const claudeCodePath = path.join(tempDir, '.claude', 'skills', 'partial-valid', 'SKILL.md');
+      const content = await fs.readFile(claudeCodePath, 'utf-8');
+      expect(content).toContain('name: partial-valid');
+
+      // Bad platform should not create any output (no .bad-platform directory)
+      const badPath = path.join(tempDir, '.bad-platform');
+      await expect(fs.access(badPath)).rejects.toThrow();
+    });
+  });
+
+  // Additional edge cases
+  describe('Edge cases', () => {
+    it('should handle skill with empty platforms array gracefully', async () => {
+      // Create a skill, then manually set empty platforms (edge case)
+      kspecFull(
+        'skill add --id no-plat --name "No Platform" --description "Test" --platform claude-code',
+        tempDir
+      );
+
+      // Remove the platform
+      kspecFull('skill set @no-plat --remove-platform claude-code', tempDir);
+
+      const skillMdPath = path.join(tempDir, 'skills', 'no-plat', 'SKILL.md');
+      await fs.writeFile(skillMdPath, '# No Platform\n', 'utf-8');
+
+      // Should not error, just produce no render results for that skill
+      const result = kspecJson<{
+        rendered: { id: string }[];
+      }>('skill render --json', tempDir);
+
+      const noPlat = result.rendered.filter((r) => r.id === 'no-plat');
+      expect(noPlat.length).toBe(0);
+    });
+
+    it('should handle --dry-run with multiple platforms', async () => {
+      kspecFull(
+        'skill add --id dryrun-multi --name "DryRun Multi" --description "Test" --platform claude-code --platform codex',
+        tempDir
+      );
+
+      const skillMdPath = path.join(tempDir, 'skills', 'dryrun-multi', 'SKILL.md');
+      await fs.writeFile(skillMdPath, '# DryRun Multi\n', 'utf-8');
+
+      const result = kspecJson<{
+        dry_run: boolean;
+        rendered: { id: string; platform: string; action: string }[];
+      }>('skill render --dry-run --json', tempDir);
+
+      expect(result.dry_run).toBe(true);
+
+      // Should show created for both platforms
+      const claudeResult = result.rendered.find(
+        (r) => r.id === 'dryrun-multi' && r.platform === 'claude-code'
+      );
+      const codexResult = result.rendered.find(
+        (r) => r.id === 'dryrun-multi' && r.platform === 'codex'
+      );
+
+      expect(claudeResult?.action).toBe('created');
+      expect(codexResult?.action).toBe('created');
+
+      // Files should NOT exist
+      await expect(
+        fs.access(path.join(tempDir, '.claude', 'skills', 'dryrun-multi'))
+      ).rejects.toThrow();
+      await expect(
+        fs.access(path.join(tempDir, '.agents', 'skills', 'dryrun-multi'))
+      ).rejects.toThrow();
+    });
+
+    it('should handle --force with drifted skills on multiple platforms', async () => {
+      kspecFull(
+        'skill add --id force-multi --name "Force Multi" --description "Test" --platform claude-code --platform codex',
+        tempDir
+      );
+
+      const skillMdPath = path.join(tempDir, 'skills', 'force-multi', 'SKILL.md');
+      await fs.writeFile(skillMdPath, '# Force Multi\n', 'utf-8');
+
+      // Render first
+      kspecFull('skill render', tempDir);
+
+      // Modify rendered files to create drift
+      const claudePath = path.join(tempDir, '.claude', 'skills', 'force-multi', 'SKILL.md');
+      const codexPath = path.join(tempDir, '.agents', 'skills', 'force-multi', 'SKILL.md');
+
+      await fs.appendFile(claudePath, '\n# Manual edit\n');
+      await fs.appendFile(codexPath, '\n# Manual edit\n');
+
+      // Render without force - should skip
+      const resultNoForce = kspecJson<{
+        rendered: { id: string; platform: string; action: string }[];
+      }>('skill render --json', tempDir);
+
+      const claudeSkipped = resultNoForce.rendered.find(
+        (r) => r.id === 'force-multi' && r.platform === 'claude-code'
+      );
+      expect(claudeSkipped?.action).toBe('skipped');
+
+      // Render with force - should update
+      const resultForce = kspecJson<{
+        rendered: { id: string; platform: string; action: string }[];
+      }>('skill render --force --json', tempDir);
+
+      const claudeForced = resultForce.rendered.find(
+        (r) => r.id === 'force-multi' && r.platform === 'claude-code'
+      );
+      expect(claudeForced?.action).toBe('updated');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Updates `kspec skill render` to dispatch to multiple platform renderers based on each skill's `platforms` array
- Replaces hardcoded `platforms.includes("claude-code")` filter with loop over registered renderers
- Adds per-platform status, diff, and output directory configuration
- Adds `--output-dir` flag to override platform default output directory
- Updates `kspec skill status` to show per-platform rows with Platform column
- Per-platform `--clean` behavior removes orphans from each platform's output directory
- Shows warning for unregistered platforms and skips them

## Acceptance Criteria Coverage
- [x] AC-1: Skills with platforms [claude-code, codex] render to both platforms
- [x] AC-2: Skills with only codex platform render only to codex
- [x] AC-3: Status shows per skill-platform combination rows
- [x] AC-4: --output-dir overrides platform default
- [x] AC-5: --clean operates per-platform
- [x] AC-6: Platform column in render table output
- [x] AC-7: Unregistered platform warning and skip

## Test plan
- [x] 18 new tests in `tests/multi-platform-render-cli.test.ts`
- [x] All 74 existing skill-rendering tests pass
- [x] All 77 skill-cli tests pass
- [x] Full test suite passes (2706 tests)

Task: @implement-multi-platform-render-cli
Spec: @multi-platform-render-cli

🤖 Generated with [Claude Code](https://claude.ai/code)