### PR TITLE
chore: bump @agentclientprotocol/sdk to ^0.14.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "kspec": "dist/cli/index.js"
       },
       "devDependencies": {
-        "@agentclientprotocol/sdk": "^0.13.0",
+        "@agentclientprotocol/sdk": "^0.14.0",
         "@biomejs/biome": "2.3.11",
         "@tailwindcss/postcss": "^4.1.18",
         "@types/diff": "^7.0.2",
@@ -50,9 +50,9 @@
       }
     },
     "node_modules/@agentclientprotocol/sdk": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-0.13.0.tgz",
-      "integrity": "sha512-Z6/Fp4cXLbYdMXr5AK752JM5qG2VKb6ShM0Ql6FimBSckMmLyK54OA20UhPYoH4C37FSFwUTARuwQOwQUToYrw==",
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-0.14.1.tgz",
+      "integrity": "sha512-b6r3PS3Nly+Wyw9U+0nOr47bV8tfS476EgyEMhoKvJCZLbgqoDFN7DJwkxL88RR0aiOqOYV1ZnESHqb+RmdH8w==",
       "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
-    "@agentclientprotocol/sdk": "^0.13.0",
+    "@agentclientprotocol/sdk": "^0.14.0",
     "@biomejs/biome": "2.3.11",
     "@tailwindcss/postcss": "^4.1.18",
     "@types/diff": "^7.0.2",


### PR DESCRIPTION
## Summary
- Bumps `@agentclientprotocol/sdk` from `^0.13.0` to `^0.14.0` (types-only devDependency)
- All 21 imported types remain compatible — changes are strictly additive (new `Usage`/`UsageUpdate` types, optional `usage` field)
- `tsc --noEmit` passes cleanly, full test suite green (3 pre-existing failures unrelated)

## Test plan
- [x] `tsc --noEmit` — no type errors
- [x] `npm test` — 3103 tests pass, 3 pre-existing failures (tracked by @01KJ3SMT, @01KJ3SMV)

Task: @01KHY9W8

🤖 Generated with [Claude Code](https://claude.com/claude-code)