### PR TITLE
feat: add spec AC for daemon.host configuration

### DIFF
--- a/src/parser/config.ts
+++ b/src/parser/config.ts
@@ -398,6 +398,7 @@ export function resolveConfig(fileConfig: KspecConfig | null): ResolvedKspecConf
         (envPort && !isNaN(envPort) ? envPort : undefined) ??
         file.daemon?.port ??
         DEFAULT_CONFIG.daemon.port,
+      // AC: @config-daemon ac-5 ac-6 — host from config/env
       host: envHost ?? file.daemon?.host ?? DEFAULT_CONFIG.daemon.host,
       // AC: @config-daemon ac-3 — auto_start from config
       auto_start: file.daemon?.auto_start ?? DEFAULT_CONFIG.daemon.auto_start,

--- a/tests/parser/config.test.ts
+++ b/tests/parser/config.test.ts
@@ -80,6 +80,7 @@ describe("Project Config", () => {
 
     // AC: @project-config ac-2 (partial - config file parsing)
     // AC: @config-validation ac-1 ac-2 — validation config fields
+    // AC: @config-daemon ac-5 — host from config file
     it("parses valid config file", async () => {
       await fs.writeFile(
         path.join(tempDir, "kspec.config.yaml"),
@@ -173,6 +174,7 @@ another_unknown:
     });
 
     // AC: @project-config ac-5
+    // AC: @config-daemon ac-6 — env var overrides config host
     it("env vars take precedence over config file values", async () => {
       await fs.writeFile(
         path.join(tempDir, "kspec.config.yaml"),


### PR DESCRIPTION
## Summary
- Added ac-5 to @config-daemon spec: host configuration from kspec.config.yaml
- Added ac-6 to @config-daemon spec: KSPEC_DAEMON_HOST env var override
- Added AC annotations to existing tests and implementation for traceability

## Test plan
- [x] Existing tests in config.test.ts verify host from config (line 83)
- [x] Existing tests verify env var override (line 177)
- [x] All 2944 tests pass (1 pre-existing bun compile failure unrelated)
- [x] kspec validate passes with no reference errors

Task: @01KHWQEPZ
Spec: @config-daemon

🤖 Generated with [Claude Code](https://claude.ai/code)