### PR TITLE
refactor: eliminate duplicated types in web-ui by importing from shared

### DIFF
--- a/packages/shared/src/api.ts
+++ b/packages/shared/src/api.ts
@@ -256,3 +256,124 @@ export interface AlignmentStats {
   tasks_without_specs: number;
   warnings: string[];
 }
+
+/**
+ * Convention definition from meta manifest
+ */
+export interface Convention {
+  _ulid: string;
+  domain: string;
+  rules: string[];
+  examples?: Array<{ good: string; bad: string }>;
+  validation?: {
+    type: 'regex' | 'enum' | 'range' | 'prose';
+    pattern?: string;
+    message?: string;
+    allowed?: string[];
+    min?: number;
+    max?: number;
+    unit?: 'words' | 'chars' | 'lines';
+  };
+}
+
+/**
+ * Triage status lifecycle
+ */
+export type TriageStatus = 'pending' | 'triaged' | 'acted_on';
+
+/**
+ * Triage action types
+ */
+export type TriageAction = 'promote' | 'delete' | 'defer' | 'spec-gap' | 'duplicate';
+
+/**
+ * Triage record
+ */
+export interface TriageRecord {
+  _ulid: string;
+  inbox_ref: string;
+  item_snapshot: string;
+  status: TriageStatus;
+  action?: TriageAction;
+  reasoning?: string;
+  decided_by?: string;
+  evidence_refs: string[];
+  override_reasoning?: string;
+  override_by?: string;
+  override_at?: string;
+  acted_at?: string;
+  result_ref?: string;
+  created_at: string;
+  updated_at?: string;
+}
+
+/**
+ * Acceptance criterion with inheritance tracking
+ */
+export interface InheritedAC extends AcceptanceCriterion {
+  _inherited_from: string;
+}
+
+/**
+ * Exported task with resolved spec reference title
+ */
+export interface ExportedTask extends TaskDetail {
+  spec_ref_title?: string;
+}
+
+/**
+ * Exported spec item with nested hierarchy and inherited ACs.
+ * Note: extends ItemDetail (acceptance_criteria required) because the JSON
+ * snapshot always includes the field. The core export module uses Omit to
+ * build from parser types where AC may not yet exist, but by the time data
+ * reaches the web-ui via snapshot, AC is always present (at least as []).
+ */
+export interface ExportedItem extends ItemDetail {
+  children?: ExportedItem[];
+  inherited_acs?: InheritedAC[];
+}
+
+/**
+ * Project metadata in a snapshot
+ */
+export interface ExportedProject {
+  name: string;
+  version?: string;
+  description?: string;
+}
+
+/**
+ * Validation result included in a snapshot
+ */
+export interface ExportedValidation {
+  valid: boolean;
+  errorCount: number;
+  warningCount: number;
+  errors: Array<{
+    file: string;
+    message: string;
+    path?: string;
+  }>;
+  warnings: Array<{
+    file: string;
+    message: string;
+  }>;
+}
+
+/**
+ * Full kspec snapshot structure
+ */
+export interface KspecSnapshot {
+  version: string;
+  exported_at: string;
+  project: ExportedProject;
+  tasks: ExportedTask[];
+  items: ExportedItem[];
+  inbox: InboxItem[];
+  session: SessionContext | null;
+  observations: Observation[];
+  agents: Agent[];
+  workflows: Workflow[];
+  conventions: Convention[];
+  validation?: ExportedValidation;
+}

--- a/packages/web-ui/src/lib/types/snapshot.ts
+++ b/packages/web-ui/src/lib/types/snapshot.ts
@@ -1,91 +1,15 @@
 /**
  * Snapshot Types
  *
- * Types for the static JSON snapshot used in read-only mode.
- * These mirror the export types from the CLI.
+ * Re-exported from @kynetic-ai/shared for backwards compatibility.
+ * Types that were previously defined locally now come from the shared package.
  */
 
-import type {
-	TaskDetail,
-	ItemDetail,
-	InboxItem,
-	SessionContext,
-	Observation,
-	Agent,
-	Workflow
+export type {
+	Convention,
+	ExportedTask,
+	ExportedItem,
+	ExportedValidation,
+	KspecSnapshot,
+	InheritedAC
 } from '@kynetic-ai/shared';
-
-/**
- * Convention from meta manifest
- */
-export interface Convention {
-	_ulid: string;
-	domain: string;
-	rules: string[];
-}
-
-/**
- * Acceptance criterion with inheritance tracking
- */
-export interface InheritedAC {
-	id: string;
-	given: string;
-	when: string;
-	then: string;
-	_inherited_from: string;
-}
-
-/**
- * Exported task with resolved spec reference title
- */
-export interface ExportedTask extends TaskDetail {
-	spec_ref_title?: string;
-}
-
-/**
- * Exported spec item with inherited ACs
- */
-export interface ExportedItem extends ItemDetail {
-	children?: ExportedItem[];
-	inherited_acs?: InheritedAC[];
-}
-
-/**
- * Validation result in snapshot
- */
-export interface ExportedValidation {
-	valid: boolean;
-	errorCount: number;
-	warningCount: number;
-	errors: Array<{
-		file: string;
-		message: string;
-		path?: string;
-	}>;
-	warnings: Array<{
-		file: string;
-		message: string;
-	}>;
-}
-
-/**
- * Full kspec snapshot structure
- */
-export interface KspecSnapshot {
-	version: string;
-	exported_at: string;
-	project: {
-		name: string;
-		version?: string;
-		description?: string;
-	};
-	tasks: ExportedTask[];
-	items: ExportedItem[];
-	inbox: InboxItem[];
-	session: SessionContext | null;
-	observations: Observation[];
-	agents: Agent[];
-	workflows: Workflow[];
-	conventions: Convention[];
-	validation?: ExportedValidation;
-}

--- a/packages/web-ui/src/lib/types/triage.ts
+++ b/packages/web-ui/src/lib/types/triage.ts
@@ -1,27 +1,7 @@
 /**
  * Triage Types
  *
- * Types for triage records used in the web UI.
- * Mirrors the schema types from src/schema/triage.ts.
+ * Re-exported from @kynetic-ai/shared for backwards compatibility.
  */
 
-export type TriageStatus = 'pending' | 'triaged' | 'acted_on';
-export type TriageAction = 'promote' | 'delete' | 'defer' | 'spec-gap' | 'duplicate';
-
-export interface TriageRecord {
-	_ulid: string;
-	inbox_ref: string;
-	item_snapshot: string;
-	status: TriageStatus;
-	action?: TriageAction;
-	reasoning?: string;
-	decided_by?: string;
-	evidence_refs: string[];
-	override_reasoning?: string;
-	override_by?: string;
-	override_at?: string;
-	acted_at?: string;
-	result_ref?: string;
-	created_at: string;
-	updated_at?: string;
-}
+export type { TriageStatus, TriageAction, TriageRecord } from '@kynetic-ai/shared';

--- a/tests/web-ui-shared-types.test.ts
+++ b/tests/web-ui-shared-types.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Tests for Web UI Shared Types
+ *
+ * Verifies that web-ui types files re-export from @kynetic-ai/shared
+ * instead of defining duplicate local types. Prevents type drift
+ * between the shared package and web-ui.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFile, readdir } from 'fs/promises';
+import { join } from 'path';
+
+const TYPES_DIR = join(process.cwd(), 'packages/web-ui/src/lib/types');
+
+describe('Web UI shared types', () => {
+  it('types directory files should only re-export from @kynetic-ai/shared', async () => {
+    const files = await readdir(TYPES_DIR);
+    const tsFiles = files.filter(f => f.endsWith('.ts') && !f.endsWith('.d.ts'));
+
+    for (const file of tsFiles) {
+      const content = await readFile(join(TYPES_DIR, file), 'utf-8');
+
+      // Should not define local interfaces
+      const interfaceMatches = content.match(/^export interface /gm);
+      expect(
+        interfaceMatches,
+        `${file} should not define local interfaces — import from @kynetic-ai/shared instead`
+      ).toBeNull();
+
+      // Should not define local type aliases (except re-exports)
+      const typeDefMatches = content.match(/^export type \w+ =/gm);
+      expect(
+        typeDefMatches,
+        `${file} should not define local type aliases — import from @kynetic-ai/shared instead`
+      ).toBeNull();
+
+      // Should re-export from shared
+      expect(
+        content,
+        `${file} should re-export from @kynetic-ai/shared`
+      ).toContain('@kynetic-ai/shared');
+    }
+  });
+
+  it('triage types should re-export TriageRecord, TriageAction, TriageStatus', async () => {
+    const content = await readFile(join(TYPES_DIR, 'triage.ts'), 'utf-8');
+    expect(content).toContain('TriageRecord');
+    expect(content).toContain('TriageAction');
+    expect(content).toContain('TriageStatus');
+    expect(content).toContain("from '@kynetic-ai/shared'");
+  });
+
+  it('snapshot types should re-export Convention and export types', async () => {
+    const content = await readFile(join(TYPES_DIR, 'snapshot.ts'), 'utf-8');
+    expect(content).toContain('Convention');
+    expect(content).toContain('ExportedTask');
+    expect(content).toContain('ExportedItem');
+    expect(content).toContain('KspecSnapshot');
+    expect(content).toContain("from '@kynetic-ai/shared'");
+  });
+});

--- a/tests/web-ui-triage.test.ts
+++ b/tests/web-ui-triage.test.ts
@@ -227,31 +227,18 @@ describe('Triage API Client', () => {
 });
 
 describe('Triage Types', () => {
-  it('should define TriageRecord, TriageStatus, and TriageAction types', async () => {
+  it('should re-export triage types from @kynetic-ai/shared', async () => {
     const content = await readFile(TYPES_PATH, 'utf-8');
 
-    expect(content).toContain('export type TriageStatus');
-    expect(content).toContain('export type TriageAction');
-    expect(content).toContain('export interface TriageRecord');
+    // Types are re-exported from shared package, not defined locally
+    expect(content).toContain("from '@kynetic-ai/shared'");
+    expect(content).toContain('TriageStatus');
+    expect(content).toContain('TriageAction');
+    expect(content).toContain('TriageRecord');
 
-    // Status values
-    expect(content).toContain("'pending'");
-    expect(content).toContain("'triaged'");
-    expect(content).toContain("'acted_on'");
-
-    // Action values
-    expect(content).toContain("'promote'");
-    expect(content).toContain("'delete'");
-    expect(content).toContain("'defer'");
-    expect(content).toContain("'spec-gap'");
-    expect(content).toContain("'duplicate'");
-
-    // Record fields
-    expect(content).toContain('inbox_ref');
-    expect(content).toContain('item_snapshot');
-    expect(content).toContain('evidence_refs');
-    expect(content).toContain('override_reasoning');
-    expect(content).toContain('override_by');
+    // Should NOT define local interfaces or type aliases
+    expect(content).not.toMatch(/^export interface /m);
+    expect(content).not.toMatch(/^export type \w+ =/m);
   });
 });
 


### PR DESCRIPTION
## Summary
- Added 9 missing types to `@kynetic-ai/shared` (Convention, TriageStatus, TriageAction, TriageRecord, ExportedTask, ExportedItem, InheritedAC, ExportedValidation, KspecSnapshot, ExportedProject)
- Replaced `packages/web-ui/src/lib/types/triage.ts` and `snapshot.ts` with re-exports from `@kynetic-ai/shared` instead of manual type mirrors
- Added static analysis test (`web-ui-shared-types.test.ts`) that enforces no local interface/type definitions in the web-ui types directory, preventing future drift

## Test plan
- [x] All 3196 tests pass (net +1 from new test file)
- [x] svelte-check passes (53 pre-existing errors, 0 new)
- [x] Shared package builds cleanly
- [x] New test verifies types files only re-export from shared
- [x] Existing web-ui-triage test updated for re-export pattern

Task: @task-deduplicate-web-ui-types

🤖 Generated with [Claude Code](https://claude.com/claude-code)