### PR TITLE
feat: clean up dead manifest config blocks

### DIFF
--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -46,15 +46,6 @@ function generateManifest(projectName: string, singleFile: boolean): string {
     );
   }
 
-  lines.push(
-    `# Configuration`,
-    `config:`,
-    `  validation:`,
-    `    strict_refs: true`,
-    `    require_acceptance: false`,
-    ``,
-  );
-
   return lines.join("\n");
 }
 

--- a/src/parser/shadow.ts
+++ b/src/parser/shadow.ts
@@ -1353,12 +1353,6 @@ project:
 # Module includes
 includes:
   - modules/main.yaml
-
-# Configuration
-config:
-  validation:
-    strict_refs: true
-    require_acceptance: false
 `;
 }
 

--- a/src/schema/spec.ts
+++ b/src/schema/spec.ts
@@ -132,7 +132,13 @@ export const ManifestSchema = z.object({
   // Hooks configuration
   hooks: z.record(z.string()).optional(),
 
-  // Daemon configuration
+  // AC: @config-manifest-cleanup ac-2 — backward compat for existing manifests with config block
+  // This field is DEPRECATED — use kspec.config.yaml instead
+  config: z.any().optional(),
+
+  // AC: @config-manifest-cleanup ac-4 — backward compat for existing manifests with daemon block
+  // DEPRECATED: Use kspec.config.yaml daemon settings instead
+  // Kept as explicit optional for backward compat parsing (do not use .passthrough())
   daemon: z.object({
     auto_start: z.boolean().default(true),
     port: z.number().int().min(1).max(65535).default(3456),

--- a/tests/parser/manifest-cleanup.test.ts
+++ b/tests/parser/manifest-cleanup.test.ts
@@ -1,0 +1,240 @@
+/**
+ * Tests for manifest cleanup spec
+ *
+ * AC coverage:
+ * - @config-manifest-cleanup ac-1: kspec init generates manifest without config block
+ * - @config-manifest-cleanup ac-2: existing manifests with config block parse successfully
+ * - @config-manifest-cleanup ac-3: kspec init generates manifest without daemon block
+ * - @config-manifest-cleanup ac-4: existing manifests with daemon block parse successfully
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { ManifestSchema } from "../../src/schema/spec.js";
+import { createTempDir, cleanupTempDir, initGitRepo, kspec } from "../helpers/cli.js";
+
+describe("Manifest Cleanup", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await createTempDir("kspec-manifest-cleanup-");
+    initGitRepo(tempDir);
+    // Create initial commit so we have a branch
+    await fs.writeFile(path.join(tempDir, "README.md"), "# Test Project\n");
+    const { execSync } = await import("node:child_process");
+    execSync("git add . && git commit -m 'Initial commit'", {
+      cwd: tempDir,
+      stdio: "pipe",
+    });
+  });
+
+  afterEach(async () => {
+    await cleanupTempDir(tempDir);
+  });
+
+  describe("generated manifest content", () => {
+    // AC: @config-manifest-cleanup ac-1 — no config block in generated manifest
+    it("kspec init generates manifest without config block", async () => {
+      const result = kspec("init --no-prompt", tempDir);
+
+      expect(result.exitCode).toBe(0);
+
+      // Find and read the generated manifest
+      const kspecDir = path.join(tempDir, ".kspec");
+      const files = await fs.readdir(kspecDir);
+      const manifestFile = files.find(
+        (f) => f.endsWith(".yaml") && !f.endsWith(".tasks.yaml") && !f.startsWith("project.")
+      );
+      expect(manifestFile).toBeDefined();
+
+      const manifestContent = await fs.readFile(
+        path.join(kspecDir, manifestFile!),
+        "utf-8"
+      );
+
+      // Should NOT contain config block
+      expect(manifestContent).not.toMatch(/^config:/m);
+      expect(manifestContent).not.toContain("validation:");
+      expect(manifestContent).not.toContain("strict_refs:");
+      expect(manifestContent).not.toContain("require_acceptance:");
+    });
+
+    // AC: @config-manifest-cleanup ac-3 — no daemon block in generated manifest
+    it("kspec init generates manifest without daemon block", async () => {
+      const result = kspec("init --no-prompt", tempDir);
+
+      expect(result.exitCode).toBe(0);
+
+      // Find and read the generated manifest
+      const kspecDir = path.join(tempDir, ".kspec");
+      const files = await fs.readdir(kspecDir);
+      const manifestFile = files.find(
+        (f) => f.endsWith(".yaml") && !f.endsWith(".tasks.yaml") && !f.startsWith("project.")
+      );
+      expect(manifestFile).toBeDefined();
+
+      const manifestContent = await fs.readFile(
+        path.join(kspecDir, manifestFile!),
+        "utf-8"
+      );
+
+      // Should NOT contain daemon block
+      expect(manifestContent).not.toMatch(/^daemon:/m);
+      expect(manifestContent).not.toContain("auto_start:");
+      expect(manifestContent).not.toContain("port:");
+    });
+  });
+
+  describe("backward compatibility parsing", () => {
+    // AC: @config-manifest-cleanup ac-2 — existing manifests with config block parse successfully
+    it("parses manifest with config block without errors", () => {
+      const manifestWithConfig = {
+        kynetic: "1.0",
+        project: {
+          name: "Test Project",
+          version: "1.0.0",
+          status: "draft",
+        },
+        config: {
+          validation: {
+            strict_refs: true,
+            require_acceptance: false,
+          },
+        },
+      };
+
+      const result = ManifestSchema.safeParse(manifestWithConfig);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        // Config is accepted but stored as-is (z.any())
+        expect(result.data.config).toEqual({
+          validation: {
+            strict_refs: true,
+            require_acceptance: false,
+          },
+        });
+      }
+    });
+
+    // AC: @config-manifest-cleanup ac-2 — config block with arbitrary content parses
+    it("parses manifest with arbitrary config content", () => {
+      const manifestWithArbitraryConfig = {
+        kynetic: "1.0",
+        project: {
+          name: "Test Project",
+          version: "1.0.0",
+        },
+        config: {
+          some_future_field: "value",
+          nested: {
+            deeply: {
+              unknown: true,
+            },
+          },
+        },
+      };
+
+      const result = ManifestSchema.safeParse(manifestWithArbitraryConfig);
+
+      expect(result.success).toBe(true);
+    });
+
+    // AC: @config-manifest-cleanup ac-4 — existing manifests with daemon block parse successfully
+    it("parses manifest with daemon block without errors", () => {
+      const manifestWithDaemon = {
+        kynetic: "1.0",
+        project: {
+          name: "Test Project",
+          version: "1.0.0",
+          status: "draft",
+        },
+        daemon: {
+          port: 4000,
+          auto_start: false,
+        },
+      };
+
+      const result = ManifestSchema.safeParse(manifestWithDaemon);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.daemon?.port).toBe(4000);
+        expect(result.data.daemon?.auto_start).toBe(false);
+      }
+    });
+
+    // AC: @config-manifest-cleanup ac-4 — daemon block with defaults parses
+    it("parses manifest with partial daemon block using defaults", () => {
+      const manifestWithPartialDaemon = {
+        kynetic: "1.0",
+        project: {
+          name: "Test Project",
+          version: "1.0.0",
+        },
+        daemon: {
+          port: 5000,
+          // auto_start not specified, should default to true
+        },
+      };
+
+      const result = ManifestSchema.safeParse(manifestWithPartialDaemon);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.daemon?.port).toBe(5000);
+        expect(result.data.daemon?.auto_start).toBe(true);
+      }
+    });
+
+    // AC: @config-manifest-cleanup ac-2 + ac-4 — manifest with both config and daemon parses
+    it("parses manifest with both config and daemon blocks", () => {
+      const manifestWithBoth = {
+        kynetic: "1.0",
+        project: {
+          name: "Test Project",
+          version: "1.0.0",
+        },
+        config: {
+          validation: {
+            strict_refs: false,
+          },
+        },
+        daemon: {
+          port: 4567,
+          auto_start: true,
+        },
+      };
+
+      const result = ManifestSchema.safeParse(manifestWithBoth);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.config).toBeDefined();
+        expect(result.data.daemon?.port).toBe(4567);
+      }
+    });
+
+    // Test that manifest without deprecated fields still parses
+    it("parses clean manifest without config or daemon blocks", () => {
+      const cleanManifest = {
+        kynetic: "1.0",
+        project: {
+          name: "Test Project",
+          version: "1.0.0",
+          status: "draft",
+        },
+        includes: ["modules/main.yaml"],
+      };
+
+      const result = ManifestSchema.safeParse(cleanManifest);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.config).toBeUndefined();
+        expect(result.data.daemon).toBeUndefined();
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Remove deprecated `config:` block from `generateManifest()` and `generateShadowManifest()`
- Add `config` field as `z.any().optional()` to ManifestSchema for backward compatibility with existing manifests
- Add deprecation comments for both `config` and `daemon` fields in ManifestSchema
- Add 8 tests covering all 4 acceptance criteria

Configuration is now exclusively managed via `kspec.config.yaml`. Manifest `config` and `daemon` fields are retained for backward compatibility parsing but ignored at runtime.

## Test plan
- [x] AC-1: Verify `kspec init` generates manifest without config block
- [x] AC-2: Verify existing manifests with config block parse successfully (3 tests)
- [x] AC-3: Verify `kspec init` generates manifest without daemon block
- [x] AC-4: Verify existing manifests with daemon block parse successfully (2 tests)
- [x] All 2913 tests pass (1 pre-existing failure in daemon-executable.test.ts unrelated)

Task: @implement-clean-up-dead-manifest-config
Spec: @config-manifest-cleanup

🤖 Generated with [Claude Code](https://claude.ai/code)