### PR TITLE
fix: use named handlers instead of removeAllListeners() for stdin cleanup

### DIFF
--- a/src/cli/commands/item.ts
+++ b/src/cli/commands/item.ts
@@ -1883,23 +1883,35 @@ async function readStdinFully(): Promise<string | null> {
 
   return new Promise((resolve) => {
     let data = "";
+
+    const onData = (chunk: string) => {
+      data += chunk;
+    };
+    const onEnd = () => {
+      clearTimeout(timeout);
+      cleanup();
+      resolve(data || null);
+    };
+    const onError = () => {
+      clearTimeout(timeout);
+      cleanup();
+      resolve(null);
+    };
+    const cleanup = () => {
+      process.stdin.removeListener("data", onData);
+      process.stdin.removeListener("end", onEnd);
+      process.stdin.removeListener("error", onError);
+    };
+
     const timeout = setTimeout(() => {
-      process.stdin.removeAllListeners();
+      cleanup();
       resolve(data || null);
     }, 5000); // 5 second timeout for bulk input
 
     process.stdin.setEncoding("utf8");
-    process.stdin.on("data", (chunk) => {
-      data += chunk;
-    });
-    process.stdin.on("end", () => {
-      clearTimeout(timeout);
-      resolve(data || null);
-    });
-    process.stdin.on("error", () => {
-      clearTimeout(timeout);
-      resolve(null);
-    });
+    process.stdin.on("data", onData);
+    process.stdin.on("end", onEnd);
+    process.stdin.on("error", onError);
     process.stdin.resume();
   });
 }
@@ -1915,23 +1927,35 @@ async function readStdinIfAvailable(): Promise<string | null> {
 
   return new Promise((resolve) => {
     let data = "";
+
+    const onData = (chunk: string) => {
+      data += chunk;
+    };
+    const onEnd = () => {
+      clearTimeout(timeout);
+      cleanup();
+      resolve(data || null);
+    };
+    const onError = () => {
+      clearTimeout(timeout);
+      cleanup();
+      resolve(null);
+    };
+    const cleanup = () => {
+      process.stdin.removeListener("data", onData);
+      process.stdin.removeListener("end", onEnd);
+      process.stdin.removeListener("error", onError);
+    };
+
     const timeout = setTimeout(() => {
-      process.stdin.removeAllListeners();
+      cleanup();
       resolve(data || null);
     }, 100); // 100ms timeout for quick check
 
     process.stdin.setEncoding("utf8");
-    process.stdin.on("data", (chunk) => {
-      data += chunk;
-    });
-    process.stdin.on("end", () => {
-      clearTimeout(timeout);
-      resolve(data || null);
-    });
-    process.stdin.on("error", () => {
-      clearTimeout(timeout);
-      resolve(null);
-    });
+    process.stdin.on("data", onData);
+    process.stdin.on("end", onEnd);
+    process.stdin.on("error", onError);
     process.stdin.resume();
   });
 }

--- a/tests/stdin-named-handlers.test.ts
+++ b/tests/stdin-named-handlers.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+/**
+ * Static analysis: Ensure stdin helper functions use named handlers
+ * instead of removeAllListeners(), which would remove listeners
+ * registered by other code.
+ */
+describe("stdin helpers use named handlers", () => {
+  const filesToCheck = [
+    "src/cli/commands/item.ts",
+    "src/cli/commands/session/commands.ts",
+  ];
+
+  for (const file of filesToCheck) {
+    it(`${file} should not use process.stdin.removeAllListeners()`, () => {
+      const content = readFileSync(resolve(file), "utf8");
+      expect(content).not.toContain("process.stdin.removeAllListeners()");
+    });
+
+    it(`${file} should use named removeListener for cleanup`, () => {
+      const content = readFileSync(resolve(file), "utf8");
+      // If the file has stdin listeners, it should use removeListener for cleanup
+      if (content.includes('process.stdin.on("data"')) {
+        expect(content).toContain('process.stdin.removeListener("data"');
+        expect(content).toContain('process.stdin.removeListener("end"');
+      }
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- Replaced `process.stdin.removeAllListeners()` with targeted `removeListener()` calls in both `readStdinIfAvailable()` and `readStdinFully()` in `src/cli/commands/item.ts`
- The old pattern removed ALL stdin listeners including those registered by other code, which could break concurrent stdin consumers
- Uses named handler functions with a `cleanup()` helper, matching the pattern already established in `session/commands.ts`
- Added static analysis tests to prevent regression

## Test plan
- [x] All 50 item tests pass
- [x] New static analysis test verifies no `removeAllListeners()` in stdin helper files
- [x] Test verifies `removeListener` with named handlers is used for cleanup
- [x] TypeScript compiles cleanly

Task: @01KJ9ZJP

🤖 Generated with [Claude Code](https://claude.com/claude-code)