### PR TITLE
fix: await async cleanup in ralph signal handler

### DIFF
--- a/src/cli/commands/ralph.ts
+++ b/src/cli/commands/ralph.ts
@@ -1054,18 +1054,28 @@ export function registerRalphCommand(program: Command): void {
         const sessionIterationMap = new Map<string, number>();
 
         // Signal handler refs — declared here so finally can remove them
+        // AC: @ralph-task-limit ac-signal-cleanup
         const signalCleanup = (signal: string) => {
           info(`Received ${signal}, cleaning up...`);
           if (agent) {
             agent.kill();
           }
           // AC: @ralph-session-budget-integration ac-session-close-all-paths
-          Promise.all([
-            fs.unlink(getSessionBudgetPath(specDir, sessionId)).catch(() => {}),
-            closeSession(specDir, sessionId, "abandoned", `Received ${signal}`),
-          ]).finally(() => {
-            process.exit(0);
-          });
+          // Must use async IIFE — signal handlers are called synchronously,
+          // but cleanup needs async I/O. The IIFE keeps the event loop alive
+          // until cleanup completes, then exits explicitly.
+          void (async () => {
+            try {
+              await Promise.all([
+                fs.unlink(getSessionBudgetPath(specDir, sessionId)).catch(() => {}),
+                closeSession(specDir, sessionId, "abandoned", `Received ${signal}`),
+              ]);
+            } catch {
+              // Best-effort cleanup — don't let errors prevent exit
+            } finally {
+              process.exit(0);
+            }
+          })();
         };
         const sigintHandler = () => { signalCleanup("SIGINT"); };
         const sigtermHandler = () => { signalCleanup("SIGTERM"); };

--- a/tests/ralph/end-loop.test.ts
+++ b/tests/ralph/end-loop.test.ts
@@ -292,9 +292,9 @@ describe("Session-scoped end-loop signal", () => {
       expect(ralphContent).toContain('"abandoned"');
       expect(ralphContent).toContain("Received ${signal}");
 
-      // Verify cleanup awaits before exit
-      expect(ralphContent).toContain("Promise.all");
-      expect(ralphContent).toContain(".finally(() =>");
+      // Verify cleanup awaits before exit (async IIFE pattern)
+      expect(ralphContent).toContain("await Promise.all");
+      expect(ralphContent).toContain("process.exit(0)");
     });
 
     it("should close session with completed status on normal exit", async () => {

--- a/tests/ralph/session-budget-integration.test.ts
+++ b/tests/ralph/session-budget-integration.test.ts
@@ -510,11 +510,13 @@ describe("ac-session-close-all-paths: ralph cleans up budget on exit", () => {
   }
 
   // AC: @ralph-session-budget-integration ac-session-close-all-paths
+  // AC: @ralph-task-limit ac-signal-cleanup
   it("should clean up budget.json after signal (SIGINT)", async () => {
     await testSignalCleanup("SIGINT");
   }, 30_000);
 
   // AC: @ralph-session-budget-integration ac-session-close-all-paths
+  // AC: @ralph-task-limit ac-signal-cleanup
   it("should clean up budget.json after signal (SIGTERM)", async () => {
     await testSignalCleanup("SIGTERM");
   }, 30_000);


### PR DESCRIPTION
## Summary
- Fixed unawaited async cleanup in ralph signal handler that caused budget.json to persist after SIGINT/SIGTERM
- Changed fire-and-forget `Promise.all([...]).finally()` to properly awaited async IIFE pattern
- Updated static analysis test in end-loop.test.ts to match new code pattern
- Added `@ralph-task-limit ac-signal-cleanup` AC annotations to SIGINT/SIGTERM signal tests

## Test plan
- [x] Signal cleanup tests pass (SIGINT + SIGTERM) in session-budget-integration.test.ts
- [x] End-loop static analysis test updated and passing
- [x] Full test suite passes (3600+ tests, only known flaky timeout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)