### PR TITLE
feat: generalize agent template sections for consumer projects

### DIFF
--- a/templates/agents-sections/01-quick-start.md
+++ b/templates/agents-sections/01-quick-start.md
@@ -1,14 +1,15 @@
 ## Quick Start
 
 ```bash
-# First time or any session — handles install, build, link, init if needed
-node scripts/bootstrap.cjs
+# First time setup
+kspec init            # Initialize kspec in the project
+kspec setup           # Configure agent environment
 
-# If already set up, just get session context
-kspec session start
+# Returning to work
+kspec session start   # Get session context
 ```
 
-Use `kspec` for all commands. Only use `npm run dev --` when testing uncommitted code changes.
+Verify shadow branch health with `kspec shadow status` if you encounter issues.
 
 ## Essential Rules
 

--- a/templates/agents-sections/05-commit-convention.md
+++ b/templates/agents-sections/05-commit-convention.md
@@ -11,11 +11,17 @@ Trailers enable `kspec log @ref` to find commits by task or spec.
 
 ## Code Annotations
 
-Link tests to acceptance criteria:
+Link tests to acceptance criteria using language-appropriate comment syntax:
 
-```typescript
+```javascript
 // AC: @spec-item ac-N
 it('should validate input', () => { ... });
+```
+
+```python
+# AC: @spec-item ac-N
+def test_validates_input():
+    ...
 ```
 
 Every AC SHOULD have at least one test with this annotation.

--- a/tests/agents-instruction-gen.test.ts
+++ b/tests/agents-instruction-gen.test.ts
@@ -476,10 +476,15 @@ describe('Agent Instruction Generation', () => {
         const filePath = path.join(tempDir, 'kspec-agents.md');
         const content = await fs.readFile(filePath, 'utf-8');
 
-        // Verify quick-start specific content
-        expect(content).toContain('node scripts/bootstrap.cjs');
+        // Verify quick-start specific content (generic, not kspec-repo-specific)
+        expect(content).toContain('kspec init');
+        expect(content).toContain('kspec setup');
         expect(content).toContain('kspec session start');
+        expect(content).toContain('kspec shadow status');
         expect(content).toContain('Essential Rules');
+        // Should NOT contain kspec-repo-specific commands
+        expect(content).not.toContain('bootstrap.cjs');
+        expect(content).not.toContain('npm run dev');
       });
 
       it('should include shadow-branch template content', async () => {
@@ -526,7 +531,9 @@ describe('Agent Instruction Generation', () => {
         // Verify commit-convention specific content
         expect(content).toContain('Task: @task-slug');
         expect(content).toContain('Spec: @spec-ref');
+        // Language-agnostic AC annotation examples (JavaScript and Python)
         expect(content).toContain('// AC: @spec-item ac-N');
+        expect(content).toContain('# AC: @spec-item ac-N');
       });
 
       it('should include ralph-loop template content', async () => {


### PR DESCRIPTION
## Summary
- **01-quick-start.md**: Replace kspec-repo-specific `bootstrap.cjs` with generic `kspec init && kspec setup` pattern; add `kspec shadow status` tip for troubleshooting
- **05-commit-convention.md**: Add Python example (`# AC:`) alongside JavaScript (`// AC:`) for language-agnostic AC annotations
- **Tests**: Updated to verify generic content and explicitly reject repo-specific commands (`bootstrap.cjs`, `npm run dev`)

## Test plan
- [x] All 35 agent-instruction-gen tests pass
- [x] Full test suite passes (2811 tests, 1 pre-existing failure unrelated to this change)
- [x] Verified generated output contains new generic commands via `kspec agents generate --dry-run`

Task: @01KHVK28

🤖 Generated with [Claude Code](https://claude.ai/code)