### PR TITLE
test: fix weak doctor ac-exit-zero test

### DIFF
--- a/tests/parser/doctor.test.ts
+++ b/tests/parser/doctor.test.ts
@@ -485,10 +485,14 @@ describe("Doctor Command", () => {
 
       const result = kspec("doctor --json", tempDir);
 
-      // Parse the JSON to verify structure
+      // Parse the JSON and verify healthy status
       const report = JSON.parse(result.stdout) as DoctorReport;
-      expect(report).toHaveProperty("overall");
-      // Note: May not be healthy due to missing skills, but structure is correct
+
+      // AC: @doctor-command ac-exit-zero — exit code 0 when healthy
+      expect(result.exitCode).toBe(0);
+      // AC: @trait-semantic-exit-codes ac-1 — exit 0 indicates success
+      expect(report.overall.healthy).toBe(true);
+      expect(report.overall.errorCount).toBe(0);
     });
 
     // AC: @doctor-command ac-exit-one


### PR DESCRIPTION
## Summary
- Fixed the ac-exit-zero test that was not actually asserting exit code or healthy status
- Added proper assertions: `expect(result.exitCode).toBe(0)`, `expect(report.overall.healthy).toBe(true)`, `expect(report.overall.errorCount).toBe(0)`
- Removed misleading comment suggesting the test might not be healthy

## Test plan
- [x] Run `npm test -- tests/parser/doctor.test.ts` - all 27 doctor tests pass
- [x] Run `npm test` - all 2944 tests pass (1 pre-existing unrelated bun compile failure)
- [x] Verified test fixtures produce a healthy report (warnings are acceptable)

Task: @01KHWQES

🤖 Generated with [Claude Code](https://claude.ai/code)