### PR TITLE
fix: isolate doctor daemon tests from host environment

### DIFF
--- a/tests/parser/doctor.test.ts
+++ b/tests/parser/doctor.test.ts
@@ -235,14 +235,14 @@ describe("Doctor Command", () => {
       initGitRepo(tempDir);
       await initializeShadow(tempDir, { projectName: "test-project" });
 
-      // Mock daemon as not running to isolate from host environment
+      // Mock daemon as running to test the running-with-PID path
       const daemonStatusModule = await import("../../src/parser/daemon-status.js");
       vi.spyOn(daemonStatusModule, "getDaemonStatus").mockResolvedValue({
-        running: false,
-        pid: null,
-        port: null,
-        uptime: null,
-        healthReachable: false,
+        running: true,
+        pid: 99999,
+        port: 3456,
+        uptime: 120,
+        healthReachable: true,
       });
 
       try {
@@ -252,7 +252,8 @@ describe("Doctor Command", () => {
           (c) => c.name === "daemon-running"
         );
         expect(daemonCheck).toBeDefined();
-        expect(daemonCheck!.severity).toBe("warning");
+        expect(daemonCheck!.severity).toBe("ok");
+        expect(daemonCheck!.message).toContain("PID: 99999");
       } finally {
         vi.restoreAllMocks();
       }


### PR DESCRIPTION
## Summary
- Doctor tests (`tests/parser/doctor.test.ts`) were flaky when a real kspec daemon was running on the host (e.g. during ralph loop sessions)
- Root cause: `getDaemonStatus()` checks the **global** PID file (`~/.config/kspec/daemon.pid`), not per-project. Tests asserting "daemon not running" got `severity: "ok"` instead of `"warning"` when a daemon was actually running
- Fix: Added `vi.spyOn` mocking of `getDaemonStatus` in 3 daemon-related tests, matching the pattern already used in the `ac-daemon-unreachable` test
- Also removed an unused `originalGetDaemonStatus` variable in the existing unreachable test

## Test plan
- [x] Doctor tests pass in isolation (29/29)
- [x] Full test suite passes (3168/3168, 2 consecutive runs)
- [x] Verified flakiness reproduces before fix (daemon running → test fails)
- [x] Verified fix resolves flakiness (daemon running → test still passes via mock)

Task: @task-investigate-doctor-flaky-tests

Generated with [Claude Code](https://claude.ai/code)