### PR TITLE
fix: strip ralph env vars from test helper child processes

### DIFF
--- a/tests/helpers/cli.ts
+++ b/tests/helpers/cli.ts
@@ -86,13 +86,23 @@ export interface KspecResult {
 export function kspec(args: string, cwd: string, options: KspecOptions = {}): KspecResult {
   const { stdin, expectFail = false, env = {} } = options;
 
+  // Build clean env: strip ralph-specific vars that pollute tests when running
+  // inside a ralph loop. Tests that need these vars pass them explicitly via env.
+  const cleanEnv = { ...process.env };
+  const RALPH_ENV_VARS = ['KSPEC_RALPH_SESSION', 'KSPEC_SESSION_ID'];
+  for (const key of RALPH_ENV_VARS) {
+    if (!(key in env)) {
+      delete cleanEnv[key];
+    }
+  }
+
   // Use spawnSync with shell to capture both stdout and stderr
   // Always use shell mode to properly handle argument parsing and quoting
   const result = spawnSync('/bin/sh', ['-c', `node ${CLI_PATH} ${args}`], {
     cwd,
     encoding: 'utf-8',
     timeout: 30_000,
-    env: { ...process.env, KSPEC_AUTHOR: '@test', ...env },
+    env: { ...cleanEnv, KSPEC_AUTHOR: '@test', ...env },
     input: stdin !== undefined ? (stdin.endsWith('\n') ? stdin : stdin + '\n') : undefined,
   });
 

--- a/tests/ralph.test.ts
+++ b/tests/ralph.test.ts
@@ -596,6 +596,12 @@ describe('ralph command', () => {
       // Run a simple kspec command (not ralph) and check env via mock
       // The mock won't be invoked here, so we check our own process env
       // which should not have the var set (ralph sets it on its own process)
+      // Build clean env: strip ralph vars that would be inherited when running
+      // inside a ralph loop, simulating a non-ralph child process
+      const cleanEnv = { ...process.env };
+      delete cleanEnv.KSPEC_RALPH_SESSION;
+      delete cleanEnv.KSPEC_SESSION_ID;
+
       const { spawnSync: spawnSyncDirect } = await import('node:child_process');
       const result = spawnSyncDirect('node', ['-e', `
         const fs = require('fs');
@@ -604,7 +610,7 @@ describe('ralph command', () => {
       `], {
         cwd: tempDir,
         encoding: 'utf-8',
-        env: { ...process.env }, // Inherit test env (no KSPEC_RALPH_SESSION)
+        env: cleanEnv, // Clean env without ralph vars
       });
 
       expect(result.status).toBe(0);


### PR DESCRIPTION
## Summary
- Fixes 4 test failures that occur when vitest runs inside a ralph loop (env pollution from `KSPEC_RALPH_SESSION` and `KSPEC_SESSION_ID`)
- `kspec()` test helper now strips ralph-specific env vars from spawned child processes unless explicitly provided via the `env` option
- Fixed direct `spawnSync` call in `ralph.test.ts` that verifies non-inheritance of ralph session vars

## Test plan
- [x] All 3513 tests pass (157 test files, 0 failures)
- [x] Previously-failing tests verified: `session-create.test.ts` (JSON parse errors), `ralph.test.ts` (env inheritance), `session-budget-integration.test.ts` (intermittent budget cleanup)
- [x] Tests still pass when NOT running inside ralph (clean env unaffected by delete of non-existent keys)

Task: @01KJ8T2N

🤖 Generated with [Claude Code](https://claude.com/claude-code)