### PR TITLE
feat: write core skills kspec:triage-inbox and kspec:triage-automation

### DIFF
--- a/templates/skills/manifest.yaml
+++ b/templates/skills/manifest.yaml
@@ -23,3 +23,13 @@ skills:
     description: Triage inbox items systematically. Records decisions with audit trail, then executes actions. Supports inbox, observations, and automation eligibility triage.
     platforms:
       - claude-code
+  - id: triage-inbox
+    name: Inbox Triage
+    description: Process inbox items using the record-act pattern. Categorize, promote to spec/task, merge duplicates, defer, or delete stale items with full audit trail.
+    platforms:
+      - claude-code
+  - id: triage-automation
+    name: Automation Triage
+    description: Assess and prepare tasks for automation eligibility. Verify spec coverage, acceptance criteria, and task readiness for automated agents.
+    platforms:
+      - claude-code

--- a/templates/skills/triage-automation/SKILL.md
+++ b/templates/skills/triage-automation/SKILL.md
@@ -1,0 +1,134 @@
+# Automation Triage
+
+Assess and prepare tasks for automation eligibility. Goal: make tasks self-contained so they can be worked on by automated agents.
+
+## When to Use
+
+- During a triage session focused on automation readiness
+- When new tasks need eligibility assessment
+- Before starting an automated work loop (to ensure eligible tasks exist)
+
+## Philosophy
+
+- **Eligible is the goal** — Manual-only should be the exception
+- **Criteria are for visibility** — Help identify what's missing, not auto-approve
+- **Fix issues, don't just assess** — Guide toward making tasks automatable
+
+## Eligibility Criteria
+
+A task is ready for automation when:
+
+1. Has `spec_ref` pointing to a resolvable spec
+2. Spec has acceptance criteria (testable outcomes)
+3. Task type is not `spike` (spikes output knowledge, not code)
+
+**Having spec + ACs is necessary but not sufficient** — you must also verify the spec is appropriate and ACs are adequate for the task.
+
+**Task type does not determine automation eligibility.** Any non-spike task can be `automation: eligible` — including design tasks, refactoring tasks, documentation tasks, etc. The `automation` field is the definitive source. Once a task is marked `eligible`, do not second-guess it based on type, title, or description.
+
+## Workflow
+
+### 1. Get Assessment Overview
+
+```bash
+# Show unassessed pending tasks with criteria status
+kspec tasks assess automation
+
+# See what auto mode would change
+kspec tasks assess automation --auto --dry-run
+```
+
+### 2. Process Each Task
+
+For each task shown:
+
+**If spike:**
+- Mark `manual_only` — spikes are inherently human work
+- `kspec task set @ref --automation manual_only --reason "Spike - output is knowledge"`
+
+**If missing spec_ref or no ACs:**
+- Ask: "Fix now or mark for later?"
+- **Fix now:**
+  1. Create or find appropriate spec: `kspec item add --under @parent --title "..."`
+  2. Add acceptance criteria: `kspec item ac add @spec --given "..." --when "..." --then "..."`
+  3. Link task to spec: `kspec task set @ref --spec-ref @spec`
+  4. Re-assess and mark eligible if appropriate
+- **Mark for later:**
+  - `kspec task set @ref --automation needs_review --reason "Missing spec - needs spec creation"`
+
+**If has spec + ACs:**
+- Review for eligibility:
+  - Is the spec appropriate for this task?
+  - Are the ACs adequate and testable?
+  - Does the task have sufficient context?
+- If yes: `kspec task set @ref --automation eligible`
+- If no: Fix issues or mark `needs_review` with specific reason
+
+### 3. Batch Processing with Auto Mode
+
+For fast triage of obvious cases:
+
+```bash
+# Apply auto mode (spikes → manual_only, missing → needs_review)
+kspec tasks assess automation --auto
+
+# Then manually review the "review_for_eligible" tasks
+kspec tasks ready --unassessed
+```
+
+Auto mode is conservative:
+- Spikes → `manual_only`
+- Missing spec/ACs → `needs_review`
+- Has spec + ACs → **NOT auto-marked** (requires review)
+
+## Commands Reference
+
+```bash
+# Assessment
+kspec tasks assess automation              # Show unassessed with criteria
+kspec tasks assess automation @ref         # Single task
+kspec tasks assess automation --all        # Include already-assessed
+kspec tasks assess automation --auto       # Apply obvious cases
+kspec tasks assess automation --dry-run    # Preview changes
+
+# Setting automation status
+kspec task set @ref --automation eligible
+kspec task set @ref --automation needs_review --reason "Why"
+kspec task set @ref --automation manual_only --reason "Why"
+kspec task set @ref --no-automation        # Clear to unassessed
+
+# Filtering tasks
+kspec tasks ready --unassessed             # Tasks needing assessment
+kspec tasks ready --eligible               # Automation-ready tasks
+kspec tasks ready --needs-review           # Tasks needing human triage
+```
+
+## Assessment Output
+
+```
+@task-slug  "Task title"
+  spec_ref:     ✓ @feature-slug
+  has_acs:      ✓ 3 acceptance criteria
+  not_spike:    ✓ type: task
+  → review_for_eligible (verify spec/AC adequacy)
+```
+
+| Recommendation | Meaning | Auto Mode Action |
+|----------------|---------|------------------|
+| `review_for_eligible` | Passes criteria, needs review | No change (manual review) |
+| `needs_review` | Missing spec or ACs | Sets `needs_review` with reason |
+| `manual_only` | Spike task | Sets `manual_only` |
+
+## Key Principles
+
+- **CLI doesn't auto-mark eligible** — Requires agent/human review
+- **Agents CAN mark eligible** — When reviewing based on user instruction
+- **Add notes when setting status** — Document the "why"
+- **Re-assess after fixes** — After adding spec/ACs, check again
+- **Task type is not destiny** — Any non-spike task can be eligible
+
+## Integration
+
+- **`/kspec:triage-inbox`** — Inbox triage may promote items to tasks needing assessment
+- **`kspec tasks ready --eligible`** — Used by task-work loop to find automatable work
+- **Ralph loop** — Consumes eligible tasks; automation assessment feeds the pipeline

--- a/templates/skills/triage-inbox/SKILL.md
+++ b/templates/skills/triage-inbox/SKILL.md
@@ -1,0 +1,225 @@
+# Inbox Triage
+
+Systematically process inbox items using the **record → act** pattern. Records decisions with audit trail, then executes actions.
+
+## When to Use
+
+- Processing accumulated inbox items
+- During a triage session (`kspec workflow start @inbox-triage`)
+- When inbox count is growing and needs attention
+
+## Core Concept: Record → Act
+
+Triage separates **decision-making** from **execution**:
+
+1. **Record** the decision (what to do + why)
+2. **Act** on the decision (execute it)
+
+This enables review, override, and audit trails.
+
+```bash
+# Step 1: Record what you want to do
+kspec triage record @inbox-ref --action promote --reasoning "Clear feature request"
+
+# Step 2: Execute the decision
+kspec triage act @triage-ref
+```
+
+### Actions
+
+| Action | What `act` does |
+|--------|-----------------|
+| `promote` | Creates task from inbox item snapshot |
+| `delete` | Deletes the inbox item |
+| `defer` | Records deferral, no side effect |
+| `spec-gap` | Creates observation tagged spec-gap |
+| `duplicate` | Deletes the inbox item |
+
+### Lifecycle
+
+```
+record (with action)     override (optional)     act
+    → triaged        →       triaged         →  acted_on
+```
+
+## Workflow
+
+### 1. Gather Context
+
+```bash
+kspec session start --full
+kspec inbox list
+```
+
+### 2. Categorize Items
+
+Group inbox items by type:
+- **Bugs** — implementation issues, errors
+- **Spec gaps** — missing or incomplete specs
+- **Quick wins** — small, well-defined improvements
+- **Larger features** — need plan mode to design
+- **Process/workflow** — meta improvements
+- **Delete candidates** — outdated, duplicates, already done
+
+Present categories to user for alignment.
+
+### 3. Triage Each Item
+
+**Interactive mode** (recommended for multiple items):
+
+```bash
+kspec triage start
+# Presents untriaged items one by one
+# Prompts for action + reasoning
+# Ctrl+C preserves all previously committed records
+```
+
+**Individual recording** (for targeted decisions):
+
+```bash
+kspec triage record @ref --action promote --reasoning "Clear feature request with spec coverage"
+kspec triage record @ref --action delete --reasoning "Already implemented in PR #123"
+kspec triage record @ref --action defer --reasoning "Depends on auth system redesign"
+kspec triage record @ref --action spec-gap --reasoning "No spec covers error handling for this flow"
+kspec triage record @ref --action duplicate --reasoning "Covered by @existing-spec"
+```
+
+### 4. Review and Execute Decisions
+
+```bash
+# Review what was recorded
+kspec triage list --status triaged
+
+# Preview before executing
+kspec triage act @triage-ref --dry-run
+
+# Execute decisions
+kspec triage act @triage-ref
+```
+
+### 5. Override If Needed
+
+```bash
+# Override changes the action while preserving the audit trail
+kspec triage override @triage-ref --action defer --reasoning "Reconsidered - not ready"
+
+# Then act on the updated decision
+kspec triage act @triage-ref
+```
+
+## Spec-First Processing
+
+For behavior changes, check spec coverage before promoting:
+
+1. **Check coverage**: `kspec item list | grep <relevant>`
+2. **Identify gaps**: Does spec have description AND acceptance criteria?
+3. **Update spec**:
+   ```bash
+   kspec item set @ref --description "..."
+   kspec item ac add @ref --given "..." --when "..." --then "..."
+   ```
+4. **Record and act**:
+   ```bash
+   kspec triage record @inbox-ref --action promote --reasoning "Spec updated" --evidence @spec-ref
+   kspec triage act @triage-ref
+   ```
+
+## Plan Mode for Larger Items
+
+When an item needs design work:
+
+1. Enter plan mode
+2. Explore codebase for patterns/context
+3. Design spec structure and implementation approach
+4. Write plan, exit for approval
+5. Execute: create spec, add AC, derive task
+
+## Observation Processing
+
+During triage sessions, you may also process pending observations:
+
+```bash
+kspec meta observations --pending-resolution
+```
+
+For each observation:
+
+| Type | How to Process |
+|------|----------------|
+| **friction** | Reveals spec gap? → Create spec or inbox item. Already addressed? → Resolve |
+| **success** | Document in relevant spec or AGENTS.md if broadly useful → Resolve |
+| **question** | Answer if you can. Needs investigation? → Promote to task |
+| **idea** | Clear scope? → Inbox or task. Unclear? → Leave or delete if stale |
+
+```bash
+# Promote observation to task
+kspec meta promote @ref --title "Add bulk AC command" --priority 2
+
+# Resolve observation
+kspec meta resolve @ref "Resolution notes"
+kspec meta resolve --refs @ref1 @ref2 --resolution "Batch resolution"
+
+# Convert inbox item to observation (if it's a pattern, not a task)
+kspec meta observe --from-inbox @ref
+```
+
+## Export for Context
+
+Share triage decisions with other agents or sessions:
+
+```bash
+# Markdown context blocks (for agent handoff)
+kspec triage export --format context
+
+# Full structured data
+kspec triage export --format json
+```
+
+## Bulk Operations with Batch
+
+When triaging many items, use `kspec batch` for atomic operations:
+
+```bash
+kspec batch --commands '[
+  {"command":"triage record","args":{"ref":"@ref1","action":"delete","reasoning":"Stale"}},
+  {"command":"triage record","args":{"ref":"@ref2","action":"promote","reasoning":"Clear scope"}}
+]'
+```
+
+Use `--dry-run` to preview. See `/kspec:help` for full batch documentation.
+
+## Common Patterns
+
+| Pattern | Action |
+|---------|--------|
+| Already implemented | Verify impl exists → check spec gaps → record delete |
+| Duplicate of existing | Verify original covers scope → record duplicate |
+| Small flag/option | Update spec + AC → record promote |
+| New command | Plan mode → design spec → record promote with evidence |
+| Bug report | Check spec coverage → update spec → record promote |
+| Vague idea | Record defer, or leave untriaged for later |
+| Missing spec | Record spec-gap → creates observation for follow-up |
+
+## Key Principles
+
+- **Record before act** — Separate decisions from execution for audit trail
+- **Ask one question at a time** — Don't batch decisions in interactive mode
+- **Spec before task** — Fill spec gaps before promoting to tasks
+- **AC is required** — Specs without acceptance criteria are incomplete
+- **Use CLI, not YAML** — All changes through kspec commands
+- **Delete freely** — Outdated or duplicate items should go
+
+## Progress Tracking
+
+At session end, provide summary:
+- Items triaged (recorded decisions)
+- Actions executed (promoted, deleted, deferred, spec-gap, duplicate)
+- Tasks created/updated
+- Observations resolved
+- Remaining items
+
+## Integration
+
+- **`/kspec:reflect`** — Session reflection may generate inbox items for triage
+- **`/kspec:observations`** — Captures systemic patterns found during triage
+- **`kspec session start`** — Shows inbox count for triage awareness


### PR DESCRIPTION
## Summary
- Split the monolithic triage skill into two focused, self-descriptive skills
- **triage-inbox**: Inbox item processing with record→act pattern, categorization, spec-first processing, observation processing, export, and batch operations (225 lines)
- **triage-automation**: Task automation eligibility assessment with criteria verification, per-task workflow, auto mode batch processing, and commands reference (134 lines)
- Added both entries to templates/skills/manifest.yaml
- Both install successfully via `kspec skill install-core` and render to `.kspec/skills/`

## Test plan
- [x] `kspec skill install-core` — both new skills created successfully
- [x] `kspec skill status` — both show as `plugin-provided`
- [x] `kspec skill list --json` — both have correct metadata
- [x] All CLI commands cross-referenced against source code
- [x] All 3181 tests pass
- [x] Local review: fixed batch resolve syntax (was using positional args instead of --refs flag)

Task: @01KHZHPM

🤖 Generated with [Claude Code](https://claude.com/claude-code)