### PR TITLE
fix: make sidebar nav links clickable and add triage SPA route

### DIFF
--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -335,7 +335,7 @@ export async function createServer(options: ServerOptions) {
 
     // SPA fallback routes for client-side routing
     // These catch paths like /tasks, /items, /inbox that don't have static files
-    const spaRoutes = ['/tasks', '/tasks/*', '/items', '/items/*', '/inbox', '/observations'];
+    const spaRoutes = ['/tasks', '/tasks/*', '/items', '/items/*', '/inbox', '/observations', '/triage'];
     for (const route of spaRoutes) {
       app.get(route, () => Bun.file(indexHtmlPath));
     }

--- a/packages/web-ui/src/lib/components/Sidebar.svelte
+++ b/packages/web-ui/src/lib/components/Sidebar.svelte
@@ -113,11 +113,14 @@
 					{#each navItems as item}
 						<SidebarMenuItem>
 							<SidebarMenuButton
-								href="{base}{item.path}"
 								isActive={$page.url.pathname === `${base}${item.path}` || $page.url.pathname === item.path}
 								data-testid="nav-link-{item.label.toLowerCase()}"
 							>
-								<span>{item.label}</span>
+								{#snippet child({ props })}
+									<a href="{base}{item.path}" {...props}>
+										<span>{item.label}</span>
+									</a>
+								{/snippet}
 							</SidebarMenuButton>
 						</SidebarMenuItem>
 					{/each}


### PR DESCRIPTION
## Summary

- Sidebar navigation links (Dashboard, Tasks, Items, Inbox, Triage) were not clickable — `SidebarMenuButton` renders a `<button>` by default, so the `href` prop had no effect
- Used the shadcn-svelte `child` snippet pattern to render proper `<a>` elements with all styling/data attributes preserved
- Added `/triage` to daemon SPA fallback routes so direct URL navigation works

## Root Cause

The `SidebarMenuButton` component spreads `restProps` onto a `<button>` element. Passing `href` to a button is ignored by browsers. The `child` snippet pattern is the designed escape hatch for rendering custom elements (like `<a>`) while preserving component styling.

## Test plan

- [x] Web UI builds cleanly (`npm run build` in packages/web-ui)
- [x] Full test suite passes (3167/3167 + 3 skipped)
- [x] Local review: no MUST-FIX findings
- [ ] Manual: verify sidebar links navigate when clicked
- [ ] Manual: verify `http://localhost:3456/triage` loads the triage page directly

Task: @task-fix-sidebar-nav-links

🤖 Generated with [Claude Code](https://claude.com/claude-code)