### PR TITLE
test: strengthen batch malformed JSON error tests

### DIFF
--- a/tests/batch-exec-engine.test.ts
+++ b/tests/batch-exec-engine.test.ts
@@ -447,23 +447,42 @@ describe("batch command integration", () => {
 
   // AC: @batch-exec ac-invalid-json
   // AC: @trait-semantic-exit-codes ac-2 — validation error exits non-zero
-  it("rejects malformed JSON", () => {
+  it("rejects malformed JSON with error details including position info", () => {
     const result = kspec(
-      `batch --commands 'not valid json'`,
+      `batch --commands '{bad json}'`,
       tempDir,
       { expectFail: true },
     );
-    expect(result.exitCode).not.toBe(0);
+    expect(result.exitCode).toBe(1);
+    // Must surface error message (not silent), including position info
+    expect(result.stderr).toContain("Invalid JSON");
+    expect(result.stderr).toMatch(/position \d+/i);
+  });
+
+  // AC: @batch-exec ac-invalid-json — JSON mode returns structured error
+  // AC: @trait-json-output ac-3 — error returned as JSON with error field
+  it("returns structured JSON error for malformed JSON in --json mode", () => {
+    const result = kspec(
+      `batch --json --commands '{bad json}'`,
+      tempDir,
+      { expectFail: true },
+    );
+    expect(result.exitCode).toBe(1);
+    const parsed = JSON.parse(result.stdout);
+    expect(parsed.success).toBe(false);
+    expect(parsed.error).toContain("Invalid JSON");
+    expect(parsed.error).toMatch(/position \d+/i);
   });
 
   // AC: @batch-exec ac-empty-batch
-  it("rejects empty batch", () => {
+  it("rejects empty batch with descriptive error", () => {
     const result = kspec(
       `batch --commands '[]'`,
       tempDir,
       { expectFail: true },
     );
-    expect(result.exitCode).not.toBe(0);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toMatch(/at least one command|no commands/i);
   });
 
   // AC: @batch-exec ac-stdin — stdin tested via parseBatchInput in batch-schema.test.ts

--- a/tests/batch-schema.test.ts
+++ b/tests/batch-schema.test.ts
@@ -151,15 +151,26 @@ describe("parseBatchInput", () => {
     expect(result[1].id).toBe("b");
   });
 
-  // AC: parent ac-invalid-json — invalid JSON throws with position info
+  // AC: @batch-exec ac-invalid-json — invalid JSON throws with position info
   it("throws BatchParseError on invalid JSON with position info", async () => {
     await expect(
       parseBatchInput({ type: "inline", json: "{bad json" }),
     ).rejects.toThrow(BatchParseError);
 
+    // Must include "Invalid JSON" label and position info from native parser
     await expect(
       parseBatchInput({ type: "inline", json: "{bad json" }),
-    ).rejects.toThrow(/Invalid JSON/);
+    ).rejects.toThrow(/Invalid JSON.*position \d+/i);
+  });
+
+  // AC: @batch-exec ac-invalid-json — non-array valid JSON is rejected with schema error
+  it("throws BatchParseError on valid JSON that is not an array", async () => {
+    await expect(
+      parseBatchInput({ type: "inline", json: '{"command":"test"}' }),
+    ).rejects.toThrow(BatchParseError);
+    await expect(
+      parseBatchInput({ type: "inline", json: '{"command":"test"}' }),
+    ).rejects.toThrow(/Expected array/);
   });
 
   // AC: parent ac-empty-batch — empty array rejected


### PR DESCRIPTION
## Summary
- Strengthened `ac-invalid-json` tests to verify error message content (position info) rather than just exit code
- Added JSON-mode error test verifying structured `{success, error}` output for malformed JSON
- Added non-array valid JSON schema validation test
- Strengthened empty batch test to verify descriptive error message

The error handling code already works correctly — malformed JSON produces clear error messages with position info in both human and JSON modes. This PR ensures the test suite catches any future regression in error message quality.

## Test plan
- [x] All 3295 tests pass (3 skipped as expected)
- [x] Batch-specific tests: 100 pass (batch-schema + batch-exec-engine)
- [x] Verified manually: `kspec batch --commands '{bad}'` outputs position info
- [x] Verified manually: `kspec batch --json --commands '{bad}'` outputs structured error

Task: @01KJ4T48
Spec: @batch-exec

🤖 Generated with [Claude Code](https://claude.com/claude-code)