### PR TITLE
fix: resolve bun build --compile failure for daemon executable

### DIFF
--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "build:compile": "bun build --compile --minify src/index.ts --outfile dist/kspec-daemon",
+    "build:compile": "bun build --compile --minify ../../dist/daemon/index.ts --outfile ../../dist/kspec-daemon",
     "dev": "bun --watch src/index.ts",
     "start": "bun dist/index.js"
   },

--- a/scripts/build-executables.sh
+++ b/scripts/build-executables.sh
@@ -2,10 +2,16 @@
 set -euo pipefail
 
 # Build kspec-daemon executables for multiple platforms
-# Requires Bun 1.0+ with --compile support
+# Requires: npm run build (to populate dist/daemon/ with correct import paths)
+# Requires: Bun 1.0+ with --compile support
 
-DAEMON_SRC="packages/daemon/src/index.ts"
+DAEMON_SRC="dist/daemon/index.ts"
 DIST_DIR="dist/executables"
+
+if [ ! -f "$DAEMON_SRC" ]; then
+  echo "Error: $DAEMON_SRC not found. Run 'npm run build' first."
+  exit 1
+fi
 
 echo "Building kspec-daemon executables..."
 

--- a/tests/daemon-executable.test.ts
+++ b/tests/daemon-executable.test.ts
@@ -10,21 +10,15 @@ import { join } from 'path';
 
 describe('Daemon Executable Compilation', () => {
   const daemonDir = join(process.cwd(), 'packages/daemon');
-  // When running from packages/daemon, outfile is relative to that directory
-  // But bun seems to resolve it from the repo root. Let's check both.
-  const possiblePaths = [
-    join(process.cwd(), 'dist/kspec-daemon'),
-    join(daemonDir, 'dist/kspec-daemon'),
-  ];
+  // build:compile outputs to ../../dist/kspec-daemon (relative to daemon dir = project root dist/)
+  const executablePath = join(process.cwd(), 'dist/kspec-daemon');
 
   afterEach(async () => {
-    // Clean up compiled executables if they exist
-    for (const path of possiblePaths) {
-      try {
-        await rm(path, { force: true });
-      } catch {
-        // Ignore cleanup errors
-      }
+    // Clean up compiled executable if it exists
+    try {
+      await rm(executablePath, { force: true });
+    } catch {
+      // Ignore cleanup errors
     }
   });
 
@@ -50,25 +44,7 @@ describe('Daemon Executable Compilation', () => {
     }
     expect(buildResult.status).toBe(0);
 
-    // Find which path the executable was created at
-    let executablePath: string | undefined;
-    for (const path of possiblePaths) {
-      try {
-        const stats = await stat(path);
-        if (stats.isFile()) {
-          executablePath = path;
-          break;
-        }
-      } catch {
-        // Try next path
-      }
-    }
-
-    if (!executablePath) {
-      throw new Error(`Executable not found at any of: ${possiblePaths.join(', ')}`);
-    }
-
-    // Verify executable exists
+    // Verify executable exists at expected path
     const stats = await stat(executablePath);
     expect(stats.isFile()).toBe(true);
 


### PR DESCRIPTION
## Summary
- Fixed `bun build --compile` failing because relative imports (`../../parser/index.js`) from `packages/daemon/src/routes/` couldn't resolve outside the daemon package
- Changed `build:compile` to compile from `dist/daemon/index.ts` (populated by `npm run build:daemon`) where the relative import paths correctly resolve to `dist/parser/` and `dist/utils/`
- Updated `build-executables.sh` with corrected source path and pre-flight check for missing dist files

## Test plan
- [x] All 3 daemon-executable tests pass (were failing before)
- [x] Full test suite: 3105 passed (1 pre-existing doctor flaky failure)
- [x] Verified compiled executable starts and serves correctly

Task: @task-fix-daemon-executable-build
Spec: @daemon-server ac-16

🤖 Generated with [Claude Code](https://claude.com/claude-code)