### PR TITLE
refactor(cli): consolidate dual ImplementationStatusSchema import in item.ts

### DIFF
--- a/src/cli/commands/item.ts
+++ b/src/cli/commands/item.ts
@@ -325,7 +325,6 @@ export function registerItemCommands(program: Command): void {
         // AC: @multi-value-status-filter ac-item-list-parity, ac-invalid-item-status
         if (options.status) {
           const { parseMultiStatus } = await import("./tasks.js");
-          const { ImplementationStatusSchema } = await import("../../schema/common.js");
           const statuses = parseMultiStatus(
             options.status,
             ImplementationStatusSchema.options,


### PR DESCRIPTION
## Summary

- Removes redundant dynamic `import()` of `ImplementationStatusSchema` in the item list `--status` handler
- The schema is already statically imported at the top of the file (`src/cli/commands/item.ts` lines 35-38)
- The dynamic import unnecessarily shadowed the static import and created a duplicate module reference
- One line removed; zero behavior change

## Test plan

- [x] `tests/multi-value-status-filter.test.ts` — exercises the exact code path (item list --status filter) — 10 tests pass
- [x] `tests/item-set-enum-validation.test.ts` — validates ImplementationStatusSchema usage — 12 tests pass
- [x] `tests/item-list-under.test.ts` — 12 tests pass
- [x] `npm run test:shard1` — 1186 tests pass, 0 failures
- [x] `npm run build` — clean TypeScript compilation

🤖 Generated with [Claude Code](https://claude.com/claude-code)