### PR TITLE
test: add deprecation warning tests for config-daemon and manifest-cleanup

### DIFF
--- a/src/parser/yaml.ts
+++ b/src/parser/yaml.ts
@@ -37,6 +37,42 @@ import {
 import { TraitIndex } from "./traits.js";
 
 /**
+ * Log a debug message (only when KSPEC_DEBUG=1)
+ */
+function debugLog(prefix: string, message: string): void {
+  if (process.env.KSPEC_DEBUG === "1") {
+    console.error(`[DEBUG] ${prefix}: ${message}`);
+  }
+}
+
+/**
+ * Parse a manifest and emit deprecation warnings for deprecated fields.
+ *
+ * AC: @config-manifest-cleanup ac-4 — debug-level deprecation note for daemon block
+ */
+function parseManifestWithWarnings(rawManifest: unknown): Manifest {
+  const manifest = ManifestSchema.parse(rawManifest);
+
+  // AC: @config-manifest-cleanup ac-4 — log debug-level deprecation note for daemon block
+  if (manifest.daemon) {
+    debugLog(
+      "manifest",
+      'Deprecated "daemon" block found in manifest. Use kspec.config.yaml instead.',
+    );
+  }
+
+  // Also warn for deprecated config block
+  if (manifest.config) {
+    debugLog(
+      "manifest",
+      'Deprecated "config" block found in manifest. Use kspec.config.yaml instead.',
+    );
+  }
+
+  return manifest;
+}
+
+/**
  * Spec item with runtime metadata for source tracking.
  * _sourceFile is not serialized - it's used to know where to write updates.
  * _path tracks location within the file for nested items (e.g., "features[0].requirements[2]")
@@ -260,7 +296,7 @@ export async function initContext(startDir?: string): Promise<KspecContext> {
     if (manifestPath) {
       try {
         const rawManifest = await readYamlFile<unknown>(manifestPath);
-        manifest = ManifestSchema.parse(rawManifest);
+        manifest = parseManifestWithWarnings(rawManifest);
       } catch {
         // Manifest exists but may be invalid
       }
@@ -306,7 +342,7 @@ export async function initContext(startDir?: string): Promise<KspecContext> {
     if (manifestPath) {
       try {
         const rawManifest = await readYamlFile<unknown>(manifestPath);
-        manifest = ManifestSchema.parse(rawManifest);
+        manifest = parseManifestWithWarnings(rawManifest);
       } catch {
         // Manifest exists but may be invalid
       }
@@ -342,7 +378,7 @@ export async function initContext(startDir?: string): Promise<KspecContext> {
 
     try {
       const rawManifest = await readYamlFile<unknown>(manifestPath);
-      manifest = ManifestSchema.parse(rawManifest);
+      manifest = parseManifestWithWarnings(rawManifest);
     } catch {
       // Manifest exists but may be invalid
     }

--- a/tests/parser/daemon-config.test.ts
+++ b/tests/parser/daemon-config.test.ts
@@ -18,7 +18,7 @@ import {
   KspecConfigSchema,
 } from "../../src/parser/config.js";
 import { initContext } from "../../src/parser/yaml.js";
-import { createTempDir, cleanupTempDir, initGitRepo } from "../helpers/cli.js";
+import { createTempDir, cleanupTempDir, initGitRepo, kspec } from "../helpers/cli.js";
 import { stringify } from "yaml";
 
 describe("Daemon Config", () => {
@@ -281,6 +281,32 @@ daemon:
       // manifest.daemon should still have old values (for deprecation warning)
       expect(ctx.manifest?.daemon?.port).toBe(5000);
       expect(ctx.manifest?.daemon?.auto_start).toBe(true);
+    });
+
+    // AC: @config-daemon ac-4 — CLI emits deprecation warning to stderr
+    it("CLI emits deprecation warning when manifest has daemon block", async () => {
+      // Write manifest with daemon block
+      await fs.writeFile(
+        path.join(tempDir, "kynetic.yaml"),
+        stringify({
+          kynetic: "1.0",
+          project: { name: "Test Project" },
+          daemon: {
+            auto_start: false,
+            port: 5000,
+          },
+        })
+      );
+
+      // Run a CLI command that triggers maybeAutoStartDaemon()
+      // Using 'validate' since it doesn't require init and loads context
+      const result = kspec("validate", tempDir, { expectFail: true });
+
+      // Should contain the deprecation warning in stderr
+      expect(result.stderr).toContain('Manifest "daemon" block is deprecated');
+      expect(result.stderr).toContain("Migrate to kspec.config.yaml");
+      expect(result.stderr).toContain("port: 5000");
+      expect(result.stderr).toContain("auto_start: false");
     });
   });
 

--- a/tests/parser/manifest-cleanup.test.ts
+++ b/tests/parser/manifest-cleanup.test.ts
@@ -5,7 +5,7 @@
  * - @config-manifest-cleanup ac-1: kspec init generates manifest without config block
  * - @config-manifest-cleanup ac-2: existing manifests with config block parse successfully
  * - @config-manifest-cleanup ac-3: kspec init generates manifest without daemon block
- * - @config-manifest-cleanup ac-4: existing manifests with daemon block parse successfully
+ * - @config-manifest-cleanup ac-4: existing manifests with daemon block parse and log deprecation
  */
 
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
@@ -235,6 +235,83 @@ describe("Manifest Cleanup", () => {
         expect(result.data.config).toBeUndefined();
         expect(result.data.daemon).toBeUndefined();
       }
+    });
+  });
+
+  describe("deprecation logging", () => {
+    // AC: @config-manifest-cleanup ac-4 — debug-level deprecation note for daemon block
+    it("emits debug log when parsing manifest with daemon block", async () => {
+      // Write manifest with deprecated daemon block
+      await fs.writeFile(
+        path.join(tempDir, "kynetic.yaml"),
+        `kynetic: "1.0"
+project:
+  name: Test Project
+daemon:
+  port: 5000
+  auto_start: false
+`
+      );
+
+      // Run CLI command with KSPEC_DEBUG=1 to see debug output
+      const result = kspec("validate", tempDir, {
+        expectFail: true,
+        env: { KSPEC_DEBUG: "1" },
+      });
+
+      // Should contain the debug-level deprecation note
+      expect(result.stderr).toContain("[DEBUG] manifest:");
+      expect(result.stderr).toContain('Deprecated "daemon" block found');
+      expect(result.stderr).toContain("Use kspec.config.yaml instead");
+    });
+
+    // AC: @config-manifest-cleanup ac-2 — debug-level deprecation note for config block
+    it("emits debug log when parsing manifest with config block", async () => {
+      // Write manifest with deprecated config block
+      await fs.writeFile(
+        path.join(tempDir, "kynetic.yaml"),
+        `kynetic: "1.0"
+project:
+  name: Test Project
+config:
+  validation:
+    strict_refs: true
+`
+      );
+
+      // Run CLI command with KSPEC_DEBUG=1 to see debug output
+      const result = kspec("validate", tempDir, {
+        expectFail: true,
+        env: { KSPEC_DEBUG: "1" },
+      });
+
+      // Should contain the debug-level deprecation note
+      expect(result.stderr).toContain("[DEBUG] manifest:");
+      expect(result.stderr).toContain('Deprecated "config" block found');
+      expect(result.stderr).toContain("Use kspec.config.yaml instead");
+    });
+
+    // Verify no debug logs when KSPEC_DEBUG is not set
+    it("does not emit debug logs when KSPEC_DEBUG is not set", async () => {
+      // Write manifest with deprecated blocks
+      await fs.writeFile(
+        path.join(tempDir, "kynetic.yaml"),
+        `kynetic: "1.0"
+project:
+  name: Test Project
+daemon:
+  port: 5000
+config:
+  validation:
+    strict_refs: true
+`
+      );
+
+      // Run CLI command without KSPEC_DEBUG
+      const result = kspec("validate", tempDir, { expectFail: true });
+
+      // Should NOT contain debug logs
+      expect(result.stderr).not.toContain("[DEBUG] manifest:");
     });
   });
 });


### PR DESCRIPTION
## Summary

- Added test for `@config-daemon ac-4` verifying CLI emits deprecation warning to stderr when manifest has a daemon block
- Implemented debug-level deprecation logging for `@config-manifest-cleanup ac-4` (was missing from implementation)
- Added tests verifying `KSPEC_DEBUG=1` shows deprecation notes for both daemon and config blocks in manifest

## Changes

- `src/parser/yaml.ts`: Added `parseManifestWithWarnings()` helper that emits debug-level deprecation notes when manifest contains deprecated `daemon` or `config` blocks
- `tests/parser/daemon-config.test.ts`: Added CLI test for deprecation warning output
- `tests/parser/manifest-cleanup.test.ts`: Added 3 tests for debug-level deprecation logging

## Test plan

- [x] All 32 tests in `daemon-config.test.ts` and `manifest-cleanup.test.ts` pass
- [x] Full test suite passes (2944 tests, 1 pre-existing bun compile failure unrelated)
- [x] Tests run in temp directories
- [x] Tests properly annotated with AC references

Task: @01KHWQEP3
Spec: @config-daemon, @config-manifest-cleanup

🤖 Generated with [Claude Code](https://claude.ai/code)