### PR TITLE
fix: handle relative parent paths (..) in detectRemoteType()

### DIFF
--- a/src/parser/config.ts
+++ b/src/parser/config.ts
@@ -141,8 +141,13 @@ export interface ResolvedShadowRemote {
  * @returns Detected type: "path" for filesystem, "url" for git URLs, "named" for git remote names
  */
 export function detectRemoteType(remote: string): ShadowRemoteType {
-  // AC: ac-4 — Local filesystem path (starts with /, ./, or ~)
-  if (remote.startsWith("/") || remote.startsWith("./") || remote.startsWith("~")) {
+  // AC: ac-4 — Local filesystem path (starts with /, ./, ../, or ~)
+  if (
+    remote.startsWith("/") ||
+    remote.startsWith("./") ||
+    remote.startsWith("../") ||
+    remote.startsWith("~")
+  ) {
     return "path";
   }
   // AC: ac-5 — Git URL (contains :// or starts with git@)

--- a/tests/shadow.test.ts
+++ b/tests/shadow.test.ts
@@ -1441,6 +1441,7 @@ describe('Shadow Branch', () => {
       it('detectRemoteType identifies local filesystem path (ac-4)', () => {
         expect(detectRemoteType('/home/user/specs.git')).toBe('path');
         expect(detectRemoteType('./local-repo')).toBe('path');
+        expect(detectRemoteType('../relative/path')).toBe('path');
         expect(detectRemoteType('~/projects/specs')).toBe('path');
       });
 


### PR DESCRIPTION
## Summary

- Fixed `detectRemoteType()` in `src/parser/config.ts` to recognize `../` prefixes as filesystem paths
- Previously, relative parent paths like `../relative/path` were incorrectly classified as `named` (git remote name) instead of `path`
- Added `'../'` to the path prefix detection alongside `/`, `./`, and `~`
- Added test case for `../relative/path` in shadow.test.ts

## Test plan

- [x] Existing remote type detection tests pass
- [x] New test case for `../relative/path` passes
- [x] All 79 shadow tests pass
- [x] Full test suite (2940 tests) passes (1 pre-existing unrelated failure in daemon-executable.test.ts)

Task: @01KHWQEM

🤖 Generated with [Claude Code](https://claude.ai/code)