### PR TITLE
fix: clean up kspec validate reference errors

### DIFF
--- a/src/parser/validate.ts
+++ b/src/parser/validate.ts
@@ -1502,9 +1502,12 @@ export async function validate(
   }
 
   // Find and validate task files
+  // Exclude test fixtures which have their own self-contained references
   const taskFiles = await findTaskFiles(ctx.rootDir);
   const specTaskFiles = await findTaskFiles(path.join(ctx.rootDir, "spec"));
-  const allTaskFiles = [...new Set([...taskFiles, ...specTaskFiles])];
+  const allTaskFiles = [...new Set([...taskFiles, ...specTaskFiles])].filter(
+    (f) => !f.includes("/fixtures/"),
+  );
 
   for (const taskFile of allTaskFiles) {
     if (runSchema) {


### PR DESCRIPTION
## Summary
- Updated 2 `@ralph-end-iteration` references to `@ralph-end-loop` (spec was renamed)
- Cleared 3 orphaned `@batch-command-execution-via-json` plan_refs (plan deleted after implementation)
- Cleared 4 `@session-log-analysis-tooling` plan_refs (plan deleted after implementation)
- Updated `@inbox-set` spec_ref to `@inbox-commands` (correct spec)
- Added `automation-assess` agent to meta for historical note validation (17 notes referenced this deleted agent)
- Excluded fixture directories from validation task discovery (they have self-contained references)

**Result:** `kspec validate --refs` now passes with 0 errors (down from 35).

## Test plan
- [x] `kspec validate --refs` passes with 0 reference errors
- [x] Full test suite passes (2944 tests, only 1 pre-existing bun compile failure)
- [x] No regressions in validate-config tests

Task: @01KHWTXF

🤖 Generated with [Claude Code](https://claude.ai/code)