### PR TITLE
feat: add discriminant field for skill type guards

### DIFF
--- a/src/cli/commands/skill-crud.ts
+++ b/src/cli/commands/skill-crud.ts
@@ -24,6 +24,7 @@ import {
   findMetaItemByRef,
   getSkillContentPath,
   initContext,
+  isSkill,
   loadMetaContext,
   loadSkillContent,
   loadSkillDocs,
@@ -419,8 +420,8 @@ export function registerSkillCrudCommands(skill: Command): void {
           process.exit(EXIT_CODES.NOT_FOUND);
         }
 
-        // Check it's a skill
-        if (!("origin" in item)) {
+        // Check it's a skill (uses _type discriminant)
+        if (!isSkill(item)) {
           error(`Item ${ref} is not a skill`);
           process.exit(EXIT_CODES.ERROR);
         }
@@ -501,8 +502,8 @@ export function registerSkillCrudCommands(skill: Command): void {
           process.exit(EXIT_CODES.NOT_FOUND);
         }
 
-        // Check it's a skill
-        if (!("origin" in item)) {
+        // Check it's a skill (uses _type discriminant)
+        if (!isSkill(item)) {
           error(`Item ${ref} is not a skill`);
           process.exit(EXIT_CODES.ERROR);
         }
@@ -697,8 +698,8 @@ export function registerSkillCrudCommands(skill: Command): void {
           process.exit(EXIT_CODES.NOT_FOUND);
         }
 
-        // Check it's a skill
-        if (!("origin" in item)) {
+        // Check it's a skill (uses _type discriminant)
+        if (!isSkill(item)) {
           error(`Item ${ref} is not a skill`);
           process.exit(EXIT_CODES.ERROR);
         }

--- a/src/cli/commands/skill-diff.ts
+++ b/src/cli/commands/skill-diff.ts
@@ -17,6 +17,7 @@ import type { Command } from "commander";
 import {
   findMetaItemByRef,
   initContext,
+  isSkill,
   loadMetaContext,
   loadSkillContent,
   type LoadedSkill,
@@ -271,9 +272,9 @@ export function registerSkillDiffCommands(skill: Command): void {
         // Support both positional ref argument and --skill option
         const skillRef = ref || options.skill;
         if (skillRef) {
-          // Resolve the ref to a skill
+          // Resolve the ref to a skill (uses _type discriminant)
           const item = findMetaItemByRef(metaCtx, skillRef);
-          if (!item || !("origin" in item)) {
+          if (!item || !isSkill(item)) {
             error(`Skill not found: ${skillRef}`);
             console.log(chalk.gray("Try: kspec skill list"));
             process.exit(EXIT_CODES.NOT_FOUND);
@@ -688,8 +689,8 @@ export function registerSkillDiffCommands(skill: Command): void {
           process.exit(EXIT_CODES.NOT_FOUND);
         }
 
-        // Check it's a skill
-        if (!("origin" in item)) {
+        // Check it's a skill (uses _type discriminant)
+        if (!isSkill(item)) {
           error(`Item ${ref} is not a skill`);
           process.exit(EXIT_CODES.ERROR);
         }

--- a/src/parser/meta.ts
+++ b/src/parser/meta.ts
@@ -17,6 +17,7 @@ import {
   type Convention,
   ConventionSchema,
   getMetaItemType,
+  isSkill,
   type MetaItem,
   type MetaManifest,
   MetaManifestSchema,
@@ -714,8 +715,8 @@ export async function listSkillSupportingDirs(
   return dirs;
 }
 
-// Re-export the getMetaItemType function
-export { getMetaItemType };
+// Re-export the getMetaItemType and isSkill functions
+export { getMetaItemType, isSkill };
 export type { Agent, Workflow, Convention, Observation, Skill, MetaItem };
 
 // ============================================================

--- a/src/parser/validate.ts
+++ b/src/parser/validate.ts
@@ -9,6 +9,7 @@ import * as path from "node:path";
 import {
   AgentSchema,
   ConventionSchema,
+  isSkill,
   ManifestSchema,
   MetaManifestSchema,
   ObservationSchema,
@@ -1382,9 +1383,8 @@ function validateSkillDependsOn(
           message: `Skill '${skill.id}' depends_on reference '${depRef}' cannot be resolved`,
         });
       } else {
-        // Check that the resolved item is actually a skill (has origin field)
-        const resolvedItem = result.item as { origin?: string };
-        if (!("origin" in resolvedItem)) {
+        // Check that the resolved item is actually a skill (uses _type discriminant)
+        if (!isSkill(result.item)) {
           warnings.push({
             ref: depRef,
             sourceFile: skill._sourceFile,

--- a/src/schema/meta.ts
+++ b/src/schema/meta.ts
@@ -211,6 +211,7 @@ const KEBAB_CASE_REGEX = /^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/;
  */
 export const SkillSchema = z.object({
   _ulid: MetaUlidSchema,
+  _type: z.literal("skill").default("skill"),
   id: z
     .string({ required_error: "Skill ID is required" })
     .regex(
@@ -358,13 +359,26 @@ export type WorkflowRunsFile = z.infer<typeof WorkflowRunsFileSchema>;
 export type MetaItem = Agent | Workflow | Convention | Observation | Skill;
 
 /**
+ * Type guard for skill items
+ * Uses _type discriminant field for reliable discrimination
+ */
+export function isSkill(item: MetaItem | unknown): item is Skill {
+  return (
+    typeof item === "object" &&
+    item !== null &&
+    "_type" in item &&
+    (item as { _type: unknown })._type === "skill"
+  );
+}
+
+/**
  * Determine the type of a meta item
- * AC: @skill-meta-type ac-7 - skills discriminated by the origin field (unique to skills)
+ * AC: @skill-meta-type ac-7 - skills discriminated by _type field
  */
 export function getMetaItemType(
   item: MetaItem,
 ): "agent" | "workflow" | "convention" | "observation" | "skill" {
-  if ("origin" in item) return "skill";
+  if (isSkill(item)) return "skill";
   if ("capabilities" in item) return "agent";
   if ("trigger" in item) return "workflow";
   if ("domain" in item) return "convention";

--- a/tests/skill-meta-type.test.ts
+++ b/tests/skill-meta-type.test.ts
@@ -13,7 +13,7 @@ import {
   findMetaItemByRef,
   getSkillContentPath,
 } from '../src/parser/meta';
-import { getMetaItemType, MetaManifestSchema, SkillSchema } from '../src/schema/meta';
+import { getMetaItemType, isSkill, MetaManifestSchema, SkillSchema } from '../src/schema/meta';
 import type { KspecContext } from '../src/parser/yaml';
 
 describe('Skill Meta Type', () => {
@@ -379,6 +379,7 @@ Some usage instructions.
     it('should return skill for item with origin field', () => {
       const skill = {
         _ulid: testUlid('SKTYPE'),
+        _type: 'skill' as const,
         id: 'test-skill',
         name: 'Test Skill',
         origin: 'core' as const,
@@ -423,6 +424,7 @@ Some usage instructions.
 
       const skill = {
         _ulid: testUlid('SKTYPE'),
+        _type: 'skill' as const,
         id: 'test-skill',
         name: 'Test Skill',
         origin: 'core' as const,
@@ -434,6 +436,106 @@ Some usage instructions.
       expect(getMetaItemType(convention)).toBe('convention');
       expect(getMetaItemType(observation)).toBe('observation');
       expect(getMetaItemType(skill)).toBe('skill');
+    });
+  });
+
+  describe('isSkill type guard', () => {
+    // AC: @skill-type-guard ac-1 - isSkill returns true for skill items
+    it('should return true for items with _type: skill', () => {
+      const skill = {
+        _ulid: testUlid('SKGARD'),
+        _type: 'skill' as const,
+        id: 'test-skill',
+        name: 'Test Skill',
+        origin: 'core' as const,
+        tags: [],
+      };
+
+      expect(isSkill(skill)).toBe(true);
+    });
+
+    // AC: @skill-type-guard ac-2 - isSkill returns false for non-skill items
+    it('should return false for items without _type: skill', () => {
+      const agent = {
+        _ulid: testUlid('AGSKIP'),
+        id: 'test-agent',
+        name: 'Test Agent',
+        capabilities: [],
+        tools: [],
+        conventions: [],
+      };
+
+      const workflow = {
+        _ulid: testUlid('WFSKIP'),
+        id: 'test-workflow',
+        trigger: 'on command',
+        steps: [],
+      };
+
+      const convention = {
+        _ulid: testUlid('CVSKIP'),
+        domain: 'test-convention',
+        rules: [],
+        examples: [],
+      };
+
+      const observation = {
+        _ulid: testUlid('OBSKIP'),
+        type: 'friction' as const,
+        content: 'Test observation',
+        created_at: new Date().toISOString(),
+        resolved: false,
+      };
+
+      expect(isSkill(agent)).toBe(false);
+      expect(isSkill(workflow)).toBe(false);
+      expect(isSkill(convention)).toBe(false);
+      expect(isSkill(observation)).toBe(false);
+    });
+
+    // AC: @skill-type-guard ac-3 - isSkill handles edge cases safely
+    it('should handle edge cases safely', () => {
+      expect(isSkill(null)).toBe(false);
+      expect(isSkill(undefined)).toBe(false);
+      expect(isSkill('string')).toBe(false);
+      expect(isSkill(123)).toBe(false);
+      expect(isSkill({})).toBe(false);
+      expect(isSkill({ _type: 'agent' })).toBe(false);
+      expect(isSkill({ _type: 'observation' })).toBe(false);
+    });
+
+    // AC: @skill-type-guard ac-4 - isSkill works with parsed schema data
+    it('should work with SkillSchema.parse() output', () => {
+      const skillData = {
+        _ulid: testUlid('SKSHEM'),
+        id: 'schema-test',
+        name: 'Schema Test Skill',
+        origin: 'project' as const,
+      };
+
+      const parsed = SkillSchema.parse(skillData);
+      expect(isSkill(parsed)).toBe(true);
+      expect(parsed._type).toBe('skill');
+    });
+
+    // AC: @skill-type-guard ac-5 - backward compatibility with origin field
+    it('should correctly identify skill items that have origin but were parsed through schema', () => {
+      // Items without _type but with origin need to be parsed through schema to get _type
+      const rawSkillData = {
+        _ulid: testUlid('SKBACK'),
+        id: 'backward-compat',
+        name: 'Backward Compatible Skill',
+        origin: 'local' as const,
+        // No _type field - simulating old YAML file
+      };
+
+      // Before parsing, isSkill returns false (no _type)
+      expect(isSkill(rawSkillData)).toBe(false);
+
+      // After parsing through schema, isSkill returns true
+      const parsed = SkillSchema.parse(rawSkillData);
+      expect(isSkill(parsed)).toBe(true);
+      expect(parsed._type).toBe('skill');
     });
   });
 });


### PR DESCRIPTION
## Summary
- Add `_type: "skill"` discriminant field to SkillSchema for reliable type discrimination
- Create `isSkill()` type guard function that uses `_type` instead of checking for `origin` field
- Update `getMetaItemType()` to use the new `isSkill()` helper
- Update 6 call sites across validate.ts, skill-diff.ts (2), and skill-crud.ts (3) to use `isSkill()`
- Backward compatibility preserved via `.default("skill")` - existing YAML without `_type` gets it added during parse

## Why
The previous approach of checking `"origin" in item` to identify skills was fragile. If any other meta type (agent, workflow, convention, observation) ever added an `origin` field, it would cause silent misclassification. The `_type` discriminant is explicit and won't conflict.

## Test plan
- [x] All 2814 existing tests pass
- [x] Updated 2 existing tests in skill-meta-type.test.ts to include `_type` field
- [x] Added 5 new tests for `isSkill()` type guard including edge cases (null, undefined, wrong _type)
- [x] Verified backward compatibility: skills without `_type` in YAML get it added via schema default

Task: @01KHTAMT

🤖 Generated with [Claude Code](https://claude.ai/code)