### PR TITLE
feat: add unlocks N dependency display to session start

### DIFF
--- a/src/cli/commands/session.ts
+++ b/src/cli/commands/session.ts
@@ -236,7 +236,7 @@ export interface SessionOptions {
 
 /**
  * Build a reverse dependency map: for each task ULID, count how many
- * non-completed tasks depend on it. Unresolvable refs are silently skipped.
+ * pending tasks depend on it. Unresolvable refs are silently skipped.
  */
 function computeUnlocksMap(
   allTasks: LoadedTask[],
@@ -245,8 +245,8 @@ function computeUnlocksMap(
   const counts = new Map<string, number>();
 
   for (const task of allTasks) {
-    // Only count pending tasks as "unlockable" downstream work
-    if (task.status === "completed" || task.status === "cancelled") continue;
+    // Only count pending tasks as "unlockable" downstream work per spec
+    if (task.status !== "pending") continue;
 
     for (const depRef of task.depends_on) {
       const result = index.resolve(depRef);

--- a/tests/cli/session-start-unlocks.test.ts
+++ b/tests/cli/session-start-unlocks.test.ts
@@ -132,8 +132,7 @@ describe('session start dependency display', () => {
       kspec('task add --title "Done parent" --slug task-done-parent', tempDir);
       kspec('task add --title "Done child" --slug task-done-child --depends-on @task-done-parent', tempDir);
 
-      // Complete the child task (dependency won't keep it from counting - but it should not count
-      // because completed/cancelled tasks are excluded from unlocks)
+      // Complete the child task — completed tasks should not count
       kspec('task start @task-done-child', tempDir);
       kspec('task submit @task-done-child', tempDir);
       kspec('task complete @task-done-child --reason "Finished"', tempDir);
@@ -141,6 +140,37 @@ describe('session start dependency display', () => {
       const session = kspecJson<SessionContext>('session start --json', tempDir);
 
       const parentTask = session.ready_tasks.find((t) => t.title === 'Done parent');
+      expect(parentTask).toBeDefined();
+      expect(parentTask!.unlocks).toBe(0);
+    });
+
+    it('should not count in_progress dependents as unlockable', () => {
+      // Only pending tasks count — in_progress tasks are already being worked on
+      kspec('task add --title "IP parent" --slug task-ip-parent', tempDir);
+      kspec('task add --title "IP child" --slug task-ip-child --depends-on @task-ip-parent', tempDir);
+
+      // Start the child so it becomes in_progress
+      kspec('task start @task-ip-child', tempDir);
+
+      const session = kspecJson<SessionContext>('session start --json', tempDir);
+
+      const parentTask = session.ready_tasks.find((t) => t.title === 'IP parent');
+      expect(parentTask).toBeDefined();
+      expect(parentTask!.unlocks).toBe(0);
+    });
+
+    it('should not count blocked dependents as unlockable', () => {
+      // Blocked tasks are not pending work waiting to be unblocked by this task
+      kspec('task add --title "Blocked dep parent" --slug task-bdp', tempDir);
+      kspec('task add --title "Blocked dep child" --slug task-bdc --depends-on @task-bdp', tempDir);
+
+      // Block the child
+      kspec('task start @task-bdc', tempDir);
+      kspec('task block @task-bdc --reason "External"', tempDir);
+
+      const session = kspecJson<SessionContext>('session start --json', tempDir);
+
+      const parentTask = session.ready_tasks.find((t) => t.title === 'Blocked dep parent');
       expect(parentTask).toBeDefined();
       expect(parentTask!.unlocks).toBe(0);
     });


### PR DESCRIPTION
## Summary
- Ready and blocked tasks in `session start` output now show "unlocks N" annotation when N>0 pending tasks depend on them
- Helps agents and users prioritize work that unblocks the most downstream tasks
- Unresolvable dependency refs are silently skipped (no errors)

## Changes
- `computeUnlocksMap()` builds a reverse dependency map using `ReferenceIndex`
- `ReadyTaskSummary` and `BlockedTaskSummary` types gain `unlocks` field
- Human output renders green "unlocks N" text; JSON output includes the field
- 9 integration tests covering all 3 spec ACs

## Test plan
- [x] ac-unlocks-shown: JSON + human output for ready tasks with dependents
- [x] ac-unlocks-shown: JSON + human output for blocked tasks with dependents
- [x] ac-unlocks-omit-zero: Zero dependents show no annotation
- [x] ac-unlocks-omit-zero: Completed dependents excluded from count
- [x] ac-unlocks-unresolvable: Bogus YAML ref silently skipped
- [x] Full test suite passes (3 pre-existing failures in session-create.test.ts unrelated)

Task: @implement-session-start-dependency-display
Spec: @session-start-unlocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)