### PR TITLE
feat: add session_id to task schema for session-scoped claiming

### DIFF
--- a/src/cli/commands/task.ts
+++ b/src/cli/commands/task.ts
@@ -1100,11 +1100,25 @@ Examples:
           process.exit(EXIT_CODES.VALIDATION_FAILED); // Exit code 4 = invalid state
         }
 
+        // AC: @session-scoped-task-claiming ac-startable - warn if claimed by another session
+        const sessionId = process.env.KSPEC_SESSION_ID || null;
+        if (
+          foundTask.session_id &&
+          sessionId &&
+          foundTask.session_id !== sessionId
+        ) {
+          warn(
+            `Task was claimed by session ${foundTask.session_id.slice(0, 8)}...`,
+          );
+        }
+
         // Update status
+        // AC: @session-scoped-task-claiming ac-stamp, ac-no-env
         const updatedTask: Task = {
           ...foundTask,
           status: "in_progress",
           started_at: new Date().toISOString(),
+          ...(sessionId ? { session_id: sessionId } : {}),
         };
 
         await saveTask(ctx, updatedTask);
@@ -1504,9 +1518,11 @@ Examples:
           getAuthor(ctx.config?.identity?.author),
         );
 
+        // AC: @session-scoped-task-claiming ac-claim-clear
         const updatedTask: Task = {
           ...foundTask,
           status: "needs_work",
+          session_id: null,
           notes: [...foundTask.notes, note],
         };
 
@@ -1584,10 +1600,12 @@ Examples:
           return;
         }
 
+        // AC: @session-scoped-task-claiming ac-claim-clear
         const updatedTask: Task = {
           ...foundTask,
           status: "pending",
           blocked_by: [],
+          session_id: null,
         };
 
         await saveTask(ctx, updatedTask);
@@ -1740,6 +1758,11 @@ Examples:
         if (foundTask.blocked_by.length > 0) {
           updatedTask.blocked_by = [];
           clearedFields.push("blocked_by");
+        }
+        // AC: @session-scoped-task-claiming ac-claim-clear
+        if (foundTask.session_id) {
+          updatedTask.session_id = null;
+          clearedFields.push("session_id");
         }
 
         // AC: @spec-task-reset ac-4 - Add note documenting the reset

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -256,7 +256,12 @@ export function formatTask(
       ? chalk.red(`P${task.priority}`)
       : chalk.gray(`P${task.priority}`);
 
-  let line = `${ref} ${status} ${priority} ${task.title}`;
+  // AC: @session-scoped-task-claiming ac-display
+  const sessionLabel = task.session_id
+    ? chalk.yellow(`[session ${task.session_id.slice(0, 8)}...]`)
+    : "";
+
+  let line = `${ref} ${status} ${priority}${sessionLabel ? ` ${sessionLabel}` : ""} ${task.title}`;
 
   if (verbose && !full) {
     // AC: @task-list-verbose ac-2 - Single verbose (-v) shows current behavior
@@ -422,8 +427,12 @@ export function formatTaskListWithAutomation(
         ? chalk.red(`P${task.priority}`)
         : chalk.gray(`P${task.priority}`);
     const automationLabel = formatAutomationStatus(task.automation);
+    // AC: @session-scoped-task-claiming ac-display
+    const sessionLabel = task.session_id
+      ? chalk.yellow(`[session ${task.session_id.slice(0, 8)}...]`)
+      : "";
 
-    let line = `${ref} ${status} ${priority} ${automationLabel} ${task.title}`;
+    let line = `${ref} ${status} ${priority} ${automationLabel}${sessionLabel ? ` ${sessionLabel}` : ""} ${task.title}`;
 
     if (verbose && !full) {
       if (task.spec_ref) {
@@ -550,6 +559,11 @@ export function formatTaskDetails(
   console.log(
     `${fieldLabels.automation} ${automationColor(automationDisplay)}`,
   );
+
+  // AC: @session-scoped-task-claiming ac-display
+  if (task.session_id) {
+    console.log(`Session:   ${chalk.yellow(task.session_id)}`);
+  }
 
   if (task.description?.trim()) {
     console.log(`\n${sectionHeaders.description}`);

--- a/src/schema/task.ts
+++ b/src/schema/task.ts
@@ -93,6 +93,10 @@ export const TaskSchema = z.object({
   // VCS references
   vcs_refs: z.array(VcsRefSchema).default([]),
 
+  // Session scoping (advisory, not enforced)
+  // AC: @session-scoped-task-claiming ac-schema
+  session_id: z.string().nullable().optional(),
+
   // Timestamps (auto-populated if not provided)
   created_at: DateTimeSchema.default(() => new Date().toISOString()),
   started_at: DateTimeSchema.nullable().optional(),
@@ -154,6 +158,9 @@ export const TaskInputSchema = z.object({
 
   // VCS references
   vcs_refs: z.array(VcsRefSchema).optional(),
+
+  // Session scoping
+  session_id: z.string().nullable().optional(),
 
   // Timestamps
   created_at: DateTimeSchema.optional(),

--- a/tests/session-scoped-task-claiming.test.ts
+++ b/tests/session-scoped-task-claiming.test.ts
@@ -1,0 +1,271 @@
+/**
+ * Integration tests for session-scoped task claiming
+ * AC: @session-scoped-task-claiming
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  kspec,
+  kspecJson,
+  kspecOutput,
+  setupTempFixtures,
+  cleanupTempDir,
+  initGitRepo,
+} from './helpers/cli';
+
+describe('Integration: session-scoped task claiming', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await setupTempFixtures();
+    initGitRepo(tempDir);
+  });
+
+  afterEach(async () => {
+    await cleanupTempDir(tempDir);
+  });
+
+  // AC: @session-scoped-task-claiming ac-schema
+  describe('ac-schema: session_id is optional and backward compatible', () => {
+    it('should load existing tasks without session_id', () => {
+      // Existing fixtures have no session_id field
+      const task = kspecJson<{ status: string; session_id?: string | null }>(
+        'task get @test-task-pending',
+        tempDir,
+      );
+      expect(task.status).toBe('pending');
+      // session_id should be absent or undefined — backward compatible
+      expect(task.session_id).toBeUndefined();
+    });
+
+    it('should accept tasks with session_id set', () => {
+      // Start task with session_id to prove the field is accepted
+      kspec('task start @test-task-pending', tempDir, {
+        env: { KSPEC_SESSION_ID: '01KJ6NFBHNMBABEHHDVEYSPJFR' },
+      });
+      const task = kspecJson<{ status: string; session_id?: string | null }>(
+        'task get @test-task-pending',
+        tempDir,
+      );
+      expect(task.status).toBe('in_progress');
+      expect(task.session_id).toBe('01KJ6NFBHNMBABEHHDVEYSPJFR');
+    });
+  });
+
+  // AC: @session-scoped-task-claiming ac-stamp
+  describe('ac-stamp: task start stamps session_id when env var set', () => {
+    it('should set session_id from KSPEC_SESSION_ID env var', () => {
+      const sessionId = '01KJ6NFBHNMBABEHHDVEYSPJFR';
+      kspec('task start @test-task-pending', tempDir, {
+        env: { KSPEC_SESSION_ID: sessionId },
+      });
+
+      const task = kspecJson<{ session_id?: string | null }>(
+        'task get @test-task-pending',
+        tempDir,
+      );
+      expect(task.session_id).toBe(sessionId);
+    });
+  });
+
+  // AC: @session-scoped-task-claiming ac-no-env
+  describe('ac-no-env: no session_id stamped when env var not set', () => {
+    it('should not set session_id when KSPEC_SESSION_ID is absent', () => {
+      // Explicitly remove KSPEC_SESSION_ID if somehow set
+      const originalEnv = process.env.KSPEC_SESSION_ID;
+      delete process.env.KSPEC_SESSION_ID;
+
+      try {
+        kspec('task start @test-task-pending', tempDir);
+        const task = kspecJson<{ session_id?: string | null }>(
+          'task get @test-task-pending',
+          tempDir,
+        );
+        // session_id should not be set
+        expect(task.session_id).toBeUndefined();
+      } finally {
+        if (originalEnv !== undefined) {
+          process.env.KSPEC_SESSION_ID = originalEnv;
+        }
+      }
+    });
+  });
+
+  // AC: @session-scoped-task-claiming ac-startable
+  describe('ac-startable: warn when starting task claimed by another session', () => {
+    it('should show warning when task has session_id from another session', async () => {
+      // Write a custom tasks file with session_id pre-set on a pending task
+      const fs = await import('node:fs/promises');
+      const path = await import('node:path');
+      const tasksFile = path.join(tempDir, 'project.tasks.yaml');
+      const content = await fs.readFile(tasksFile, 'utf-8');
+
+      // Add session_id to the first pending task
+      const updatedContent = content.replace(
+        'status: pending\n    priority: 2\n    automation: eligible',
+        'status: pending\n    priority: 2\n    automation: eligible\n    session_id: "01KJ6NFBHNMBABEHHDVEYSPJFR"',
+      );
+      await fs.writeFile(tasksFile, updatedContent);
+
+      // Start the task with a different session
+      const result = kspec('task start @test-task-pending', tempDir, {
+        env: { KSPEC_SESSION_ID: '01KJ7AAAAAAAAAAAAAAAAAAAAAA' },
+      });
+
+      // Should contain warning about the other session
+      const combined = result.stdout + result.stderr;
+      expect(combined).toContain('session 01KJ6NFB');
+      expect(combined).toContain('Started task');
+    });
+
+    it('should not warn when same session re-starts a task', async () => {
+      const sessionId = '01KJ6NFBHNMBABEHHDVEYSPJFR';
+
+      // Write a custom tasks file with session_id pre-set to same session
+      const fs = await import('node:fs/promises');
+      const path = await import('node:path');
+      const tasksFile = path.join(tempDir, 'project.tasks.yaml');
+      const content = await fs.readFile(tasksFile, 'utf-8');
+      const updatedContent = content.replace(
+        'status: pending\n    priority: 2\n    automation: eligible',
+        `status: pending\n    priority: 2\n    automation: eligible\n    session_id: "${sessionId}"`,
+      );
+      await fs.writeFile(tasksFile, updatedContent);
+
+      const result = kspec('task start @test-task-pending', tempDir, {
+        env: { KSPEC_SESSION_ID: sessionId },
+      });
+
+      // Should NOT contain warning about session claiming
+      const combined = result.stdout + result.stderr;
+      expect(combined).not.toContain('claimed by session');
+      expect(combined).toContain('Started task');
+    });
+  });
+
+  // AC: @session-scoped-task-claiming ac-display
+  describe('ac-display: session indicator in task list output', () => {
+    it('should show session indicator for tasks with session_id', async () => {
+      // Start a task with a session ID to give it session_id
+      kspec('task start @test-task-pending', tempDir, {
+        env: { KSPEC_SESSION_ID: '01KJ6NFBHNMBABEHHDVEYSPJFR' },
+      });
+
+      // List in-progress tasks (which should include the session indicator)
+      const result = kspecOutput('tasks list --status in_progress', tempDir);
+      expect(result).toContain('[session 01KJ6NFB...]');
+    });
+
+    it('should show session_id in task details', () => {
+      const sessionId = '01KJ6NFBHNMBABEHHDVEYSPJFR';
+      kspec('task start @test-task-pending', tempDir, {
+        env: { KSPEC_SESSION_ID: sessionId },
+      });
+
+      const result = kspecOutput('task get @test-task-pending', tempDir);
+      expect(result).toContain(sessionId);
+    });
+
+    it('should include session_id in JSON output', () => {
+      const sessionId = '01KJ6NFBHNMBABEHHDVEYSPJFR';
+      kspec('task start @test-task-pending', tempDir, {
+        env: { KSPEC_SESSION_ID: sessionId },
+      });
+
+      const task = kspecJson<{ session_id?: string | null }>(
+        'task get @test-task-pending',
+        tempDir,
+      );
+      expect(task.session_id).toBe(sessionId);
+    });
+  });
+
+  // AC: @session-scoped-task-claiming ac-claim-clear
+  describe('ac-claim-clear: session_id cleared on status transitions', () => {
+    it('should clear session_id when task transitions to needs_work', () => {
+      const sessionId = '01KJ6NFBHNMBABEHHDVEYSPJFR';
+
+      // Start with session
+      kspec('task start @test-task-pending', tempDir, {
+        env: { KSPEC_SESSION_ID: sessionId },
+      });
+
+      // Submit
+      kspec('task submit @test-task-pending', tempDir);
+
+      // Kick back to needs_work
+      kspec('task needs-work @test-task-pending --reason "Needs fixes"', tempDir);
+
+      const task = kspecJson<{ status: string; session_id?: string | null }>(
+        'task get @test-task-pending',
+        tempDir,
+      );
+      expect(task.status).toBe('needs_work');
+      expect(task.session_id).toBeNull();
+    });
+
+    it('should clear session_id when task is unblocked to pending', () => {
+      const sessionId = '01KJ6NFBHNMBABEHHDVEYSPJFR';
+
+      // Start with session
+      kspec('task start @test-task-pending', tempDir, {
+        env: { KSPEC_SESSION_ID: sessionId },
+      });
+
+      // Block it
+      kspec('task block @test-task-pending --reason "Waiting on design"', tempDir);
+
+      // Verify session_id exists while blocked (should be preserved from in_progress)
+      const blocked = kspecJson<{ session_id?: string | null }>(
+        'task get @test-task-pending',
+        tempDir,
+      );
+      expect(blocked.session_id).toBe(sessionId);
+
+      // Unblock it
+      kspec('task unblock @test-task-pending', tempDir);
+
+      const task = kspecJson<{ status: string; session_id?: string | null }>(
+        'task get @test-task-pending',
+        tempDir,
+      );
+      expect(task.status).toBe('pending');
+      expect(task.session_id).toBeNull();
+    });
+
+    it('should clear session_id when task is reset to pending', () => {
+      const sessionId = '01KJ6NFBHNMBABEHHDVEYSPJFR';
+
+      // Start with session
+      kspec('task start @test-task-pending', tempDir, {
+        env: { KSPEC_SESSION_ID: sessionId },
+      });
+
+      // Complete the task
+      kspec('task complete @test-task-pending --skip-review --reason "Done"', tempDir);
+
+      // Reset to pending
+      kspec('task reset @test-task-pending', tempDir);
+
+      const task = kspecJson<{ status: string; session_id?: string | null }>(
+        'task get @test-task-pending',
+        tempDir,
+      );
+      expect(task.status).toBe('pending');
+      expect(task.session_id).toBeNull();
+    });
+
+    it('should report session_id in cleared_fields on reset', () => {
+      const sessionId = '01KJ6NFBHNMBABEHHDVEYSPJFR';
+
+      kspec('task start @test-task-pending', tempDir, {
+        env: { KSPEC_SESSION_ID: sessionId },
+      });
+
+      const resetResult = kspecJson<{ cleared_fields: string[] }>(
+        'task reset @test-task-pending',
+        tempDir,
+      );
+      expect(resetResult.cleared_fields).toContain('session_id');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds optional `session_id` field to `TaskSchema` and `TaskInputSchema` for soft advisory session scoping
- `task start` reads `KSPEC_SESSION_ID` env var and stamps the task; warns if claimed by another session
- Session indicator shown in task list (`[session 01KH...]`) and task details
- `session_id` cleared on transitions to `pending` (unblock, reset) and `needs_work`

## Spec

Implements `@session-scoped-task-claiming` (all 6 ACs covered with 13 integration tests)

## Test plan

- [x] ac-schema: Backward compatible — existing tasks without session_id load fine
- [x] ac-stamp: KSPEC_SESSION_ID stamps task on start
- [x] ac-no-env: No stamp when env var absent
- [x] ac-startable: Warning when starting task claimed by another session
- [x] ac-display: Session indicator in list, details, and JSON output
- [x] ac-claim-clear: session_id cleared on needs_work, unblock, and reset

🤖 Generated with [Claude Code](https://claude.com/claude-code)