### PR TITLE
fix: validate enum values in item set --status and --maturity

### DIFF
--- a/src/cli/commands/item.ts
+++ b/src/cli/commands/item.ts
@@ -32,6 +32,10 @@ import type {
   SpecItemInput,
 } from "../../schema/index.js";
 import { SpecItemPatchSchema } from "../../schema/index.js";
+import {
+  ImplementationStatusSchema,
+  MaturitySchema,
+} from "../../schema/common.js";
 import { errors } from "../../strings/errors.js";
 import { fieldLabels, sectionHeaders } from "../../strings/labels.js";
 import { formatMatchedFields, grepItem } from "../../utils/grep.js";
@@ -964,6 +968,24 @@ Examples:
         if (options.tag) updates.tags = parseTagsArray(options.tag);
         if (options.trait) updates.traits = options.trait;
         if (options.description) updates.description = options.description;
+
+        // AC: @implementation-states ac-reject-invalid
+        // AC: @maturity-states ac-reject-invalid
+        // Validate enum values before writing
+        if (options.status) {
+          const valid = ImplementationStatusSchema.options as readonly string[];
+          if (!valid.includes(options.status)) {
+            error(`Invalid implementation status: '${options.status}'. Valid values: ${valid.join(", ")}`);
+            process.exit(EXIT_CODES.USAGE_ERROR);
+          }
+        }
+        if (options.maturity) {
+          const valid = MaturitySchema.options as readonly string[];
+          if (!valid.includes(options.maturity)) {
+            error(`Invalid maturity: '${options.maturity}'. Valid values: ${valid.join(", ")}`);
+            process.exit(EXIT_CODES.USAGE_ERROR);
+          }
+        }
 
         // Handle status updates
         if (options.status || options.maturity) {

--- a/tests/item-set-enum-validation.test.ts
+++ b/tests/item-set-enum-validation.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, beforeEach, afterEach, expect } from 'vitest';
+import { setupTempFixtures, kspec, kspecJson, cleanupTempDir } from './helpers/cli.js';
+
+describe('Item Set Enum Validation', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await setupTempFixtures();
+    // Create a test item to operate on
+    kspec('item add --under @test-core --title "Enum Test Item" --type requirement --slug enum-test', tempDir);
+  });
+
+  afterEach(async () => {
+    await cleanupTempDir(tempDir);
+  });
+
+  describe('--status validation', () => {
+    // AC: @implementation-states ac-reject-invalid
+    it('should reject invalid implementation status with error listing valid values', () => {
+      const result = kspec('item set @enum-test --status specified', tempDir, { expectFail: true });
+      expect(result.exitCode).not.toBe(0);
+      expect(result.stderr).toContain('Invalid implementation status');
+      expect(result.stderr).toContain('specified');
+      expect(result.stderr).toContain('not_started');
+      expect(result.stderr).toContain('in_progress');
+      expect(result.stderr).toContain('implemented');
+      expect(result.stderr).toContain('verified');
+    });
+
+    // AC: @implementation-states ac-reject-invalid
+    it('should not write changes when status is invalid', () => {
+      // First set a known valid status
+      kspec('item set @enum-test --status in_progress', tempDir);
+
+      // Try to set an invalid status
+      kspec('item set @enum-test --status bogus', tempDir, { expectFail: true });
+
+      // Verify the original status is preserved
+      const item = kspecJson<{ status: { implementation?: string } }>('item get @enum-test', tempDir);
+      expect(item.status.implementation).toBe('in_progress');
+    });
+
+    it('should accept all valid implementation statuses', () => {
+      for (const status of ['not_started', 'in_progress', 'implemented', 'verified']) {
+        const result = kspec(`item set @enum-test --status ${status}`, tempDir);
+        expect(result.exitCode).toBe(0);
+
+        const item = kspecJson<{ status: { implementation?: string } }>('item get @enum-test', tempDir);
+        expect(item.status.implementation).toBe(status);
+      }
+    });
+  });
+
+  describe('--maturity validation', () => {
+    // AC: @maturity-states ac-reject-invalid
+    it('should reject invalid maturity with error listing valid values', () => {
+      const result = kspec('item set @enum-test --maturity finalized', tempDir, { expectFail: true });
+      expect(result.exitCode).not.toBe(0);
+      expect(result.stderr).toContain('Invalid maturity');
+      expect(result.stderr).toContain('finalized');
+      expect(result.stderr).toContain('draft');
+      expect(result.stderr).toContain('proposed');
+      expect(result.stderr).toContain('stable');
+      expect(result.stderr).toContain('deferred');
+      expect(result.stderr).toContain('deprecated');
+    });
+
+    // AC: @maturity-states ac-reject-invalid
+    it('should not write changes when maturity is invalid', () => {
+      // Set a known valid maturity
+      kspec('item set @enum-test --maturity proposed', tempDir);
+
+      // Try to set an invalid maturity
+      kspec('item set @enum-test --maturity finalized', tempDir, { expectFail: true });
+
+      // Verify the original maturity is preserved
+      const item = kspecJson<{ status: { maturity?: string } }>('item get @enum-test', tempDir);
+      expect(item.status.maturity).toBe('proposed');
+    });
+
+    it('should accept all valid maturity values', () => {
+      for (const maturity of ['draft', 'proposed', 'stable', 'deferred', 'deprecated']) {
+        const result = kspec(`item set @enum-test --maturity ${maturity}`, tempDir);
+        expect(result.exitCode).toBe(0);
+
+        const item = kspecJson<{ status: { maturity?: string } }>('item get @enum-test', tempDir);
+        expect(item.status.maturity).toBe(maturity);
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Validates `--status` against `ImplementationStatusSchema` enum values (`not_started`, `in_progress`, `implemented`, `verified`) before writing to YAML
- Validates `--maturity` against `MaturitySchema` enum values (`draft`, `proposed`, `stable`, `deferred`, `deprecated`) before writing
- On invalid input, fails with a clear error listing valid values and exits with `USAGE_ERROR` code
- Previously, invalid values were silently written, causing Zod validation failures on read that made items invisible to all lookups

## Test plan
- [x] 6 integration tests covering both `@implementation-states ac-reject-invalid` and `@maturity-states ac-reject-invalid`
- [x] Tests verify: invalid value rejection with error message, no-write on invalid input, all valid values accepted
- [x] Full test suite passes (3592 passed, 2 known flaky ralph signal tests)

Task: @task-validate-status-enum
Spec: @implementation-states, @maturity-states

🤖 Generated with [Claude Code](https://claude.com/claude-code)