### PR TITLE
feat: implement skill platform config CLI

### DIFF
--- a/src/cli/commands/skill.ts
+++ b/src/cli/commands/skill.ts
@@ -60,7 +60,13 @@ import {
   type PlatformRenderResult,
   type DriftStatus,
 } from "../../parser/skill-render.js";
-import { SkillSchema, type SkillOrigin } from "../../schema/index.js";
+import {
+  SkillSchema,
+  ClaudeCodeConfigSchema,
+  CodexConfigSchema,
+  type SkillOrigin,
+  type PlatformConfig,
+} from "../../schema/index.js";
 import { errors } from "../../strings/errors.js";
 import { EXIT_CODES } from "../exit-codes.js";
 import { error, output, success } from "../output.js";
@@ -397,6 +403,15 @@ export function registerSkillCommands(program: Command): void {
     .option("--remove-tag <tag>", "Remove a tag from the tags array")
     .option("--add-depends-on <ref>", "Add a dependency reference")
     .option("--remove-depends-on <ref>", "Remove a dependency reference")
+    .option(
+      "--platform-config <config>",
+      "Set platform config (format: platform.key=value, e.g., claude_code.user_invocable=false)",
+      (value: string, previous: string[]) => {
+        // Collect multiple --platform-config options
+        return previous.concat([value]);
+      },
+      [] as string[],
+    )
     .action(async (ref: string, options) => {
       try {
         const ctx = await initContext();
@@ -500,13 +515,78 @@ export function registerSkillCommands(program: Command): void {
           }
         }
 
+        // AC: @skill-platform-config-cli ac-1, ac-2 - Handle platform config updates
+        if (options.platformConfig && options.platformConfig.length > 0) {
+          // Initialize platform_config if not present
+          if (!skill.platform_config) {
+            skill.platform_config = {};
+          }
+
+          for (const configStr of options.platformConfig as string[]) {
+            // Parse "platform.key=value" format
+            const match = configStr.match(/^([^.]+)\.([^=]+)=(.*)$/);
+            if (!match) {
+              error(
+                `Invalid platform config format: ${configStr}\n` +
+                  `Expected format: platform.key=value (e.g., claude_code.user_invocable=false)`,
+              );
+              process.exit(EXIT_CODES.VALIDATION_FAILED);
+            }
+
+            const [, platform, key, rawValue] = match;
+
+            // Parse value type: "true"/"false" → boolean, otherwise string
+            let value: boolean | string;
+            if (rawValue === "true") {
+              value = true;
+            } else if (rawValue === "false") {
+              value = false;
+            } else {
+              // Remove surrounding quotes if present
+              value = rawValue.replace(/^["']|["']$/g, "");
+            }
+
+            // Deep merge: initialize platform object if needed
+            if (!(platform in skill.platform_config)) {
+              (skill.platform_config as Record<string, Record<string, unknown>>)[
+                platform
+              ] = {};
+            }
+
+            // Set the value
+            (
+              skill.platform_config as Record<string, Record<string, unknown>>
+            )[platform][key] = value;
+          }
+        }
+
         // Validate updated skill
+        // AC: @skill-platform-config-cli ac-4 - validation error with guidance on valid keys
         const parsed = SkillSchema.safeParse(skill);
         if (!parsed.success) {
           const issues = parsed.error.issues
             .map((i) => `${i.path.join(".")}: ${i.message}`)
             .join("; ");
-          error(`Invalid skill data: ${issues}`);
+
+          // Check if any errors are related to platform_config and provide guidance
+          const hasPlatformConfigError = parsed.error.issues.some(
+            (i) => i.path[0] === "platform_config",
+          );
+
+          let errorMsg = `Invalid skill data: ${issues}`;
+          if (hasPlatformConfigError) {
+            // Get valid keys from schemas
+            const claudeCodeKeys = Object.keys(ClaudeCodeConfigSchema.shape).join(
+              ", ",
+            );
+            const codexKeys = Object.keys(CodexConfigSchema.shape).join(", ");
+            errorMsg +=
+              `\n\nValid platform config keys:` +
+              `\n  claude_code: ${claudeCodeKeys}` +
+              `\n  codex: ${codexKeys}`;
+          }
+
+          error(errorMsg);
           process.exit(EXIT_CODES.VALIDATION_FAILED);
         }
 

--- a/tests/skill-cli.test.ts
+++ b/tests/skill-cli.test.ts
@@ -734,6 +734,194 @@ describe('Skill CLI - skill set', () => {
   });
 });
 
+describe('Skill CLI - skill set --platform-config', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await setupTempFixtures();
+    await initGitRepo(tempDir);
+
+    // Create a test skill
+    const result = kspecFull(
+      'skill add --id my-skill --name "My Skill" --description "Test skill"',
+      tempDir
+    );
+    if (result.exitCode !== 0) throw new Error(`skill add failed: ${result.stderr}`);
+  });
+
+  afterEach(async () => {
+    await cleanupTempDir(tempDir);
+  });
+
+  // AC: @skill-platform-config-cli ac-1
+  it('should set claude_code platform config', async () => {
+    kspec('skill set @my-skill --platform-config claude_code.user_invocable=false', tempDir);
+
+    const result = kspecJson<{ platform_config?: { claude_code?: { user_invocable?: boolean } } }>(
+      'skill get @my-skill',
+      tempDir
+    );
+
+    expect(result.platform_config).toBeDefined();
+    expect(result.platform_config?.claude_code).toBeDefined();
+    expect(result.platform_config?.claude_code?.user_invocable).toBe(false);
+  });
+
+  // AC: @skill-platform-config-cli ac-1 - true value
+  it('should set claude_code.user_invocable to true', async () => {
+    kspec('skill set @my-skill --platform-config claude_code.user_invocable=true', tempDir);
+
+    const result = kspecJson<{ platform_config?: { claude_code?: { user_invocable?: boolean } } }>(
+      'skill get @my-skill',
+      tempDir
+    );
+
+    expect(result.platform_config?.claude_code?.user_invocable).toBe(true);
+  });
+
+  // AC: @skill-platform-config-cli ac-2
+  it('should set codex platform config', async () => {
+    kspec('skill set @my-skill --platform-config codex.allow_implicit_invocation=true', tempDir);
+
+    const result = kspecJson<{ platform_config?: { codex?: { allow_implicit_invocation?: boolean } } }>(
+      'skill get @my-skill',
+      tempDir
+    );
+
+    expect(result.platform_config).toBeDefined();
+    expect(result.platform_config?.codex).toBeDefined();
+    expect(result.platform_config?.codex?.allow_implicit_invocation).toBe(true);
+  });
+
+  // AC: @skill-platform-config-cli ac-1, ac-2 - multiple platform configs
+  it('should set multiple platform configs at once', async () => {
+    kspec(
+      'skill set @my-skill --platform-config claude_code.disable_model_invocation=true --platform-config codex.allow_implicit_invocation=false',
+      tempDir
+    );
+
+    const result = kspecJson<{
+      platform_config?: {
+        claude_code?: { disable_model_invocation?: boolean };
+        codex?: { allow_implicit_invocation?: boolean };
+      };
+    }>('skill get @my-skill', tempDir);
+
+    expect(result.platform_config?.claude_code?.disable_model_invocation).toBe(true);
+    expect(result.platform_config?.codex?.allow_implicit_invocation).toBe(false);
+  });
+
+  // AC: @skill-platform-config-cli ac-1 - string values
+  it('should set string platform config values', async () => {
+    kspec('skill set @my-skill --platform-config claude_code.context=full', tempDir);
+
+    const result = kspecJson<{ platform_config?: { claude_code?: { context?: string } } }>(
+      'skill get @my-skill',
+      tempDir
+    );
+
+    expect(result.platform_config?.claude_code?.context).toBe('full');
+  });
+
+  // AC: @skill-platform-config-cli ac-2 - codex string values
+  it('should set codex display_name string value', async () => {
+    kspec('skill set @my-skill --platform-config codex.display_name="My Custom Name"', tempDir);
+
+    const result = kspecJson<{ platform_config?: { codex?: { display_name?: string } } }>(
+      'skill get @my-skill',
+      tempDir
+    );
+
+    expect(result.platform_config?.codex?.display_name).toBe('My Custom Name');
+  });
+
+  // AC: @skill-platform-config-cli ac-3
+  it('should include platform_config in JSON output', async () => {
+    kspec('skill set @my-skill --platform-config claude_code.user_invocable=false', tempDir);
+
+    const result = kspecJson<{ platform_config?: object }>('skill get @my-skill', tempDir);
+
+    expect(result.platform_config).toBeDefined();
+    expect(typeof result.platform_config).toBe('object');
+  });
+
+  // AC: @skill-platform-config-cli ac-4
+  it('should show validation error with guidance for invalid key', async () => {
+    const result = kspecFull(
+      'skill set @my-skill --platform-config claude_code.invalid_key=value',
+      tempDir,
+      { expectFail: true }
+    );
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain('invalid_key');
+    // Should include guidance on valid keys
+    expect(result.stderr).toContain('Valid platform config keys');
+    expect(result.stderr).toContain('claude_code');
+    expect(result.stderr).toContain('user_invocable');
+  });
+
+  // AC: @skill-platform-config-cli ac-4 - invalid codex key
+  it('should show validation error for invalid codex key', async () => {
+    const result = kspecFull(
+      'skill set @my-skill --platform-config codex.bad_key=true',
+      tempDir,
+      { expectFail: true }
+    );
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain('bad_key');
+    expect(result.stderr).toContain('Valid platform config keys');
+    expect(result.stderr).toContain('codex');
+    expect(result.stderr).toContain('allow_implicit_invocation');
+  });
+
+  it('should show error for invalid format (missing platform)', async () => {
+    const result = kspecFull(
+      'skill set @my-skill --platform-config user_invocable=false',
+      tempDir,
+      { expectFail: true }
+    );
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain('Invalid platform config format');
+    expect(result.stderr).toContain('platform.key=value');
+  });
+
+  it('should deep merge platform_config without replacing existing keys', async () => {
+    // Set first key
+    kspec('skill set @my-skill --platform-config claude_code.user_invocable=false', tempDir);
+
+    // Set second key (should not remove first)
+    kspec('skill set @my-skill --platform-config claude_code.context=full', tempDir);
+
+    const result = kspecJson<{
+      platform_config?: { claude_code?: { user_invocable?: boolean; context?: string } };
+    }>('skill get @my-skill', tempDir);
+
+    expect(result.platform_config?.claude_code?.user_invocable).toBe(false);
+    expect(result.platform_config?.claude_code?.context).toBe('full');
+  });
+
+  it('should preserve existing platform_config when setting new platform', async () => {
+    // Set claude_code config
+    kspec('skill set @my-skill --platform-config claude_code.user_invocable=false', tempDir);
+
+    // Set codex config (should not remove claude_code)
+    kspec('skill set @my-skill --platform-config codex.allow_implicit_invocation=true', tempDir);
+
+    const result = kspecJson<{
+      platform_config?: {
+        claude_code?: { user_invocable?: boolean };
+        codex?: { allow_implicit_invocation?: boolean };
+      };
+    }>('skill get @my-skill', tempDir);
+
+    expect(result.platform_config?.claude_code?.user_invocable).toBe(false);
+    expect(result.platform_config?.codex?.allow_implicit_invocation).toBe(true);
+  });
+});
+
 describe('Skill CLI - skill import', () => {
   let tempDir: string;
   let externalSkillDir: string;


### PR DESCRIPTION
## Summary

- Add `--platform-config` option to `kspec skill set` command for managing platform-specific configuration fields
- Format: `--platform-config platform.key=value` (e.g., `claude_code.user_invocable=false`)
- Parses `true`/`false` as booleans, otherwise string values
- Deep merges into existing `platform_config` without replacing other keys
- Multiple `--platform-config` options can be passed in single command
- Validation errors show guidance on valid keys per platform (from `ClaudeCodeConfigSchema` and `CodexConfigSchema`)

## Test plan

- [x] AC-1: `--platform-config claude_code.user_invocable=false` updates `platform_config.claude_code` in meta.yaml
- [x] AC-2: `--platform-config codex.allow_implicit_invocation=true` updates `platform_config.codex` in meta.yaml
- [x] AC-3: `platform_config` included in JSON output (already implemented, verified with test)
- [x] AC-4: Invalid keys show validation error with guidance on valid keys
- [x] All 89 skill-cli tests pass

Task: @implement-skill-platform-config-cli
Spec: @skill-platform-config-cli

🤖 Generated with [Claude Code](https://claude.ai/code)