### PR TITLE
feat: skill drift detection improvements

### DIFF
--- a/src/cli/commands/skill.ts
+++ b/src/cli/commands/skill.ts
@@ -1746,7 +1746,9 @@ export function registerSkillCommands(program: Command): void {
         const skillsToCheck = metaCtx.skills;
 
         if (skillsToCheck.length === 0) {
-          console.log(chalk.yellow("No skills found"));
+          output([], () => {
+            console.log(chalk.yellow("No skills found"));
+          });
           return;
         }
 

--- a/src/parser/skill-render.ts
+++ b/src/parser/skill-render.ts
@@ -962,6 +962,7 @@ export const codexRenderer: PlatformRenderer = {
     const sidecarContent = generateCodexSidecarYaml(skill);
     const sidecarDir = path.join(targetDir, "agents");
     const sidecarPath = path.join(sidecarDir, "openai.yaml");
+    let sidecarAction: "created" | "updated" | "unchanged" | "skipped" = "skipped";
 
     if (sidecarContent) {
       // Check existing sidecar
@@ -974,7 +975,7 @@ export const codexRenderer: PlatformRenderer = {
         // Doesn't exist
       }
 
-      const sidecarAction = !sidecarExists
+      sidecarAction = !sidecarExists
         ? "created"
         : contentsEqual(sidecarContent, existingSidecar)
           ? "unchanged"
@@ -991,7 +992,9 @@ export const codexRenderer: PlatformRenderer = {
     // AC: @platform-renderer-trait ac-6 - Store per-platform hash
     // AC: @codex-renderer ac-6 - Hash written to .render-hash-codex
     // AC: @skill-drift-detection-improvements ac-1 - Include sidecar content in drift hash
-    if (!dryRun && storeHash && action !== "unchanged") {
+    // Gate on SKILL.md action OR sidecar action to avoid stale hashes when only sidecar changes
+    const contentChanged = action !== "unchanged" || (sidecarAction !== "unchanged" && sidecarAction !== "skipped");
+    if (!dryRun && storeHash && contentChanged) {
       const combinedContent = sidecarContent
         ? renderedContent + "\n" + sidecarContent
         : renderedContent;

--- a/tests/skill-rendering.test.ts
+++ b/tests/skill-rendering.test.ts
@@ -1807,6 +1807,54 @@ describe('Codex Skill Renderer', () => {
       const driftStatus = await codexRenderer.checkDrift(specDir, tempDir, 'both-drift');
       expect(driftStatus).toBe('drifted');
     });
+
+    it('should stay in-sync after re-render when sidecar source config changes', async () => {
+      // Regression test: sidecar source change must update hash, not leave stale hash
+      kspecFull(
+        'skill add --id sidecar-rerender --name "Sidecar Rerender" --description "Test rerender" --platform codex',
+        tempDir
+      );
+
+      // Initial config
+      const metaPath = path.join(tempDir, 'kynetic.meta.yaml');
+      let metaContent = await fs.readFile(metaPath, 'utf-8');
+      metaContent = metaContent.replace(
+        /id: sidecar-rerender\n/,
+        `id: sidecar-rerender
+    platform_config:
+      codex:
+        display_name: "V1"
+`
+      );
+      await fs.writeFile(metaPath, metaContent, 'utf-8');
+
+      const skillMdPath = path.join(tempDir, 'skills', 'sidecar-rerender', 'SKILL.md');
+      await fs.writeFile(skillMdPath, '# Sidecar Rerender\n', 'utf-8');
+
+      const { codexRenderer, ctx } = await loadSkillForTest('sidecar-rerender');
+      const skill1 = (await import('../src/parser/meta')).loadMetaContext(ctx).then(m => m.skills.find(s => s.id === 'sidecar-rerender'));
+      await codexRenderer.render(ctx, tempDir, (await skill1)!, { storeHash: true });
+
+      // Verify in-sync after first render
+      const specDir = path.join(tempDir, 'skills', '..');
+      let driftStatus = await codexRenderer.checkDrift(specDir, tempDir, 'sidecar-rerender');
+      expect(driftStatus).toBe('in-sync');
+
+      // Change only sidecar source config (SKILL.md unchanged)
+      metaContent = await fs.readFile(metaPath, 'utf-8');
+      metaContent = metaContent.replace('display_name: "V1"', 'display_name: "V2"');
+      await fs.writeFile(metaPath, metaContent, 'utf-8');
+
+      // Re-render (should update sidecar and hash)
+      const { loadMetaContext: loadMeta } = await import('../src/parser/meta');
+      const meta2 = await loadMeta(ctx);
+      const skill2 = meta2.skills.find(s => s.id === 'sidecar-rerender');
+      await codexRenderer.render(ctx, tempDir, skill2!, { storeHash: true });
+
+      // Should still be in-sync (hash updated to match new sidecar content)
+      driftStatus = await codexRenderer.checkDrift(specDir, tempDir, 'sidecar-rerender');
+      expect(driftStatus).toBe('in-sync');
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- **AC-1**: Include codex sidecar YAML (`agents/openai.yaml`) content in drift hash computation, so manual edits to sidecar files are detected as drift
- **AC-2**: Add `kspec skill verify` command that checks all rendered skills against their source and reports drift with actionable guidance (e.g., `kspec skill render --force` to sync, `kspec skill diff` to review). Exits non-zero when drift detected.

## Test plan
- [x] 3 tests for sidecar drift hash (detects sidecar edit, stays in-sync when unchanged, still detects SKILL.md drift with sidecar)
- [x] 3 tests for verify command (reports drifted with guidance, reports OK when clean, exits non-zero on drift)
- [x] All 2780 existing tests pass
- [x] Manual testing of `kspec skill verify` against live project

Task: @task-skill-drift-detection-improvements
Spec: @skill-drift-detection-improvements

🤖 Generated with [Claude Code](https://claude.com/claude-code)