### PR TITLE
feat: implement project config file (kspec.config.yaml)

### DIFF
--- a/src/cli/batch-exec.ts
+++ b/src/cli/batch-exec.ts
@@ -603,6 +603,9 @@ async function executeAtomic(
   // Set up atomic context
   const savedChalkLevel = chalk.level;
   const savedSpecDir = process.env.KSPEC_SPEC_DIR;
+  const savedBatchProjectRoot = process.env.KSPEC_BATCH_PROJECT_ROOT;
+  // AC: @project-config ac-7 — set real project root before redirecting spec dir
+  process.env.KSPEC_BATCH_PROJECT_ROOT = ctx.rootDir;
   process.env.KSPEC_SPEC_DIR = tempDir;
   setBatchMode(true);
   chalk.level = 0;
@@ -680,6 +683,12 @@ async function executeAtomic(
       process.env.KSPEC_SPEC_DIR = savedSpecDir;
     } else {
       delete process.env.KSPEC_SPEC_DIR;
+    }
+    // AC: @project-config ac-7 — restore batch project root env var
+    if (savedBatchProjectRoot !== undefined) {
+      process.env.KSPEC_BATCH_PROJECT_ROOT = savedBatchProjectRoot;
+    } else {
+      delete process.env.KSPEC_BATCH_PROJECT_ROOT;
     }
     // Only remove temp dir if copy-back succeeded (or commands failed)
     if (!copyBackFailed) {

--- a/src/parser/config.ts
+++ b/src/parser/config.ts
@@ -1,0 +1,320 @@
+/**
+ * Project-level configuration for kspec.
+ *
+ * Loads kspec.config.yaml from the project root (main branch) before shadow
+ * branch detection. All fields are optional with backward-compatible defaults.
+ *
+ * Priority: env vars > config file > defaults
+ *
+ * @module
+ */
+
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { z } from "zod";
+import * as YAML from "yaml";
+import { getGitRoot } from "./shadow.js";
+
+// ── Schema ──────────────────────────────────────────────────────────────
+
+/**
+ * Schema for shadow branch configuration.
+ */
+const ShadowConfigSchema = z
+  .object({
+    /** Remote URL for shadow branch (enables separate repo for specs) */
+    remote_url: z.string().optional(),
+    /** Branch name for shadow branch (default: kspec-meta) */
+    branch: z.string().optional(),
+  })
+  .strict()
+  .optional();
+
+/**
+ * Schema for identity configuration.
+ */
+const IdentityConfigSchema = z
+  .object({
+    /** Default author for notes/tasks (overridden by KSPEC_AUTHOR env var) */
+    author: z.string().optional(),
+  })
+  .strict()
+  .optional();
+
+/**
+ * Schema for validation configuration.
+ */
+const ValidationConfigSchema = z
+  .object({
+    /** Validation strictness level */
+    strictness: z.enum(["strict", "normal", "relaxed"]).optional(),
+    /** Whether to warn on unknown fields */
+    warn_unknown_fields: z.boolean().optional(),
+  })
+  .strict()
+  .optional();
+
+/**
+ * Schema for daemon configuration.
+ */
+const DaemonConfigSchema = z
+  .object({
+    /** Default port for daemon (default: 3456) */
+    port: z.number().int().min(1).max(65535).optional(),
+    /** Host to bind to (default: localhost) */
+    host: z.string().optional(),
+  })
+  .strict()
+  .optional();
+
+/**
+ * Complete schema for kspec.config.yaml.
+ *
+ * AC: @project-config ac-4 — unknown fields are ignored via passthrough
+ */
+export const KspecConfigSchema = z
+  .object({
+    /** Shadow branch configuration */
+    shadow: ShadowConfigSchema,
+    /** Identity configuration */
+    identity: IdentityConfigSchema,
+    /** Validation configuration */
+    validation: ValidationConfigSchema,
+    /** Daemon configuration */
+    daemon: DaemonConfigSchema,
+  })
+  .passthrough(); // AC: ac-4 — ignore unknown fields
+
+/**
+ * Raw config type as parsed from YAML file.
+ */
+export type KspecConfig = z.infer<typeof KspecConfigSchema>;
+
+/**
+ * Resolved config with all values finalized (env vars applied, defaults filled).
+ */
+export interface ResolvedKspecConfig {
+  shadow: {
+    remote_url: string | null;
+    branch: string;
+  };
+  identity: {
+    author: string | null;
+  };
+  validation: {
+    strictness: "strict" | "normal" | "relaxed";
+    warn_unknown_fields: boolean;
+  };
+  daemon: {
+    port: number;
+    host: string;
+  };
+}
+
+// ── Defaults ────────────────────────────────────────────────────────────
+
+/**
+ * Default configuration values.
+ *
+ * AC: @project-config ac-1 — these are the current defaults
+ */
+const DEFAULT_CONFIG: ResolvedKspecConfig = {
+  shadow: {
+    remote_url: null,
+    branch: "kspec-meta",
+  },
+  identity: {
+    author: null,
+  },
+  validation: {
+    strictness: "normal",
+    warn_unknown_fields: true,
+  },
+  daemon: {
+    port: 3456,
+    host: "localhost",
+  },
+};
+
+// ── Loading ─────────────────────────────────────────────────────────────
+
+const CONFIG_FILENAME = "kspec.config.yaml";
+
+/**
+ * Result of loading project config.
+ */
+export interface LoadConfigResult {
+  /** Resolved configuration with all values finalized */
+  config: ResolvedKspecConfig;
+  /** Path to config file if found, null otherwise */
+  configPath: string | null;
+  /** Warning message if config had issues but was recoverable */
+  warning: string | null;
+  /** The git root directory where config was loaded from */
+  gitRoot: string | null;
+}
+
+/**
+ * Find git root directory, handling KSPEC_SPEC_DIR batch mode.
+ *
+ * AC: @project-config ac-7 — in batch mode, we need the REAL project root
+ *
+ * When KSPEC_SPEC_DIR is set (batch atomic mode), the cwd might be the temp
+ * directory. We need to find the real project root by checking:
+ * 1. If KSPEC_BATCH_PROJECT_ROOT is set, use that (set by batch executor)
+ * 2. Otherwise, use git root from cwd
+ *
+ * AC: @project-config ac-6 — loads from git root, not cwd subdirectory
+ */
+export function findProjectRoot(startDir: string): string | null {
+  // In batch mode, the batch executor should set this to the real root
+  // before redirecting KSPEC_SPEC_DIR
+  const batchRoot = process.env.KSPEC_BATCH_PROJECT_ROOT;
+  if (batchRoot) {
+    return batchRoot;
+  }
+
+  // Normal mode: find git root
+  return getGitRoot(startDir);
+}
+
+/**
+ * Load project configuration from kspec.config.yaml.
+ *
+ * AC: @project-config ac-1 — no config = all defaults
+ * AC: @project-config ac-2 — config parsed and available before shadow detection
+ * AC: @project-config ac-3 — invalid YAML = defaults + warning
+ * AC: @project-config ac-4 — unknown fields ignored
+ * AC: @project-config ac-5 — env vars take precedence
+ * AC: @project-config ac-6 — loads from git root
+ * AC: @project-config ac-7 — batch mode uses real project root
+ *
+ * @param startDir Starting directory for git root detection
+ */
+export async function loadProjectConfig(
+  startDir: string = process.cwd(),
+): Promise<LoadConfigResult> {
+  const gitRoot = findProjectRoot(startDir);
+
+  if (!gitRoot) {
+    // Not in a git repo, use defaults
+    return {
+      config: resolveConfig(null),
+      configPath: null,
+      warning: null,
+      gitRoot: null,
+    };
+  }
+
+  const configPath = path.join(gitRoot, CONFIG_FILENAME);
+
+  // Check if config file exists
+  try {
+    await fs.access(configPath);
+  } catch {
+    // AC: ac-1 — no config file, use defaults
+    return {
+      config: resolveConfig(null),
+      configPath: null,
+      warning: null,
+      gitRoot,
+    };
+  }
+
+  // Try to load and parse config
+  try {
+    const content = await fs.readFile(configPath, "utf-8");
+    const raw = YAML.parse(content);
+
+    // Validate against schema
+    const result = KspecConfigSchema.safeParse(raw);
+
+    if (!result.success) {
+      // AC: ac-3 — validation error = defaults + warning
+      const issues = result.error.issues
+        .map((i) => `${i.path.join(".")}: ${i.message}`)
+        .join("; ");
+      return {
+        config: resolveConfig(null),
+        configPath,
+        warning: `Config validation failed: ${issues}. Using defaults.`,
+        gitRoot,
+      };
+    }
+
+    // AC: ac-5 — apply env var overrides during resolution
+    return {
+      config: resolveConfig(result.data),
+      configPath,
+      warning: null,
+      gitRoot,
+    };
+  } catch (err) {
+    // AC: ac-3 — parse error = defaults + warning
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      config: resolveConfig(null),
+      configPath,
+      warning: `Failed to parse ${CONFIG_FILENAME}: ${message}. Using defaults.`,
+      gitRoot,
+    };
+  }
+}
+
+/**
+ * Resolve configuration by merging file config with env vars and defaults.
+ *
+ * Priority: env vars > config file > defaults
+ *
+ * AC: @project-config ac-5 — env vars take precedence
+ */
+export function resolveConfig(fileConfig: KspecConfig | null): ResolvedKspecConfig {
+  const file = fileConfig || {};
+
+  // Get env var overrides
+  const envAuthor = process.env.KSPEC_AUTHOR;
+  const envPort = process.env.KSPEC_DAEMON_PORT
+    ? parseInt(process.env.KSPEC_DAEMON_PORT, 10)
+    : undefined;
+  const envHost = process.env.KSPEC_DAEMON_HOST;
+
+  return {
+    shadow: {
+      remote_url: file.shadow?.remote_url ?? DEFAULT_CONFIG.shadow.remote_url,
+      branch: file.shadow?.branch ?? DEFAULT_CONFIG.shadow.branch,
+    },
+    identity: {
+      // AC: ac-5 — env var takes precedence
+      author: envAuthor ?? file.identity?.author ?? DEFAULT_CONFIG.identity.author,
+    },
+    validation: {
+      strictness:
+        file.validation?.strictness ?? DEFAULT_CONFIG.validation.strictness,
+      warn_unknown_fields:
+        file.validation?.warn_unknown_fields ??
+        DEFAULT_CONFIG.validation.warn_unknown_fields,
+    },
+    daemon: {
+      // AC: ac-5 — env vars take precedence
+      port:
+        (envPort && !isNaN(envPort) ? envPort : undefined) ??
+        file.daemon?.port ??
+        DEFAULT_CONFIG.daemon.port,
+      host: envHost ?? file.daemon?.host ?? DEFAULT_CONFIG.daemon.host,
+    },
+  };
+}
+
+/**
+ * Get the default configuration (no file, no env vars).
+ * Useful for testing or when config loading fails completely.
+ * Returns a deep copy to prevent mutation of shared defaults.
+ */
+export function getDefaultConfig(): ResolvedKspecConfig {
+  return {
+    shadow: { ...DEFAULT_CONFIG.shadow },
+    identity: { ...DEFAULT_CONFIG.identity },
+    validation: { ...DEFAULT_CONFIG.validation },
+    daemon: { ...DEFAULT_CONFIG.daemon },
+  };
+}

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -2,6 +2,7 @@
 
 export * from "./agent-data-sections.js";
 export * from "./alignment.js";
+export * from "./config.js";
 export * from "./assess.js";
 export * from "./convention-validation.js";
 export * from "./coverage-cache.js";

--- a/src/parser/yaml.ts
+++ b/src/parser/yaml.ts
@@ -30,6 +30,10 @@ import {
   type ShadowConfig,
   ShadowError,
 } from "./shadow.js";
+import {
+  loadProjectConfig,
+  type ResolvedKspecConfig,
+} from "./config.js";
 import { TraitIndex } from "./traits.js";
 
 /**
@@ -211,18 +215,41 @@ export interface KspecContext {
   manifest: Manifest | null;
   /** Shadow branch configuration (null if not using shadow) */
   shadow: ShadowConfig | null;
+  /**
+   * Project configuration from kspec.config.yaml.
+   * Loaded before shadow detection. Always present (defaults if no config file).
+   *
+   * AC: @project-config ac-2 — config available on KspecContext.config
+   */
+  config: ResolvedKspecConfig;
 }
 
 /**
  * Initialize context by finding manifest.
  *
  * Detection order:
- * 1. Check for shadow branch (.kspec/ directory)
- * 2. Fall back to traditional spec/ directory
+ * 1. Load project config from git root (before shadow detection)
+ * 2. Check for shadow branch (.kspec/ directory)
+ * 3. Fall back to traditional spec/ directory
  *
  * When shadow is detected, all operations use .kspec/ as specDir.
+ *
+ * AC: @project-config ac-2 — config loaded before shadow detection
  */
 export async function initContext(startDir?: string): Promise<KspecContext> {
+  const cwd = startDir || process.cwd();
+
+  // AC: @project-config ac-2, ac-6, ac-7 — load config before shadow detection
+  // Config is loaded from git root, not cwd or KSPEC_SPEC_DIR temp dir
+  const configResult = await loadProjectConfig(cwd);
+
+  // AC: @project-config ac-3 — emit warning to stderr if config had issues
+  if (configResult.warning) {
+    console.error(`Warning: ${configResult.warning}`);
+  }
+
+  const { config } = configResult;
+
   // KSPEC_SPEC_DIR override: used by batch atomic mode to redirect to temp copy
   const specDirOverride = process.env.KSPEC_SPEC_DIR;
   if (specDirOverride) {
@@ -245,10 +272,9 @@ export async function initContext(startDir?: string): Promise<KspecContext> {
       manifestPath,
       manifest,
       shadow: null, // No shadow in overridden context
+      config,
     };
   }
-
-  const cwd = startDir || process.cwd();
 
   // Check if running from inside the shadow worktree
   const mainProjectRoot = await detectRunningFromShadowWorktree(cwd);
@@ -284,6 +310,7 @@ export async function initContext(startDir?: string): Promise<KspecContext> {
       manifestPath,
       manifest,
       shadow,
+      config,
     };
   }
 
@@ -313,7 +340,7 @@ export async function initContext(startDir?: string): Promise<KspecContext> {
     }
   }
 
-  return { rootDir, specDir, manifestPath, manifest, shadow: null };
+  return { rootDir, specDir, manifestPath, manifest, shadow: null, config };
 }
 
 /**

--- a/tests/parser/config.test.ts
+++ b/tests/parser/config.test.ts
@@ -1,0 +1,415 @@
+/**
+ * Tests for project configuration loading (kspec.config.yaml)
+ *
+ * AC coverage:
+ * - @project-config ac-1: no config = defaults
+ * - @project-config ac-2: config available on KspecContext.config
+ * - @project-config ac-3: invalid YAML = defaults + warning
+ * - @project-config ac-4: unknown fields ignored
+ * - @project-config ac-5: env vars take precedence
+ * - @project-config ac-6: loads from git root, not cwd
+ * - @project-config ac-7: batch mode uses real project root
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import {
+  loadProjectConfig,
+  resolveConfig,
+  getDefaultConfig,
+  KspecConfigSchema,
+  type ResolvedKspecConfig,
+} from "../../src/parser/config.js";
+import { initContext } from "../../src/parser/yaml.js";
+import { createTempDir, cleanupTempDir, initGitRepo } from "../helpers/cli.js";
+
+describe("Project Config", () => {
+  let tempDir: string;
+  let originalEnv: NodeJS.ProcessEnv;
+
+  beforeEach(async () => {
+    tempDir = await createTempDir("kspec-config-test-");
+    initGitRepo(tempDir);
+    originalEnv = { ...process.env };
+    // Clean env vars that might affect tests
+    delete process.env.KSPEC_AUTHOR;
+    delete process.env.KSPEC_DAEMON_PORT;
+    delete process.env.KSPEC_DAEMON_HOST;
+    delete process.env.KSPEC_BATCH_PROJECT_ROOT;
+  });
+
+  afterEach(async () => {
+    await cleanupTempDir(tempDir);
+    // Restore env
+    process.env = originalEnv;
+  });
+
+  describe("loadProjectConfig", () => {
+    // AC: @project-config ac-1
+    it("returns defaults when no config file exists", async () => {
+      const result = await loadProjectConfig(tempDir);
+
+      expect(result.configPath).toBeNull();
+      expect(result.warning).toBeNull();
+      expect(result.gitRoot).toBe(tempDir);
+      expect(result.config).toEqual(getDefaultConfig());
+    });
+
+    // AC: @project-config ac-1
+    it("returns defaults with no behavior change when no config exists", async () => {
+      const result = await loadProjectConfig(tempDir);
+      const defaults = getDefaultConfig();
+
+      expect(result.config.shadow.branch).toBe(defaults.shadow.branch);
+      expect(result.config.shadow.remote_url).toBe(defaults.shadow.remote_url);
+      expect(result.config.daemon.port).toBe(defaults.daemon.port);
+      expect(result.config.daemon.host).toBe(defaults.daemon.host);
+      expect(result.config.validation.strictness).toBe(
+        defaults.validation.strictness
+      );
+    });
+
+    // AC: @project-config ac-2 (partial - config file parsing)
+    it("parses valid config file", async () => {
+      await fs.writeFile(
+        path.join(tempDir, "kspec.config.yaml"),
+        `
+shadow:
+  branch: custom-branch
+  remote_url: https://example.com/specs.git
+daemon:
+  port: 4000
+  host: 0.0.0.0
+identity:
+  author: "@custom-author"
+validation:
+  strictness: strict
+  warn_unknown_fields: false
+`
+      );
+
+      const result = await loadProjectConfig(tempDir);
+
+      expect(result.configPath).toBe(path.join(tempDir, "kspec.config.yaml"));
+      expect(result.warning).toBeNull();
+      expect(result.config.shadow.branch).toBe("custom-branch");
+      expect(result.config.shadow.remote_url).toBe(
+        "https://example.com/specs.git"
+      );
+      expect(result.config.daemon.port).toBe(4000);
+      expect(result.config.daemon.host).toBe("0.0.0.0");
+      expect(result.config.identity.author).toBe("@custom-author");
+      expect(result.config.validation.strictness).toBe("strict");
+      expect(result.config.validation.warn_unknown_fields).toBe(false);
+    });
+
+    // AC: @project-config ac-3
+    it("falls back to defaults and warns on invalid YAML syntax", async () => {
+      await fs.writeFile(
+        path.join(tempDir, "kspec.config.yaml"),
+        `
+shadow:
+  branch: [invalid yaml
+  this is broken:
+`
+      );
+
+      const result = await loadProjectConfig(tempDir);
+
+      expect(result.configPath).toBe(path.join(tempDir, "kspec.config.yaml"));
+      expect(result.warning).toContain("Failed to parse kspec.config.yaml");
+      expect(result.config).toEqual(getDefaultConfig());
+    });
+
+    // AC: @project-config ac-3
+    it("falls back to defaults and warns on validation errors", async () => {
+      await fs.writeFile(
+        path.join(tempDir, "kspec.config.yaml"),
+        `
+daemon:
+  port: "not-a-number"
+`
+      );
+
+      const result = await loadProjectConfig(tempDir);
+
+      expect(result.warning).toContain("Config validation failed");
+      expect(result.config).toEqual(getDefaultConfig());
+    });
+
+    // AC: @project-config ac-4
+    it("ignores unknown fields and applies valid fields", async () => {
+      await fs.writeFile(
+        path.join(tempDir, "kspec.config.yaml"),
+        `
+daemon:
+  port: 5000
+unknown_top_level_field: "should be ignored"
+another_unknown:
+  nested: value
+`
+      );
+
+      const result = await loadProjectConfig(tempDir);
+
+      expect(result.warning).toBeNull();
+      expect(result.config.daemon.port).toBe(5000);
+      // Defaults should still be applied for unspecified fields
+      expect(result.config.shadow.branch).toBe("kspec-meta");
+    });
+
+    // AC: @project-config ac-5
+    it("env vars take precedence over config file values", async () => {
+      await fs.writeFile(
+        path.join(tempDir, "kspec.config.yaml"),
+        `
+identity:
+  author: "@config-author"
+daemon:
+  port: 5000
+  host: from-config.local
+`
+      );
+
+      process.env.KSPEC_AUTHOR = "@env-author";
+      process.env.KSPEC_DAEMON_PORT = "6000";
+      process.env.KSPEC_DAEMON_HOST = "env-host.local";
+
+      const result = await loadProjectConfig(tempDir);
+
+      expect(result.config.identity.author).toBe("@env-author");
+      expect(result.config.daemon.port).toBe(6000);
+      expect(result.config.daemon.host).toBe("env-host.local");
+    });
+
+    // AC: @project-config ac-5
+    it("env vars apply even when no config file exists", async () => {
+      process.env.KSPEC_AUTHOR = "@env-only";
+      process.env.KSPEC_DAEMON_PORT = "7000";
+
+      const result = await loadProjectConfig(tempDir);
+
+      expect(result.config.identity.author).toBe("@env-only");
+      expect(result.config.daemon.port).toBe(7000);
+    });
+
+    // AC: @project-config ac-6
+    it("loads config from git root, not subdirectory", async () => {
+      // Create config in git root
+      await fs.writeFile(
+        path.join(tempDir, "kspec.config.yaml"),
+        `
+daemon:
+  port: 8000
+`
+      );
+
+      // Create subdirectory
+      const subDir = path.join(tempDir, "src", "deep", "nested");
+      await fs.mkdir(subDir, { recursive: true });
+
+      const result = await loadProjectConfig(subDir);
+
+      expect(result.gitRoot).toBe(tempDir);
+      expect(result.config.daemon.port).toBe(8000);
+    });
+
+    // AC: @project-config ac-7
+    it("uses KSPEC_BATCH_PROJECT_ROOT when set (batch mode)", async () => {
+      // Create config in the "real" project root
+      await fs.writeFile(
+        path.join(tempDir, "kspec.config.yaml"),
+        `
+daemon:
+  port: 9000
+`
+      );
+
+      // Create a separate temp dir to simulate batch mode
+      const batchTempDir = await createTempDir("kspec-batch-");
+
+      try {
+        // Simulate batch mode by setting the env var
+        process.env.KSPEC_BATCH_PROJECT_ROOT = tempDir;
+
+        // Load config from the batch temp dir - should still find config from real root
+        const result = await loadProjectConfig(batchTempDir);
+
+        expect(result.config.daemon.port).toBe(9000);
+      } finally {
+        await cleanupTempDir(batchTempDir);
+      }
+    });
+  });
+
+  describe("resolveConfig", () => {
+    it("returns defaults for null input", () => {
+      const config = resolveConfig(null);
+      expect(config).toEqual(getDefaultConfig());
+    });
+
+    it("merges partial config with defaults", () => {
+      const config = resolveConfig({
+        daemon: { port: 4567 },
+      });
+
+      expect(config.daemon.port).toBe(4567);
+      expect(config.daemon.host).toBe("localhost"); // default
+      expect(config.shadow.branch).toBe("kspec-meta"); // default
+    });
+
+    it("applies env var overrides", () => {
+      process.env.KSPEC_AUTHOR = "@test-author";
+
+      const config = resolveConfig({
+        identity: { author: "@file-author" },
+      });
+
+      expect(config.identity.author).toBe("@test-author");
+    });
+
+    it("handles invalid KSPEC_DAEMON_PORT gracefully", () => {
+      process.env.KSPEC_DAEMON_PORT = "not-a-number";
+
+      const config = resolveConfig({
+        daemon: { port: 4000 },
+      });
+
+      // Should fall back to file value since env is invalid
+      expect(config.daemon.port).toBe(4000);
+    });
+  });
+
+  describe("KspecConfigSchema", () => {
+    it("validates correct config", () => {
+      const result = KspecConfigSchema.safeParse({
+        shadow: {
+          branch: "my-branch",
+          remote_url: "https://github.com/org/repo.git",
+        },
+        daemon: {
+          port: 3000,
+          host: "localhost",
+        },
+        identity: {
+          author: "@me",
+        },
+        validation: {
+          strictness: "strict",
+          warn_unknown_fields: true,
+        },
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    it("allows partial config", () => {
+      const result = KspecConfigSchema.safeParse({
+        daemon: { port: 4000 },
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    it("allows empty config", () => {
+      const result = KspecConfigSchema.safeParse({});
+      expect(result.success).toBe(true);
+    });
+
+    // AC: @project-config ac-4
+    it("allows unknown top-level fields (passthrough)", () => {
+      const result = KspecConfigSchema.safeParse({
+        daemon: { port: 4000 },
+        custom_field: "value",
+        another: { nested: true },
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    it("rejects invalid port", () => {
+      const result = KspecConfigSchema.safeParse({
+        daemon: { port: 70000 }, // above 65535
+      });
+
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects invalid strictness value", () => {
+      const result = KspecConfigSchema.safeParse({
+        validation: { strictness: "invalid" },
+      });
+
+      expect(result.success).toBe(false);
+    });
+  });
+
+  // AC: @project-config ac-2 - full integration test
+  describe("initContext integration", () => {
+    it("includes config on KspecContext", async () => {
+      // Create a minimal kspec setup
+      await fs.mkdir(path.join(tempDir, "spec"), { recursive: true });
+      await fs.writeFile(
+        path.join(tempDir, "spec", "kynetic.yaml"),
+        `
+kynetic: "1.0"
+title: Test Project
+`
+      );
+      await fs.writeFile(
+        path.join(tempDir, "kspec.config.yaml"),
+        `
+daemon:
+  port: 5555
+`
+      );
+
+      const ctx = await initContext(tempDir);
+
+      expect(ctx.config).toBeDefined();
+      expect(ctx.config.daemon.port).toBe(5555);
+      expect(ctx.config.shadow.branch).toBe("kspec-meta"); // default
+    });
+
+    it("has config available even when no config file exists", async () => {
+      // Create a minimal kspec setup without config file
+      await fs.mkdir(path.join(tempDir, "spec"), { recursive: true });
+      await fs.writeFile(
+        path.join(tempDir, "spec", "kynetic.yaml"),
+        `
+kynetic: "1.0"
+title: Test Project
+`
+      );
+
+      const ctx = await initContext(tempDir);
+
+      expect(ctx.config).toBeDefined();
+      expect(ctx.config).toEqual(getDefaultConfig());
+    });
+  });
+
+  describe("getDefaultConfig", () => {
+    it("returns consistent defaults", () => {
+      const defaults = getDefaultConfig();
+
+      expect(defaults.shadow.branch).toBe("kspec-meta");
+      expect(defaults.shadow.remote_url).toBeNull();
+      expect(defaults.identity.author).toBeNull();
+      expect(defaults.validation.strictness).toBe("normal");
+      expect(defaults.validation.warn_unknown_fields).toBe(true);
+      expect(defaults.daemon.port).toBe(3456);
+      expect(defaults.daemon.host).toBe("localhost");
+    });
+
+    it("returns independent objects", () => {
+      const defaults1 = getDefaultConfig();
+      const defaults2 = getDefaultConfig();
+
+      defaults1.daemon.port = 9999;
+
+      expect(defaults2.daemon.port).toBe(3456); // Should not be affected
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add project-level configuration support with `kspec.config.yaml` in project root
- Config is loaded before shadow branch detection and available on `KspecContext.config`
- Supports shadow branch settings (remote_url, branch name), identity settings (default author), validation settings (strictness), and daemon settings (port, host)
- All fields optional with backward-compatible defaults
- Env vars (`KSPEC_AUTHOR`, `KSPEC_DAEMON_PORT`, `KSPEC_DAEMON_HOST`) take precedence over file values
- Invalid YAML falls back to defaults with warning to stderr

## Test Plan

- [x] 24 new tests in `tests/parser/config.test.ts` covering all 7 acceptance criteria
- [x] AC-1: No config = defaults (2 tests)
- [x] AC-2: Config available on KspecContext.config (2 tests)
- [x] AC-3: Invalid YAML = defaults + warning (2 tests)
- [x] AC-4: Unknown fields ignored (2 tests)
- [x] AC-5: Env vars take precedence (3 tests)
- [x] AC-6: Loads from git root, not cwd (1 test)
- [x] AC-7: Batch mode uses real project root (1 test)
- [x] All 2848 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)