### PR TITLE
fix: honor spec_ref on manual tasks in plan import

### DIFF
--- a/src/cli/commands/plan-import.ts
+++ b/src/cli/commands/plan-import.ts
@@ -549,7 +549,7 @@ async function importPlan(
         info(`Would create manual task: @${uniqueSlug}`);
         result.createdTasks.push(`@${uniqueSlug}`);
       } else {
-        // AC: @plan-import ac-27 - Manual tasks have plan_ref but no spec_ref
+        // AC: @plan-import ac-27 - Manual tasks have plan_ref; spec_ref honored if provided
         const taskInput: TaskInput = {
           title: taskDef.title,
           type: "task",
@@ -559,6 +559,7 @@ async function importPlan(
           tags: taskDef.tags || [],
           depends_on: [],
           notes: [],
+          ...(taskDef.spec_ref ? { spec_ref: normalizeRefInput(taskDef.spec_ref) } : {}),
         };
 
         if (taskDef.description) {

--- a/src/parser/plan-document.ts
+++ b/src/parser/plan-document.ts
@@ -38,6 +38,7 @@ export const PlanTaskSchema = z.object({
   priority: z.number().optional(),
   description: z.string().optional(),
   tags: z.array(z.string()).optional(),
+  spec_ref: z.string().optional(),
 });
 
 export type PlanTask = z.infer<typeof PlanTaskSchema>;

--- a/tests/cli-plan-import.test.ts
+++ b/tests/cli-plan-import.test.ts
@@ -776,6 +776,85 @@ derive_from_specs: true
     expect(manualTask!.tags).toContain("manual");
   });
 
+  // AC: @plan-import ac-27 — manual task with explicit spec_ref honors the ref
+  it("should honor spec_ref on manual tasks when explicitly provided", async () => {
+    const planPath = path.join(tempDir, "test-plan.md");
+    await fs.writeFile(
+      planPath,
+      `# Spec Ref Plan
+
+## Specs
+
+\`\`\`yaml
+- title: Target Spec
+  slug: target-spec
+\`\`\`
+
+## Tasks
+
+\`\`\`yaml
+- title: Manual With Spec Ref
+  slug: manual-with-ref
+  spec_ref: "@target-spec"
+\`\`\`
+`,
+    );
+
+    kspec(`plan import "${planPath}" --module @test-core`, tempDir);
+
+    const tasks = kspecJson<
+      Array<{
+        title: string;
+        spec_ref?: string;
+        plan_ref: string;
+      }>
+    >("task list --json", tempDir);
+
+    const manualTask = tasks.find((t) => t.title === "Manual With Spec Ref");
+    expect(manualTask).toBeDefined();
+    expect(manualTask!.spec_ref).toBe("@target-spec");
+    expect(manualTask!.plan_ref).toBe("@plan-spec-ref-plan");
+  });
+
+  // AC: @plan-import ac-27 — manual task spec_ref is normalized with @ prefix
+  it("should normalize spec_ref on manual tasks (add @ prefix)", async () => {
+    const planPath = path.join(tempDir, "test-plan.md");
+    await fs.writeFile(
+      planPath,
+      `# Normalize Plan
+
+## Specs
+
+\`\`\`yaml
+- title: Norm Spec
+  slug: norm-spec
+\`\`\`
+
+## Tasks
+
+\`\`\`yaml
+- title: Manual Bare Ref
+  slug: manual-bare-ref
+  spec_ref: norm-spec
+\`\`\`
+`,
+    );
+
+    kspec(`plan import "${planPath}" --module @test-core`, tempDir);
+
+    const tasks = kspecJson<
+      Array<{
+        title: string;
+        spec_ref?: string;
+      }>
+    >("task list --json", tempDir);
+
+    const manualTask = tasks.find((t) => t.title === "Manual Bare Ref");
+    expect(manualTask).toBeDefined();
+    // Should be normalized with @ prefix even though YAML said "norm-spec"
+    expect(manualTask!.spec_ref).toBe("@norm-spec");
+  });
+
   // AC: @plan-import ac-28
   it("should make plan ref resolvable in kspec commands", async () => {
     const planPath = path.join(tempDir, "test-plan.md");


### PR DESCRIPTION
## Summary
- Added `spec_ref` field to `PlanTaskSchema` so manual tasks in plan YAML can specify a spec reference
- Updated manual task creation path in `plan-import.ts` to read and normalize `spec_ref` when provided
- Updated AC ac-27 wording to reflect that explicit `spec_ref` is now honored

## Test plan
- [x] Manual task with explicit `spec_ref` — verified spec_ref is preserved on created task
- [x] Manual task with bare ref (no `@` prefix) — verified normalization adds `@` prefix
- [x] Existing test for manual tasks without `spec_ref` — verified no regression (only plan_ref set)
- [x] Full test suite passes (3227 tests)

Task: @01KJ4SMB
Spec: @plan-import

🤖 Generated with [Claude Code](https://claude.com/claude-code)