### PR TITLE
feat: skip kspec-agents.md regeneration when content unchanged

### DIFF
--- a/src/cli/commands/agents.ts
+++ b/src/cli/commands/agents.ts
@@ -342,6 +342,24 @@ export function registerAgentsCommands(program: Command): void {
         const outputPath = path.join(ctx.rootDir, GENERATED_FILE_NAME);
         const hashPath = path.join(ctx.rootDir, ".kspec", HASH_FILE_NAME);
 
+        // AC: @agent-instruction-gen ac-6 - skip regeneration when content unchanged
+        if (!dryRun) {
+          const status = await checkAgentStatus(ctx.rootDir, metaHash);
+          if (status.status === "current") {
+            output(
+              {
+                path: outputPath,
+                status: "current",
+                skipped: true,
+              },
+              () => {
+                success(`${GENERATED_FILE_NAME} is already up to date`);
+              },
+            );
+            return;
+          }
+        }
+
         // AC: @trait-dry-run ac-3 - clear indication this is a preview
         if (dryRun) {
           output(

--- a/tests/agents-instruction-gen.test.ts
+++ b/tests/agents-instruction-gen.test.ts
@@ -1,6 +1,6 @@
 /**
  * Tests for Agent Instruction Generation
- * AC: @agent-instruction-gen ac-1 through ac-5
+ * AC: @agent-instruction-gen ac-1 through ac-6
  * AC: @agents-cli ac-1 through ac-4
  * AC: @trait-dry-run (dry run support)
  * AC: @agent-templates ac-1 through ac-3
@@ -330,6 +330,59 @@ describe('Agent Instruction Generation', () => {
       // Verify current
       status = kspecFull('agents status', tempDir);
       expect(status.stdout).toContain('up to date');
+    });
+  });
+
+  // AC: @agent-instruction-gen ac-6
+  describe('ac-6: skip regeneration when content unchanged', () => {
+    it('should skip writing and report up to date when meta has not changed', async () => {
+      // First generate
+      kspecFull('agents generate', tempDir);
+
+      const filePath = path.join(tempDir, 'kspec-agents.md');
+      const firstContent = await fs.readFile(filePath, 'utf-8');
+
+      // Second generate without changes
+      const result = kspecFull('agents generate', tempDir);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('up to date');
+
+      // File should not have been rewritten (timestamp unchanged)
+      const secondContent = await fs.readFile(filePath, 'utf-8');
+      expect(secondContent).toBe(firstContent);
+    });
+
+    it('should return skipped flag in JSON output when unchanged', async () => {
+      kspecFull('agents generate', tempDir);
+
+      const result = kspecJson<{
+        path: string;
+        status: string;
+        skipped: boolean;
+      }>('agents generate', tempDir);
+
+      expect(result.skipped).toBe(true);
+      expect(result.status).toBe('current');
+    });
+
+    it('should regenerate when meta has changed', async () => {
+      kspecFull('agents generate', tempDir);
+
+      // Add a skill to change meta
+      kspecFull(
+        'skill add --id skip-test-skill --name "Skip Test" --description "Test skill for skip"',
+        tempDir,
+      );
+
+      // Should regenerate, not skip
+      const result = kspecFull('agents generate', tempDir);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).not.toContain('up to date');
+      expect(result.stdout).toContain('Generated');
+
+      const filePath = path.join(tempDir, 'kspec-agents.md');
+      const content = await fs.readFile(filePath, 'utf-8');
+      expect(content).toContain('skip-test-skill');
     });
   });
 


### PR DESCRIPTION
## Summary
- `kspec agents generate` now checks the stored meta hash before writing
- If content hasn't changed (same conventions, workflows, skills, templates), skips file writes and reports "already up to date"
- Prevents unnecessary timestamp-only diffs in `kspec-agents.md`
- JSON output includes `skipped: true` and `status: "current"` when skipped

## Test plan
- [x] New test: skip writing when meta unchanged, file content identical
- [x] New test: JSON output includes `skipped` flag
- [x] New test: still regenerates when meta has changed
- [x] All 38 agents instruction-gen tests pass
- [x] Full test suite passes (3 pre-existing daemon failures unrelated)

Task: @01KHZ941
Spec: @agent-instruction-gen

Generated with [Claude Code](https://claude.ai/code)