### PR TITLE
fix: handle phased tool call events from ACP SDK 0.14+

### DIFF
--- a/src/cli/commands/session.ts
+++ b/src/cli/commands/session.ts
@@ -42,6 +42,7 @@ import {
   computeTimePeriodStats,
   listSessions,
   searchSessionEvents,
+  deduplicatePhasedToolCalls,
 } from "../../sessions/store.js";
 import type { SessionEvent, SessionStatus } from "../../sessions/types.js";
 import {
@@ -1679,7 +1680,9 @@ async function sessionLogShowAction(
     // AC: @session-log-show ac-3, ac-4, ac-5 - Event timeline
     let events: SessionEvent[] | null = null;
     if (options.events) {
-      let allEvents = await readEvents(ctx.specDir, sessionId);
+      let allEvents = deduplicatePhasedToolCalls(
+        await readEvents(ctx.specDir, sessionId),
+      );
 
       // AC: @session-log-show ac-4 - Filter by type
       if (options.type) {

--- a/src/ralph/events.ts
+++ b/src/ralph/events.ts
@@ -689,6 +689,31 @@ export function createTranslator(): RalphTranslator {
         const pending = state.pendingTools.get(toolCallId);
         const tool = pending?.tool || extractToolName(u);
 
+        // Check if rawInput arrived with this update (phased event pattern)
+        const newInput = u.rawInput || u.input || u.params;
+        if (newInput && pending) {
+          const oldSummary = getToolSummary(pending.tool, pending.input);
+          const newSummary = getToolSummary(tool, newInput);
+          if (newSummary && !oldSummary) {
+            // Input became available - update pending entry and emit summary
+            pending.input = newInput;
+            pending.tool = tool;
+            return {
+              type: "tool_update",
+              timestamp,
+              data: {
+                kind: "tool_update",
+                toolCallId,
+                tool,
+                status: "pending" as const,
+                summary: newSummary,
+              },
+            };
+          }
+          // Update the pending entry even if summary didn't change
+          pending.input = newInput;
+        }
+
         // Non-terminal status update
         if (
           status === "pending" ||

--- a/src/sessions/store.ts
+++ b/src/sessions/store.ts
@@ -342,6 +342,49 @@ export async function readEvents(
 }
 
 /**
+ * Deduplicate phased tool_call events.
+ *
+ * ACP SDK 0.14+ sends tool calls in two phases: first with empty rawInput,
+ * then with populated rawInput. This merges them by keeping only the version
+ * with populated rawInput per toolCallId.
+ */
+export function deduplicatePhasedToolCalls(
+  events: SessionEvent[],
+): SessionEvent[] {
+  // First pass: find toolCallIds that have a populated rawInput version
+  const populatedToolCalls = new Map<string, number>(); // toolCallId → index
+  for (let i = 0; i < events.length; i++) {
+    const event = events[i];
+    if (event.type !== "session.update") continue;
+    const data = event.data as { update?: { sessionUpdate?: string; toolCallId?: string; tool_call_id?: string; id?: string; rawInput?: Record<string, unknown> } } | null;
+    const update = data?.update;
+    if (update?.sessionUpdate !== "tool_call") continue;
+    const toolCallId = update.toolCallId || update.tool_call_id || update.id;
+    if (!toolCallId) continue;
+    const rawInput = update.rawInput;
+    const hasContent = rawInput && Object.keys(rawInput).length > 0;
+    if (hasContent) {
+      populatedToolCalls.set(toolCallId, i);
+    } else if (!populatedToolCalls.has(toolCallId)) {
+      // First (empty) version - track it in case no populated version exists
+      populatedToolCalls.set(toolCallId, i);
+    }
+  }
+
+  // Second pass: keep only the best version per toolCallId
+  return events.filter((event, i) => {
+    if (event.type !== "session.update") return true;
+    const data = event.data as { update?: { sessionUpdate?: string; toolCallId?: string; tool_call_id?: string; id?: string; rawInput?: Record<string, unknown> } } | null;
+    const update = data?.update;
+    if (update?.sessionUpdate !== "tool_call") return true;
+    const toolCallId = update.toolCallId || update.tool_call_id || update.id;
+    if (!toolCallId) return true;
+    // Keep this event only if it's the best version (populated or only version)
+    return populatedToolCalls.get(toolCallId) === i;
+  });
+}
+
+/**
  * Read events within a time range.
  *
  * @param specDir - The .kspec directory path
@@ -990,6 +1033,8 @@ export async function computeToolUsageStats(
       const content = await fsPromises.readFile(eventsPath, "utf-8");
       if (!content.trim()) continue;
       const lines = content.trim().split("\n");
+      // Track seen toolCallIds to deduplicate phased events
+      const seenToolCallIds = new Set<string>();
       for (const line of lines) {
         // Quick pre-filter: only parse lines that might be tool_call events
         if (!line.includes('"tool_call"')) continue;
@@ -998,6 +1043,10 @@ export async function computeToolUsageStats(
           if (event?.type === "session.update") {
             const update = event?.data?.update;
             if (update?.sessionUpdate === "tool_call") {
+              // Deduplicate phased tool_call events by toolCallId
+              const toolCallId = update?.toolCallId || update?.tool_call_id || update?.id;
+              if (toolCallId && seenToolCallIds.has(toolCallId)) continue;
+              if (toolCallId) seenToolCallIds.add(toolCallId);
               const toolName = update?._meta?.claudeCode?.toolName || "unknown";
               toolCounts[toolName] = (toolCounts[toolName] || 0) + 1;
               totalToolCalls++;
@@ -1258,6 +1307,8 @@ export async function searchSessionEvents(
 
     const matches: SearchMatch[] = [];
     const lines = content.trim().split("\n");
+    // Track seen tool_call IDs to skip phased duplicates
+    const seenToolCallIds = new Set<string>();
 
     for (const line of lines) {
       if (totalMatches >= limit) break;
@@ -1270,6 +1321,18 @@ export async function searchSessionEvents(
 
         // AC: @session-log-search ac-2 - Filter by event type
         if (options.eventType && event.type !== options.eventType) continue;
+
+        // Deduplicate phased tool_call events
+        if (event?.type === "session.update") {
+          const update = event?.data?.update;
+          if (update?.sessionUpdate === "tool_call") {
+            const toolCallId = update?.toolCallId || update?.tool_call_id || update?.id;
+            if (toolCallId) {
+              if (seenToolCallIds.has(toolCallId)) continue;
+              seenToolCallIds.add(toolCallId);
+            }
+          }
+        }
 
         // Verify match in stringified data (not just line, in case pattern appears in metadata)
         const dataStr = JSON.stringify(event.data);

--- a/tests/ralph.test.ts
+++ b/tests/ralph.test.ts
@@ -1234,6 +1234,97 @@ describe('ralph event translator', () => {
       expect(data.output).toContain('success');
       expect(data.output).not.toContain('[object Object]');
     });
+
+    it('emits summary when tool_call_update arrives with populated rawInput (phased pattern)', () => {
+      const translator = createTranslator();
+
+      // Phase 1: tool_call with empty rawInput
+      const event1 = translator.translate({
+        sessionUpdate: 'tool_call',
+        toolCallId: 'toolu_phased_update',
+        rawInput: {},
+        _meta: { claudeCode: { toolName: 'Bash' } },
+      } as SessionUpdate);
+
+      expect(event1).not.toBeNull();
+      expect(event1!.type).toBe('tool_start');
+      expect((event1!.data as { summary: string }).summary).toBe('');
+
+      // Phase 2: tool_call_update with populated rawInput (the ACP 0.14+ pattern)
+      const event2 = translator.translate({
+        sessionUpdate: 'tool_call_update',
+        toolCallId: 'toolu_phased_update',
+        rawInput: { command: 'git status' },
+        _meta: { claudeCode: { toolName: 'Bash' } },
+      } as SessionUpdate);
+
+      // Should emit tool_update with summary from newly-available rawInput
+      expect(event2).not.toBeNull();
+      expect(event2!.type).toBe('tool_update');
+      expect((event2!.data as { summary: string }).summary).toBe('git status');
+    });
+
+    it('does not emit summary from tool_call_update when pending already had summary', () => {
+      const translator = createTranslator();
+
+      // Phase 1: tool_call WITH rawInput (already has summary)
+      translator.translate({
+        sessionUpdate: 'tool_call',
+        toolCallId: 'toolu_already_has',
+        rawInput: { command: 'npm test' },
+        _meta: { claudeCode: { toolName: 'Bash' } },
+      } as SessionUpdate);
+
+      // Phase 2: tool_call_update with same rawInput
+      const event2 = translator.translate({
+        sessionUpdate: 'tool_call_update',
+        toolCallId: 'toolu_already_has',
+        rawInput: { command: 'npm test' },
+        status: 'running',
+        _meta: { claudeCode: { toolName: 'Bash' } },
+      } as SessionUpdate);
+
+      // Should emit a normal status update, not a summary update
+      expect(event2).not.toBeNull();
+      expect(event2!.type).toBe('tool_update');
+      expect((event2!.data as { summary?: string }).summary).toBeUndefined();
+      expect((event2!.data as { status: string }).status).toBe('running');
+    });
+
+    it('handles full phased lifecycle: empty tool_call → populated tool_call_update → completed', () => {
+      const translator = createTranslator();
+
+      // Phase 1: tool_call with empty rawInput
+      const start = translator.translate({
+        sessionUpdate: 'tool_call',
+        toolCallId: 'toolu_full_lifecycle',
+        rawInput: {},
+        _meta: { claudeCode: { toolName: 'Read' } },
+      } as SessionUpdate);
+      expect(start!.type).toBe('tool_start');
+      expect((start!.data as { summary: string }).summary).toBe('');
+
+      // Phase 2: tool_call_update with populated rawInput
+      const update = translator.translate({
+        sessionUpdate: 'tool_call_update',
+        toolCallId: 'toolu_full_lifecycle',
+        rawInput: { file_path: '/src/main.ts' },
+        _meta: { claudeCode: { toolName: 'Read' } },
+      } as SessionUpdate);
+      expect(update!.type).toBe('tool_update');
+      expect((update!.data as { summary: string }).summary).toBe('main.ts');
+
+      // Phase 3: tool_call_update completed
+      const result = translator.translate({
+        sessionUpdate: 'tool_call_update',
+        toolCallId: 'toolu_full_lifecycle',
+        status: 'completed',
+        rawOutput: [{ type: 'text', text: 'file contents' }],
+        _meta: { claudeCode: { toolName: 'Read' } },
+      } as SessionUpdate);
+      expect(result!.type).toBe('tool_result');
+      expect((result!.data as { output: string }).output).toBe('file contents');
+    });
   });
 });
 

--- a/tests/session-log-stats.test.ts
+++ b/tests/session-log-stats.test.ts
@@ -17,6 +17,7 @@ import {
   computeSessionLogStats,
   computeToolUsageStats,
   computeTimePeriodStats,
+  deduplicatePhasedToolCalls,
   type SessionLogSummary,
   type SessionLogStats,
   type ToolUsageStats,
@@ -237,6 +238,35 @@ describe('computeToolUsageStats', () => {
     // Custom limit
     const limited = await computeToolUsageStats(testDir, [sessionId], 5);
     expect(limited).toHaveLength(5);
+  });
+
+  it('should deduplicate phased tool_call events by toolCallId', async () => {
+    const sessionId = testUlid('SESS', 2);
+    await createSession(testDir, {
+      id: sessionId,
+      agent_type: 'claude-agent-acp',
+    });
+
+    const eventsPath = path.join(testDir, 'sessions', sessionId, 'events.jsonl');
+    const events = [
+      // Phase 1: Bash tool_call with empty rawInput
+      { type: 'session.update', data: { update: { sessionUpdate: 'tool_call', toolCallId: 'toolu_001', rawInput: {}, _meta: { claudeCode: { toolName: 'Bash' } } } } },
+      // Phase 2: Same Bash tool_call with populated rawInput (phased duplicate)
+      { type: 'session.update', data: { update: { sessionUpdate: 'tool_call', toolCallId: 'toolu_001', rawInput: { command: 'npm test' }, _meta: { claudeCode: { toolName: 'Bash' } } } } },
+      // Different tool_call (not a duplicate)
+      { type: 'session.update', data: { update: { sessionUpdate: 'tool_call', toolCallId: 'toolu_002', rawInput: { file_path: '/src/main.ts' }, _meta: { claudeCode: { toolName: 'Read' } } } } },
+      // Another Bash with no duplicate
+      { type: 'session.update', data: { update: { sessionUpdate: 'tool_call', toolCallId: 'toolu_003', rawInput: { command: 'git status' }, _meta: { claudeCode: { toolName: 'Bash' } } } } },
+    ].map((e, i) => JSON.stringify({ ts: Date.now(), seq: i, session_id: sessionId, ...e }));
+    await fs.writeFile(eventsPath, events.join('\n') + '\n');
+
+    const toolUsage = await computeToolUsageStats(testDir, [sessionId]);
+
+    // Should count 3 unique tool calls (not 4 with the phased duplicate)
+    const totalCount = toolUsage.reduce((sum, t) => sum + t.count, 0);
+    expect(totalCount).toBe(3);
+    expect(toolUsage.find(t => t.tool_name === 'Bash')?.count).toBe(2);
+    expect(toolUsage.find(t => t.tool_name === 'Read')?.count).toBe(1);
   });
 });
 
@@ -674,5 +704,46 @@ describe('kspec session log stats (CLI)', () => {
   it('should exit with code 0 when no sessions match', () => {
     const result = kspec('session log stats --agent nonexistent', tempDir);
     expect(result.exitCode).toBe(0);
+  });
+});
+
+describe('deduplicatePhasedToolCalls', () => {
+  it('should remove empty-input duplicates when populated version exists', () => {
+    const events = [
+      // tool_call with empty rawInput
+      { ts: 1000, seq: 0, type: 'session.update' as const, session_id: 'sess1', data: { update: { sessionUpdate: 'tool_call', toolCallId: 'toolu_001', rawInput: {}, _meta: { claudeCode: { toolName: 'Bash' } } } } },
+      // Same tool_call with populated rawInput
+      { ts: 1001, seq: 1, type: 'session.update' as const, session_id: 'sess1', data: { update: { sessionUpdate: 'tool_call', toolCallId: 'toolu_001', rawInput: { command: 'npm test' }, _meta: { claudeCode: { toolName: 'Bash' } } } } },
+      // Different tool_call (should be kept)
+      { ts: 1002, seq: 2, type: 'session.update' as const, session_id: 'sess1', data: { update: { sessionUpdate: 'tool_call', toolCallId: 'toolu_002', rawInput: { file_path: '/src/main.ts' }, _meta: { claudeCode: { toolName: 'Read' } } } } },
+      // Non tool_call event (should be kept)
+      { ts: 1003, seq: 3, type: 'session.update' as const, session_id: 'sess1', data: { update: { sessionUpdate: 'agent_thought' } } },
+    ];
+
+    const result = deduplicatePhasedToolCalls(events);
+    expect(result).toHaveLength(3);
+    // The populated version should be kept
+    expect((result[0].data as any).update.rawInput.command).toBe('npm test');
+    // Other events should be unchanged
+    expect((result[1].data as any).update.toolCallId).toBe('toolu_002');
+    expect((result[2].data as any).update.sessionUpdate).toBe('agent_thought');
+  });
+
+  it('should keep single tool_call events (no phased duplicate)', () => {
+    const events = [
+      { ts: 1000, seq: 0, type: 'session.update' as const, session_id: 'sess1', data: { update: { sessionUpdate: 'tool_call', toolCallId: 'toolu_001', rawInput: { command: 'npm test' }, _meta: { claudeCode: { toolName: 'Bash' } } } } },
+    ];
+
+    const result = deduplicatePhasedToolCalls(events);
+    expect(result).toHaveLength(1);
+  });
+
+  it('should keep empty-input tool_call when no populated version exists', () => {
+    const events = [
+      { ts: 1000, seq: 0, type: 'session.update' as const, session_id: 'sess1', data: { update: { sessionUpdate: 'tool_call', toolCallId: 'toolu_001', rawInput: {}, _meta: { claudeCode: { toolName: 'Bash' } } } } },
+    ];
+
+    const result = deduplicatePhasedToolCalls(events);
+    expect(result).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Summary

- **Translator**: `tool_call_update` with newly-populated `rawInput` now emits summary, so ralph display shows tool details (command names, file paths)
- **Stats**: `computeToolUsageStats` deduplicates by `toolCallId`, preventing double-counting of phased events
- **Session display/search**: `deduplicatePhasedToolCalls` utility filters phased duplicates in session show and search

## Context

ACP SDK 0.14+ sends tool calls in two phases: first `tool_call` with empty `rawInput`, then `tool_call_update` with populated `rawInput`. This caused missing tool details in ralph output, doubled tool usage stats, and duplicate entries in session logs.

## Test plan

- [x] 3 new translator tests: phased summary emission, guard for already-populated, full lifecycle
- [x] 1 stats dedup test: phased events count as 1 tool call
- [x] 3 `deduplicatePhasedToolCalls` utility tests: populated replaces empty, single event passthrough, empty-only retention
- [x] Full test suite passes (3234 tests)

Task: @01KJ65J2

🤖 Generated with [Claude Code](https://claude.com/claude-code)