### PR TITLE
fix: prevent ralph wrap-up agent from causing test timeouts

### DIFF
--- a/tests/ralph/session-budget-integration.test.ts
+++ b/tests/ralph/session-budget-integration.test.ts
@@ -347,8 +347,10 @@ describe("ac-session-close-all-paths: ralph cleans up budget on exit", () => {
     tempDir = await setupTempFixtures();
     // Initialize a clean git repo so getWorkingTreeStatus() returns clean.
     // This prevents the wrap-up agent from spawning (2-min timeout) and
-    // causing flaky test timeouts.
+    // causing flaky test timeouts. The .gitignore ensures session artifacts
+    // created by ralph during the test don't dirty the working tree.
     initGitRepo(tempDir);
+    await fs.writeFile(path.join(tempDir, ".gitignore"), "sessions/\n");
     execSync("git add -A && git commit -m 'init'", { cwd: tempDir, stdio: "pipe" });
   });
 


### PR DESCRIPTION
## Summary

- Fixed flaky `session-budget-integration` test by isolating ralph subprocess from real project working tree
- Root cause: `spawnRalphUntil` and `testSignalCleanup` used `cwd: process.cwd()` (real project root), causing `getWorkingTreeStatus()` to detect uncommitted changes and trigger the 2-minute wrap-up agent timeout — exceeding the test's 25s safety timeout
- Fix: Use `tempDir` as cwd, initialize a clean git repo there, so `isWrapUpNeeded()` returns false and wrap-up is skipped

## Test plan

- [x] All 3513 tests pass (3 skipped as expected)
- [x] The previously-flaky "max-iterations reached" test now completes in ~2s instead of timing out
- [x] Signal cleanup tests (SIGINT/SIGTERM) and crash path tests all pass
- [x] Ran full test file multiple times to verify stability

Task: @task-fix-flaky-ralph-budget-test

🤖 Generated with [Claude Code](https://claude.com/claude-code)