### PR TITLE
fix: make --force bypass all state checks in task complete

### DIFF
--- a/src/cli/commands/task.ts
+++ b/src/cli/commands/task.ts
@@ -1182,7 +1182,7 @@ Examples:
     .option("--skip-review", "Skip review requirement (requires --reason)")
     .option(
       "--force",
-      "Force completion even if blocked (AC: @task-commands ac-1)",
+      "Force completion from any state (bypasses submit requirement)",
     )
     .option("--no-sync", "Skip syncing spec implementation status")
     .addHelpText(
@@ -1190,6 +1190,7 @@ Examples:
       `
 Examples:
   $ kspec task complete @task-slug --reason "Merged in PR #123"
+  $ kspec task complete @task-slug --force --reason "Design task, no code to review"
   $ kspec task complete --refs @task1 @task2 --reason "Batch completion"`,
     )
     .action(async (ref: string | undefined, options) => {
@@ -1229,13 +1230,11 @@ Examples:
                 };
               }
 
-              // AC: @task-commands ac-1 - Allow --force to bypass blocked state
-              // Handle blocked task with --force before other checks
-              const forcingBlockedTask =
-                foundTask.status === "blocked" && options.force;
+              // AC: @task-commands ac-1 - Allow --force to bypass all state checks
+              const forcingCompletion = options.force;
 
               // AC: @spec-completion-enforcement ac-7 - Allow skip-review bypass
-              if (!options.skipReview && !forcingBlockedTask) {
+              if (!options.skipReview && !forcingCompletion) {
                 // AC: @spec-completion-enforcement ac-2
                 if (foundTask.status === "in_progress") {
                   return {
@@ -1290,11 +1289,23 @@ Examples:
                 taskNotes = [...taskNotes, skipNote];
               }
 
-              // AC: @task-commands ac-1 - Document force completion of blocked task
-              if (forcingBlockedTask) {
-                const blockedBy = foundTask.blocked_by.join("; ");
+              // AC: @task-commands ac-1 - Document force completion from non-standard state
+              const forcedFromNonStandard =
+                forcingCompletion &&
+                foundTask.status !== "pending_review";
+              let forceStateDetail: string | undefined;
+              if (forcedFromNonStandard) {
+                forceStateDetail = `from ${foundTask.status} state`;
+                if (foundTask.status === "blocked") {
+                  const blockedBy = foundTask.blocked_by.join("; ");
+                  forceStateDetail += `. Was blocked by: ${blockedBy || "(dependency-blocked)"}`;
+                }
+                let forceMessage = `Completed with --force ${forceStateDetail}`;
+                if (options.reason) {
+                  forceMessage += `. Reason: ${options.reason}`;
+                }
                 const forceNote = createNote(
-                  `Completed with --force despite blocked state. Was blocked by: ${blockedBy || "(dependency-blocked)"}${options.reason ? `. Reason: ${options.reason}` : ""}`,
+                  forceMessage,
                   getAuthor(ctx.config?.identity?.author),
                 );
                 taskNotes = [...taskNotes, forceNote];
@@ -1362,11 +1373,10 @@ Examples:
                 }
               }
 
-              // AC: @task-commands ac-1 - Show warning when force-completing blocked task
+              // AC: @task-commands ac-1 - Show warning when force-completing from non-standard state
               let warningMsg: string | undefined;
-              if (forcingBlockedTask) {
-                const blockedBy = foundTask.blocked_by.join("; ");
-                warningMsg = `Task was blocked by: ${blockedBy || "(dependency-blocked)"}`;
+              if (forcedFromNonStandard) {
+                warningMsg = `Task was force-completed ${forceStateDetail}`;
                 if (!isJsonMode()) {
                   warn(warningMsg);
                 }
@@ -1376,7 +1386,7 @@ Examples:
                 success: true,
                 message: `Completed task: ${index.shortUlid(updatedTask._ulid)}`,
                 data: updatedTask,
-                ...(forcingBlockedTask && { warning: warningMsg }),
+                ...(warningMsg && { warning: warningMsg }),
               };
             } catch (err) {
               return {

--- a/tests/task-completion-enforcement.test.ts
+++ b/tests/task-completion-enforcement.test.ts
@@ -140,7 +140,7 @@ describe('Integration: task completion enforcement', () => {
       n.content.includes('--force')
     );
     expect(forceNote).toBeTruthy();
-    expect(forceNote?.content).toContain('blocked');
+    expect(forceNote?.content).toContain('blocked state');
     expect(forceNote?.content).toContain('Waiting for API');
   });
 
@@ -165,6 +165,159 @@ describe('Integration: task completion enforcement', () => {
     expect(result.success).toBe(true);
     expect(result.results[0].status).toBe('success');
     expect(result.results[0].warning).toContain('Dependency missing');
+  });
+
+  // AC: @task-commands ac-1 - Force from in_progress bypasses submit requirement
+  it('should complete in_progress task with --force flag', () => {
+    // Start a task (in_progress)
+    kspec('task start @test-task-pending', tempDir);
+
+    const taskData = kspecJson<{ status: string }>(
+      'task get @test-task-pending',
+      tempDir
+    );
+    expect(taskData.status).toBe('in_progress');
+
+    // Complete with --force should succeed
+    const { stdout, stderr, exitCode } = kspecWithStatus(
+      'task complete @test-task-pending --force --reason "Design task, no code to review"',
+      tempDir
+    );
+    expect(exitCode).toBe(0);
+    const output = stdout + stderr;
+    expect(output).toContain('Completed task');
+    expect(output).toContain('in_progress'); // Warning about prior state
+
+    // Verify completed and note documents force
+    const afterComplete = kspecJson<{
+      status: string;
+      closed_reason: string | null;
+      notes: Array<{ content: string }>;
+    }>('task get @test-task-pending', tempDir);
+    expect(afterComplete.status).toBe('completed');
+    expect(afterComplete.closed_reason).toBe('Design task, no code to review');
+
+    const forceNote = afterComplete.notes.find((n) =>
+      n.content.includes('--force')
+    );
+    expect(forceNote).toBeTruthy();
+    expect(forceNote?.content).toContain('in_progress state');
+  });
+
+  // AC: @task-commands ac-1 - Force from pending bypasses start+submit requirement
+  it('should complete pending task with --force flag', () => {
+    // Task starts in pending
+    const taskData = kspecJson<{ status: string }>(
+      'task get @test-task-pending',
+      tempDir
+    );
+    expect(taskData.status).toBe('pending');
+
+    // Complete with --force should succeed
+    const { stdout, stderr, exitCode } = kspecWithStatus(
+      'task complete @test-task-pending --force --reason "Already implemented elsewhere"',
+      tempDir
+    );
+    expect(exitCode).toBe(0);
+    expect(stdout + stderr).toContain('Completed task');
+
+    // Verify completed
+    const afterComplete = kspecJson<{
+      status: string;
+      closed_reason: string | null;
+      notes: Array<{ content: string }>;
+    }>('task get @test-task-pending', tempDir);
+    expect(afterComplete.status).toBe('completed');
+
+    const forceNote = afterComplete.notes.find((n) =>
+      n.content.includes('--force')
+    );
+    expect(forceNote).toBeTruthy();
+    expect(forceNote?.content).toContain('pending state');
+  });
+
+  // AC: @task-commands ac-1 - Force from cancelled bypasses reset requirement
+  it('should complete cancelled task with --force flag', () => {
+    kspec('task cancel @test-task-pending --reason "No longer needed"', tempDir);
+
+    const taskData = kspecJson<{ status: string }>(
+      'task get @test-task-pending',
+      tempDir
+    );
+    expect(taskData.status).toBe('cancelled');
+
+    // Complete with --force should succeed
+    const { stdout, stderr, exitCode } = kspecWithStatus(
+      'task complete @test-task-pending --force --reason "Actually done"',
+      tempDir
+    );
+    expect(exitCode).toBe(0);
+    expect(stdout + stderr).toContain('Completed task');
+
+    // Verify completed
+    const afterComplete = kspecJson<{
+      status: string;
+      notes: Array<{ content: string }>;
+    }>('task get @test-task-pending', tempDir);
+    expect(afterComplete.status).toBe('completed');
+
+    const forceNote = afterComplete.notes.find((n) =>
+      n.content.includes('--force')
+    );
+    expect(forceNote).toBeTruthy();
+    expect(forceNote?.content).toContain('cancelled state');
+  });
+
+  // AC: @task-commands ac-1 - Force does NOT bypass already-completed check
+  it('should still error when force-completing already completed task', () => {
+    kspec('task start @test-task-pending', tempDir);
+    kspec('task submit @test-task-pending', tempDir);
+    kspec('task complete @test-task-pending --reason "Done"', tempDir);
+
+    const taskData = kspecJson<{ status: string }>(
+      'task get @test-task-pending',
+      tempDir
+    );
+    expect(taskData.status).toBe('completed');
+
+    // --force should NOT bypass already-completed
+    const { stdout, stderr, exitCode } = kspecWithStatus(
+      'task complete @test-task-pending --force --reason "Done again"',
+      tempDir
+    );
+    expect(exitCode).toBe(1);
+    expect(stdout + stderr).toContain('Task is already completed');
+  });
+
+  // AC: @task-commands ac-1 - Force from pending_review adds no extra note
+  it('should not add force note when --force used on pending_review task', () => {
+    kspec('task start @test-task-pending', tempDir);
+    kspec('task submit @test-task-pending', tempDir);
+
+    const taskData = kspecJson<{ status: string }>(
+      'task get @test-task-pending',
+      tempDir
+    );
+    expect(taskData.status).toBe('pending_review');
+
+    // --force on pending_review is a no-op (already valid state)
+    const { exitCode } = kspecWithStatus(
+      'task complete @test-task-pending --force --reason "Reviewed and merged"',
+      tempDir
+    );
+    expect(exitCode).toBe(0);
+
+    const afterComplete = kspecJson<{
+      status: string;
+      notes: Array<{ content: string }>;
+    }>('task get @test-task-pending', tempDir);
+    expect(afterComplete.status).toBe('completed');
+
+    // Should NOT have a force note since pending_review is the normal path
+    const forceNote = afterComplete.notes.find((n) =>
+      n.content.includes('--force')
+    );
+    expect(forceNote).toBeFalsy();
   });
 
   // AC: @spec-completion-enforcement ac-5


### PR DESCRIPTION
## Summary
- `--force` flag on `task complete` now bypasses **all** state checks (in_progress, pending, cancelled, blocked), not just blocked
- Enables completing non-code tasks (design, triage, research) without a meaningless submit step
- Force-completing from `pending_review` is a no-op (already valid state); already-completed tasks still error
- Adds note and warning documenting prior state when `--force` bypasses a non-standard state
- Consolidated duplicated force-state logic into single computation

## Test plan
- [x] 5 new tests: force from in_progress, pending, cancelled, already-completed (error), pending_review (no-op)
- [x] Existing blocked --force tests updated and still pass
- [x] Full test suite: 3225 tests pass, 0 failures
- [x] Local review: no MUST-FIX issues

Task: @01KJ4SM9

🤖 Generated with [Claude Code](https://claude.com/claude-code)