### PR TITLE
fix: bump timeout on session-start-notes multiple completed tasks test

### DIFF
--- a/tests/cli/session-start-notes.test.ts
+++ b/tests/cli/session-start-notes.test.ts
@@ -155,7 +155,7 @@ describe('session start notes enrichment', () => {
       expect(result.stdout).toContain('All tests passing');
     });
 
-    it('should include notes from multiple completed tasks', () => {
+    it('should include notes from multiple completed tasks', { timeout: 20000 }, () => {
       // Create and complete two tasks with notes
       kspec('task add --title "First completed task" --slug first-completed', tempDir);
       kspec('task start @first-completed', tempDir);


### PR DESCRIPTION
## Summary
- Bump timeout on `session-start-notes.test.ts` "should include notes from multiple completed tasks" test from default 5000ms to 20000ms
- This test runs 10 sequential kspec CLI calls which exceeds the default timeout in CI (shard 1/3 failure on PR #464)

## Test plan
- [x] Test passes locally
- [x] CI should pass with increased timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)