### PR TITLE
refactor: remove dead code in session modules

### DIFF
--- a/src/cli/commands/session/context.ts
+++ b/src/cli/commands/session/context.ts
@@ -536,7 +536,6 @@ export async function gatherSessionContext(
   };
 
   // JSON always gets full list with triage status; human display filters in formatSessionContext
-  const inboxSummaries: InboxSummary[] = allInboxSummaries;
 
   // Load session context (focus, threads, questions)
   const sessionContext = await loadSessionContext(ctx);
@@ -621,7 +620,7 @@ export async function gatherSessionContext(
     recent_commits: recentCommits,
     activity_timeline: activityTimeline,
     working_tree: workingTree,
-    inbox_items: inboxSummaries,
+    inbox_items: allInboxSummaries,
     inbox_stats: inboxStats,
     observations,
     stats,

--- a/src/cli/commands/session/log.ts
+++ b/src/cli/commands/session/log.ts
@@ -678,13 +678,6 @@ interface SessionLogSearchOptions {
 }
 
 /**
- * Format relative timestamp from event timestamp (Unix ms) to session start.
- */
-function formatSearchTimestamp(eventTs: number): string {
-  return new Date(eventTs).toISOString();
-}
-
-/**
  * Format the session log search output.
  *
  * AC: @session-log-search ac-1, ac-4
@@ -713,7 +706,7 @@ function formatSessionLogSearch(results: SessionSearchResult[]): void {
 
     // AC: @session-log-search ac-4 - Show matches with session ID, timestamp, type, excerpt
     for (const match of session.matches) {
-      const ts = formatSearchTimestamp(match.timestamp);
+      const ts = new Date(match.timestamp).toISOString();
       const typeColor =
         match.event_type === "session.start" || match.event_type === "session.end"
           ? chalk.green


### PR DESCRIPTION
## Summary
- Removed `inboxSummaries` alias in `context.ts` — uses `allInboxSummaries` directly instead of assigning to an intermediate variable
- Inlined `formatSearchTimestamp()` trivial one-liner wrapper in `log.ts` — replaced with `new Date(match.timestamp).toISOString()` at call site
- Items 1 (unused imports: `listSessions`, `IterationSummary`, `SearchMatch`) and 2 (unused `_allTasks` parameter on `toBlockedTaskSummary`) were already cleaned up in the session.ts refactor (PR #523)

Task: @01KJA2FA

## Test plan
- [x] All 522 session/ralph tests pass
- [x] Clean TypeScript build (`tsc --noEmit`)
- [x] No behavioral changes — purely dead code removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)