### PR TITLE
feat: implement configurable validation defaults

### DIFF
--- a/src/cli/commands/validate.ts
+++ b/src/cli/commands/validate.ts
@@ -827,11 +827,21 @@ export function registerValidateCommand(program: Command): void {
           !options.completeness &&
           !options.conventions &&
           !options.skills;
+
+        // AC: @config-validation ac-4 — CLI --strict overrides config strict_refs
+        // If --strict is passed, use strict behavior regardless of config
+        // Otherwise, use config value (which defaults to false)
+        const strictRefs = options.strict ? true : ctx.config.validation.strict_refs;
+        const requireAcceptance = ctx.config.validation.require_acceptance;
+
         const validateOptions = {
           schema: runAll || options.schema,
           refs: runAll || options.refs,
           orphans: runAll || options.orphans,
           completeness: runAll || options.completeness,
+          // AC: @config-validation ac-2 ac-3 ac-4 — wire config into validation
+          strictRefs,
+          requireAcceptance,
         };
 
         const result = await validate(ctx, validateOptions);
@@ -1027,11 +1037,18 @@ export function registerValidateCommand(program: Command): void {
           !options.refs &&
           !options.orphans &&
           !options.completeness;
+
+        // AC: @config-validation ac-4 — CLI --strict overrides config strict_refs
+        const strictRefs = options.strict ? true : ctx.config.validation.strict_refs;
+        const requireAcceptance = ctx.config.validation.require_acceptance;
+
         const validateOptions = {
           schema: runAll || options.schema,
           refs: runAll || options.refs,
           orphans: runAll || options.orphans,
           completeness: runAll || options.completeness,
+          strictRefs,
+          requireAcceptance,
         };
 
         const result = await validate(ctx, validateOptions);

--- a/src/parser/config.ts
+++ b/src/parser/config.ts
@@ -52,13 +52,21 @@ const IdentityConfigSchema = z
 
 /**
  * Schema for validation configuration.
+ *
+ * AC: @config-validation — validation settings configurable in kspec.config.yaml
  */
 const ValidationConfigSchema = z
   .object({
-    /** Validation strictness level */
-    strictness: z.enum(["strict", "normal", "relaxed"]).optional(),
-    /** Whether to warn on unknown fields */
-    warn_unknown_fields: z.boolean().optional(),
+    /**
+     * When true, dangling references are treated as errors instead of warnings.
+     * AC: @config-validation ac-2 ac-3 — strict_refs configurable
+     */
+    strict_refs: z.boolean().optional(),
+    /**
+     * When true, specs missing acceptance criteria are reported as errors not warnings.
+     * AC: @config-validation ac-1 — require_acceptance configurable
+     */
+    require_acceptance: z.boolean().optional(),
   })
   .strict()
   .optional();
@@ -154,8 +162,16 @@ export interface ResolvedKspecConfig {
     author: string | null;
   };
   validation: {
-    strictness: "strict" | "normal" | "relaxed";
-    warn_unknown_fields: boolean;
+    /**
+     * When true, dangling references are treated as errors instead of warnings.
+     * AC: @config-validation ac-2 ac-3
+     */
+    strict_refs: boolean;
+    /**
+     * When true, specs missing acceptance criteria are reported as errors not warnings.
+     * AC: @config-validation ac-1
+     */
+    require_acceptance: boolean;
   };
   daemon: {
     port: number;
@@ -180,8 +196,11 @@ const DEFAULT_CONFIG: ResolvedKspecConfig = {
     author: null,
   },
   validation: {
-    strictness: "normal",
-    warn_unknown_fields: true,
+    // AC: @config-validation — defaults preserve existing behavior
+    // strict_refs: true = dangling refs are errors (existing behavior)
+    // require_acceptance: false = missing AC is warning (existing behavior)
+    strict_refs: true,
+    require_acceptance: false,
   },
   daemon: {
     port: 3456,
@@ -348,11 +367,12 @@ export function resolveConfig(fileConfig: KspecConfig | null): ResolvedKspecConf
       author: envAuthor ?? file.identity?.author ?? DEFAULT_CONFIG.identity.author,
     },
     validation: {
-      strictness:
-        file.validation?.strictness ?? DEFAULT_CONFIG.validation.strictness,
-      warn_unknown_fields:
-        file.validation?.warn_unknown_fields ??
-        DEFAULT_CONFIG.validation.warn_unknown_fields,
+      // AC: @config-validation ac-2 ac-3 — strict_refs from config
+      strict_refs:
+        file.validation?.strict_refs ?? DEFAULT_CONFIG.validation.strict_refs,
+      // AC: @config-validation ac-1 — require_acceptance from config
+      require_acceptance:
+        file.validation?.require_acceptance ?? DEFAULT_CONFIG.validation.require_acceptance,
     },
     daemon: {
       // AC: ac-5 — env vars take precedence
@@ -378,7 +398,10 @@ export function getDefaultConfig(): ResolvedKspecConfig {
       remote: DEFAULT_CONFIG.shadow.remote,
     },
     identity: { ...DEFAULT_CONFIG.identity },
-    validation: { ...DEFAULT_CONFIG.validation },
+    validation: {
+      strict_refs: DEFAULT_CONFIG.validation.strict_refs,
+      require_acceptance: DEFAULT_CONFIG.validation.require_acceptance,
+    },
     daemon: { ...DEFAULT_CONFIG.daemon },
   };
 }

--- a/src/parser/validate.ts
+++ b/src/parser/validate.ts
@@ -131,6 +131,16 @@ export interface ValidateOptions {
   orphans?: boolean;
   /** Check spec completeness (missing AC, descriptions, status inconsistencies) */
   completeness?: boolean;
+  /**
+   * When true, dangling references are treated as errors instead of warnings.
+   * AC: @config-validation ac-2 ac-3 ac-4
+   */
+  strictRefs?: boolean;
+  /**
+   * When true, missing acceptance criteria are treated as errors instead of warnings.
+   * AC: @config-validation ac-1
+   */
+  requireAcceptance?: boolean;
 }
 
 // ============================================================
@@ -1583,8 +1593,31 @@ export async function validate(
       allPlans,
     );
     const refResult = validateRefs(index, allTasks, allItems);
-    result.refErrors = refResult.errors;
-    result.refWarnings = refResult.warnings;
+
+    // AC: @config-validation ac-2 ac-3 — strict_refs controls error vs warning
+    // When strictRefs is false, demote "not_found" ref errors to warnings
+    if (options.strictRefs === false) {
+      // Move not_found errors to warnings
+      const notFoundErrors = refResult.errors.filter((e) => e.error === "not_found");
+      const otherErrors = refResult.errors.filter((e) => e.error !== "not_found");
+
+      result.refErrors = otherErrors;
+      result.refWarnings = [
+        ...refResult.warnings,
+        ...notFoundErrors.map((e) => ({
+          ref: e.ref,
+          sourceFile: e.sourceFile,
+          sourceUlid: e.sourceUlid,
+          field: e.field,
+          warning: "deprecated_target" as const, // Reuse existing warning type
+          message: e.message,
+        })),
+      ];
+    } else {
+      // Default/strict behavior: not_found refs are errors
+      result.refErrors = refResult.errors;
+      result.refWarnings = refResult.warnings;
+    }
 
     // AC: @skill-validation ac-2 - validate skill depends_on references
     const skillDependsOnWarnings = validateSkillDependsOn(metaCtx.skills, index);
@@ -1605,7 +1638,7 @@ export async function validate(
     if (runCompleteness) {
       // Build trait index for trait AC coverage validation
       const traitIndex = new TraitIndex(allItems, index);
-      result.completenessWarnings = await checkCompleteness(
+      const completenessWarnings = await checkCompleteness(
         allItems,
         index,
         ctx.rootDir,
@@ -1615,7 +1648,30 @@ export async function validate(
       // AC: @task-automation-eligibility ac-21, ac-23
       // Check automation eligibility warnings for tasks
       const automationWarnings = checkAutomationEligibility(allTasks, index);
-      result.completenessWarnings.push(...automationWarnings);
+      completenessWarnings.push(...automationWarnings);
+
+      // AC: @config-validation ac-1 — require_acceptance promotes missing AC to errors
+      if (options.requireAcceptance) {
+        const missingAC = completenessWarnings.filter(
+          (w) => w.type === "missing_acceptance_criteria",
+        );
+        const otherWarnings = completenessWarnings.filter(
+          (w) => w.type !== "missing_acceptance_criteria",
+        );
+
+        // Promote missing AC warnings to schema errors
+        for (const w of missingAC) {
+          result.schemaErrors.push({
+            file: "completeness",
+            path: w.itemRef,
+            message: w.message,
+          });
+        }
+
+        result.completenessWarnings = otherWarnings;
+      } else {
+        result.completenessWarnings = completenessWarnings;
+      }
     }
   }
 

--- a/tests/parser/config.test.ts
+++ b/tests/parser/config.test.ts
@@ -69,12 +69,17 @@ describe("Project Config", () => {
       expect(result.config.shadow.remote).toBe(defaults.shadow.remote);
       expect(result.config.daemon.port).toBe(defaults.daemon.port);
       expect(result.config.daemon.host).toBe(defaults.daemon.host);
-      expect(result.config.validation.strictness).toBe(
-        defaults.validation.strictness
+      // AC: @config-validation — validation defaults
+      expect(result.config.validation.strict_refs).toBe(
+        defaults.validation.strict_refs
+      );
+      expect(result.config.validation.require_acceptance).toBe(
+        defaults.validation.require_acceptance
       );
     });
 
     // AC: @project-config ac-2 (partial - config file parsing)
+    // AC: @config-validation ac-1 ac-2 — validation config fields
     it("parses valid config file", async () => {
       await fs.writeFile(
         path.join(tempDir, "kspec.config.yaml"),
@@ -89,8 +94,8 @@ daemon:
 identity:
   author: "@custom-author"
 validation:
-  strictness: strict
-  warn_unknown_fields: false
+  strict_refs: true
+  require_acceptance: true
 `
       );
 
@@ -107,8 +112,9 @@ validation:
       expect(result.config.daemon.port).toBe(4000);
       expect(result.config.daemon.host).toBe("0.0.0.0");
       expect(result.config.identity.author).toBe("@custom-author");
-      expect(result.config.validation.strictness).toBe("strict");
-      expect(result.config.validation.warn_unknown_fields).toBe(false);
+      // AC: @config-validation ac-1 ac-2
+      expect(result.config.validation.strict_refs).toBe(true);
+      expect(result.config.validation.require_acceptance).toBe(true);
     });
 
     // AC: @project-config ac-3
@@ -304,8 +310,8 @@ daemon:
           author: "@me",
         },
         validation: {
-          strictness: "strict",
-          warn_unknown_fields: true,
+          strict_refs: true,
+          require_acceptance: true,
         },
       });
 
@@ -344,9 +350,10 @@ daemon:
       expect(result.success).toBe(false);
     });
 
-    it("rejects invalid strictness value", () => {
+    // AC: @config-validation ac-1 ac-2 — validation fields are boolean
+    it("rejects non-boolean validation fields", () => {
       const result = KspecConfigSchema.safeParse({
-        validation: { strictness: "invalid" },
+        validation: { strict_refs: "invalid" },
       });
 
       expect(result.success).toBe(false);
@@ -406,8 +413,11 @@ title: Test Project
       expect(defaults.shadow.directory).toBe(".kspec");
       expect(defaults.shadow.remote).toBeNull();
       expect(defaults.identity.author).toBeNull();
-      expect(defaults.validation.strictness).toBe("normal");
-      expect(defaults.validation.warn_unknown_fields).toBe(true);
+      // AC: @config-validation — defaults preserve existing behavior
+      // strict_refs: true = dangling refs are errors (existing behavior)
+      // require_acceptance: false = missing AC is warning (existing behavior)
+      expect(defaults.validation.strict_refs).toBe(true);
+      expect(defaults.validation.require_acceptance).toBe(false);
       expect(defaults.daemon.port).toBe(3456);
       expect(defaults.daemon.host).toBe("localhost");
     });
@@ -526,6 +536,63 @@ identity:
       const author = getAuthor("project-bot");
 
       expect(author).toBe("project-bot");
+    });
+  });
+
+  // AC: @config-validation — validation config fields
+  describe("validation config", () => {
+    // AC: @config-validation ac-1 — require_acceptance config
+    it("loads require_acceptance from config", async () => {
+      await fs.writeFile(
+        path.join(tempDir, "kspec.config.yaml"),
+        `
+validation:
+  require_acceptance: true
+`
+      );
+
+      const result = await loadProjectConfig(tempDir);
+
+      expect(result.config.validation.require_acceptance).toBe(true);
+    });
+
+    // AC: @config-validation ac-2 — strict_refs config
+    it("loads strict_refs from config", async () => {
+      await fs.writeFile(
+        path.join(tempDir, "kspec.config.yaml"),
+        `
+validation:
+  strict_refs: true
+`
+      );
+
+      const result = await loadProjectConfig(tempDir);
+
+      expect(result.config.validation.strict_refs).toBe(true);
+    });
+
+    // AC: @config-validation — strict_refs defaults to true (preserve existing behavior)
+    it("defaults strict_refs to true", async () => {
+      const result = await loadProjectConfig(tempDir);
+
+      expect(result.config.validation.strict_refs).toBe(true);
+    });
+
+    // Both can be set independently
+    it("allows independent setting of strict_refs and require_acceptance", async () => {
+      await fs.writeFile(
+        path.join(tempDir, "kspec.config.yaml"),
+        `
+validation:
+  strict_refs: false
+  require_acceptance: true
+`
+      );
+
+      const result = await loadProjectConfig(tempDir);
+
+      expect(result.config.validation.strict_refs).toBe(false);
+      expect(result.config.validation.require_acceptance).toBe(true);
     });
   });
 });

--- a/tests/parser/validate-config.test.ts
+++ b/tests/parser/validate-config.test.ts
@@ -1,0 +1,332 @@
+/**
+ * Tests for configurable validation defaults.
+ *
+ * AC: @config-validation
+ *
+ * Tests that validation behavior can be configured via kspec.config.yaml:
+ * - ac-1: require_acceptance promotes missing AC to errors
+ * - ac-2: strict_refs treats dangling refs as errors
+ * - ac-3: strict_refs: false treats dangling refs as warnings
+ * - ac-4: CLI --strict overrides config strict_refs: false
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { validate } from "../../src/parser/validate.js";
+import { initContext, type KspecContext } from "../../src/parser/yaml.js";
+import { createTempDir, cleanupTempDir, initGitRepo, testUlid } from "../helpers/cli.js";
+
+describe("Configurable Validation Defaults", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await createTempDir("validate-config-test-");
+    initGitRepo(tempDir);
+  });
+
+  afterEach(async () => {
+    await cleanupTempDir(tempDir);
+  });
+
+  async function setupMinimalProject(): Promise<KspecContext> {
+    // Create manifest - use spec/ directory (non-shadow mode for testing)
+    const specDir = path.join(tempDir, "spec");
+    await fs.mkdir(specDir, { recursive: true });
+    await fs.mkdir(path.join(specDir, "modules"), { recursive: true });
+
+    await fs.writeFile(
+      path.join(specDir, "kynetic.yaml"),
+      `
+kynetic: "1.0"
+title: Test Project
+project:
+  name: test
+includes:
+  - modules/core.yaml
+`
+    );
+
+    // Create a spec file with an item that has no acceptance criteria
+    const specUlid = testUlid("NOAC01");
+    await fs.writeFile(
+      path.join(specDir, "modules", "core.yaml"),
+      `
+_ulid: ${specUlid}
+title: Feature Without AC
+type: feature
+slugs:
+  - feature-no-ac
+description: This feature has no acceptance criteria
+`
+    );
+
+    // Create tasks file
+    await fs.writeFile(
+      path.join(specDir, "project.tasks.yaml"),
+      `
+tasks: []
+`
+    );
+
+    return await initContext(tempDir);
+  }
+
+  async function setupProjectWithDanglingRef(): Promise<KspecContext> {
+    // Create manifest - use spec/ directory (non-shadow mode for testing)
+    const specDir = path.join(tempDir, "spec");
+    await fs.mkdir(specDir, { recursive: true });
+    await fs.mkdir(path.join(specDir, "modules"), { recursive: true });
+
+    await fs.writeFile(
+      path.join(specDir, "kynetic.yaml"),
+      `
+kynetic: "1.0"
+title: Test Project
+project:
+  name: test
+includes:
+  - modules/core.yaml
+`
+    );
+
+    // Create a spec file
+    const specUlid = testUlid("SPEC01");
+    await fs.writeFile(
+      path.join(specDir, "modules", "core.yaml"),
+      `
+_ulid: ${specUlid}
+title: Some Feature
+type: feature
+slugs:
+  - some-feature
+description: A feature
+acceptance_criteria:
+  - id: ac-1
+    given: something
+    when: something happens
+    then: result
+`
+    );
+
+    // Create tasks file with dangling ref
+    const taskUlid = testUlid("TASK01");
+    await fs.writeFile(
+      path.join(specDir, "project.tasks.yaml"),
+      `
+tasks:
+  - _ulid: ${taskUlid}
+    title: Task with bad ref
+    status: pending
+    spec_ref: "@nonexistent-spec"
+    priority: 3
+`
+    );
+
+    return await initContext(tempDir);
+  }
+
+  // AC: @config-validation ac-1 — require_acceptance promotes missing AC to errors
+  describe("require_acceptance", () => {
+    it("treats missing AC as warning when require_acceptance is false", async () => {
+      const ctx = await setupMinimalProject();
+
+      const result = await validate(ctx, {
+        schema: true,
+        refs: true,
+        completeness: true,
+        requireAcceptance: false,
+      });
+
+      // Should have warning, not error
+      expect(result.completenessWarnings.some(
+        w => w.type === "missing_acceptance_criteria"
+      )).toBe(true);
+      // Schema errors should not include the AC warning
+      expect(result.schemaErrors.some(
+        e => e.message.includes("no acceptance criteria")
+      )).toBe(false);
+      // Validation should still pass (warnings don't fail)
+      expect(result.valid).toBe(true);
+    });
+
+    it("treats missing AC as error when require_acceptance is true", async () => {
+      const ctx = await setupMinimalProject();
+
+      const result = await validate(ctx, {
+        schema: true,
+        refs: true,
+        completeness: true,
+        requireAcceptance: true,
+      });
+
+      // Warning should be promoted to error
+      expect(result.completenessWarnings.some(
+        w => w.type === "missing_acceptance_criteria"
+      )).toBe(false);
+      expect(result.schemaErrors.some(
+        e => e.message.includes("no acceptance criteria")
+      )).toBe(true);
+      // Validation should fail
+      expect(result.valid).toBe(false);
+    });
+  });
+
+  // AC: @config-validation ac-2 — strict_refs treats dangling refs as errors
+  describe("strict_refs: true", () => {
+    it("treats dangling refs as errors when strict_refs is true", async () => {
+      const ctx = await setupProjectWithDanglingRef();
+
+      const result = await validate(ctx, {
+        schema: true,
+        refs: true,
+        completeness: true,
+        strictRefs: true,
+      });
+
+      // Should be an error
+      expect(result.refErrors.some(
+        e => e.ref === "@nonexistent-spec"
+      )).toBe(true);
+      // Should not be a warning
+      expect(result.refWarnings.some(
+        w => w.ref === "@nonexistent-spec"
+      )).toBe(false);
+      // Validation should fail
+      expect(result.valid).toBe(false);
+    });
+  });
+
+  // AC: @config-validation ac-3 — strict_refs: false treats dangling refs as warnings
+  describe("strict_refs: false", () => {
+    it("treats dangling refs as warnings when strict_refs is false", async () => {
+      const ctx = await setupProjectWithDanglingRef();
+
+      const result = await validate(ctx, {
+        schema: true,
+        refs: true,
+        completeness: true,
+        strictRefs: false,
+      });
+
+      // Should be a warning, not an error
+      expect(result.refWarnings.some(
+        w => w.ref === "@nonexistent-spec"
+      )).toBe(true);
+      // Should not be in errors
+      expect(result.refErrors.some(
+        e => e.ref === "@nonexistent-spec"
+      )).toBe(false);
+      // Validation should still pass (dangling refs are just warnings)
+      expect(result.valid).toBe(true);
+    });
+  });
+
+  // AC: @config-validation ac-4 — CLI --strict overrides config strict_refs: false
+  describe("CLI --strict override", () => {
+    it("default strictRefs behavior is strict (errors)", async () => {
+      const ctx = await setupProjectWithDanglingRef();
+
+      // Not passing strictRefs explicitly = undefined = default strict behavior
+      const result = await validate(ctx, {
+        schema: true,
+        refs: true,
+        completeness: true,
+        // strictRefs not specified - should default to strict
+      });
+
+      // Should be an error (default is strict)
+      expect(result.refErrors.some(
+        e => e.ref === "@nonexistent-spec"
+      )).toBe(true);
+      expect(result.valid).toBe(false);
+    });
+
+    it("strictRefs: true always treats dangling refs as errors", async () => {
+      // This simulates CLI --strict overriding config strict_refs: false
+      const ctx = await setupProjectWithDanglingRef();
+
+      const result = await validate(ctx, {
+        schema: true,
+        refs: true,
+        completeness: true,
+        strictRefs: true, // Explicit true (as if --strict was passed)
+      });
+
+      expect(result.refErrors.some(
+        e => e.ref === "@nonexistent-spec"
+      )).toBe(true);
+      expect(result.valid).toBe(false);
+    });
+  });
+
+  // Combined scenarios
+  describe("combined settings", () => {
+    it("both strict_refs: false and require_acceptance: true work together", async () => {
+      // Setup a project that has both issues - use spec/ directory (non-shadow)
+      const specDir = path.join(tempDir, "spec");
+      await fs.mkdir(specDir, { recursive: true });
+      await fs.mkdir(path.join(specDir, "modules"), { recursive: true });
+
+      await fs.writeFile(
+        path.join(specDir, "kynetic.yaml"),
+        `
+kynetic: "1.0"
+title: Test Project
+project:
+  name: test
+includes:
+  - modules/core.yaml
+`
+      );
+
+      const specUlid = testUlid("NOAC02");
+      await fs.writeFile(
+        path.join(specDir, "modules", "core.yaml"),
+        `
+_ulid: ${specUlid}
+title: Feature Without AC
+type: feature
+slugs:
+  - feature-no-ac
+description: No AC here
+`
+      );
+
+      const taskUlid = testUlid("TASK02");
+      await fs.writeFile(
+        path.join(specDir, "project.tasks.yaml"),
+        `
+tasks:
+  - _ulid: ${taskUlid}
+    title: Task with bad ref
+    status: pending
+    spec_ref: "@ghost"
+    priority: 3
+`
+      );
+
+      const ctx = await initContext(tempDir);
+
+      const result = await validate(ctx, {
+        schema: true,
+        refs: true,
+        completeness: true,
+        strictRefs: false,
+        requireAcceptance: true,
+      });
+
+      // Dangling ref should be warning (strict_refs: false)
+      expect(result.refWarnings.some(w => w.ref === "@ghost")).toBe(true);
+      expect(result.refErrors.some(e => e.ref === "@ghost")).toBe(false);
+
+      // Missing AC should be error (require_acceptance: true)
+      expect(result.schemaErrors.some(
+        e => e.message.includes("no acceptance criteria")
+      )).toBe(true);
+
+      // Validation should fail because of require_acceptance error
+      expect(result.valid).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Added `validation.strict_refs` and `validation.require_acceptance` to `kspec.config.yaml`
- When `strict_refs: false`, dangling references are treated as warnings instead of errors
- When `require_acceptance: true`, missing acceptance criteria are treated as errors
- CLI `--strict` flag continues to work for orphans/staleness (existing behavior preserved)
- Defaults preserve existing behavior: `strict_refs: true`, `require_acceptance: false`

## Test plan

- [x] Config schema validates new fields correctly
- [x] `strict_refs: false` demotes dangling ref errors to warnings
- [x] `strict_refs: true` (default) keeps dangling refs as errors
- [x] `require_acceptance: true` promotes missing AC warnings to errors
- [x] `require_acceptance: false` (default) keeps missing AC as warnings
- [x] Combined settings work correctly
- [x] All 2885 tests pass (1 pre-existing failure unrelated)

Task: @implement-configurable-validation-defaults
Spec: @config-validation

🤖 Generated with [Claude Code](https://claude.ai/code)