### PR TITLE
fix: reconcile doctor command exit code with spec

### DIFF
--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -35,11 +35,12 @@ export function registerDoctorCommand(program: Command): void {
         }
 
         // AC: @doctor-command ac-exit-zero, ac-exit-one
+        // AC: @trait-semantic-exit-codes ac-1, ac-2
         // Exit 0 if healthy (no errors, warnings ok), exit 1 if any errors
         if (report.overall.healthy) {
           process.exit(EXIT_CODES.SUCCESS);
         } else {
-          process.exit(EXIT_CODES.VALIDATION_FAILED);
+          process.exit(EXIT_CODES.ERROR);
         }
       } catch (err) {
         if (isJsonMode()) {

--- a/tests/parser/doctor.test.ts
+++ b/tests/parser/doctor.test.ts
@@ -460,6 +460,7 @@ describe("Doctor Command", () => {
 
   describe("CLI integration", () => {
     // AC: @doctor-command ac-exit-zero
+    // AC: @trait-semantic-exit-codes ac-1
     it("exits with code 0 when healthy (via CLI)", async () => {
       initGitRepo(tempDir);
       await initializeShadow(tempDir, { projectName: "test-project" });
@@ -491,13 +492,14 @@ describe("Doctor Command", () => {
     });
 
     // AC: @doctor-command ac-exit-one
+    // AC: @trait-semantic-exit-codes ac-2
     it("exits with code 1 when errors exist (via CLI)", async () => {
       initGitRepo(tempDir);
       // Don't initialize - this creates errors
 
       const result = kspec("doctor --json", tempDir, { expectFail: true });
 
-      expect(result.exitCode).toBe(4); // VALIDATION_FAILED
+      expect(result.exitCode).toBe(1); // ERROR (health check failed)
       const report = JSON.parse(result.stdout) as DoctorReport;
       expect(report.overall.healthy).toBe(false);
     });


### PR DESCRIPTION
## Summary
- Changed doctor command to exit 1 (`EXIT_CODES.ERROR`) instead of 4 (`EXIT_CODES.VALIDATION_FAILED`) when health checks fail
- Doctor is a health check command, not a validation command — exit 1 is conventional for CLI health checks
- Aligns implementation with `@doctor-command ac-exit-one` ("exit code is 1") and `@trait-semantic-exit-codes ac-2`
- Added trait AC annotations to exit code tests for coverage tracking

## Test plan
- [x] All 27 doctor tests pass
- [x] Full test suite passes (2940 tests)
- [x] Exit code tests have proper AC annotations

Task: @01KHWQEN

🤖 Generated with [Claude Code](https://claude.ai/code)