### PR TITLE
fix: bootstrap always npm-links local kspec build

### DIFF
--- a/scripts/bootstrap.cjs
+++ b/scripts/bootstrap.cjs
@@ -118,34 +118,45 @@ function checkKspecCli() {
     return { available: true, linked: false, version: result.output.trim(), reason: 'local dist not built yet' };
   }
 
-  // Check if the kspec binary is a symlink pointing to our local dist.
-  // npm link creates: <global-bin>/kspec -> <global-lib>/node_modules/.bin/kspec -> our dist/cli/index.js
-  // We follow the symlink chain with realpathSync and compare to our dist.
-  // This works cross-platform (Node's fs handles symlinks on all OSes).
+  // Check if the globally installed kspec points to our local project.
+  // On Unix: npm link creates symlinks, so realpathSync follows them.
+  // On Windows: npm link creates .cmd shims containing the JS path as text.
   const prefixResult = run('npm prefix -g', { silent: true });
   if (prefixResult.success) {
     const globalPrefix = prefixResult.output.trim();
-    // npm puts bins in <prefix>/bin on Unix, <prefix> on Windows
-    const binName = process.platform === 'win32' ? 'kspec.cmd' : 'kspec';
-    const binDir = process.platform === 'win32' ? globalPrefix : path.join(globalPrefix, 'bin');
-    const globalBin = path.join(binDir, binName);
+    const resolvedDist = fs.realpathSync(distCli);
 
-    try {
-      if (fs.existsSync(globalBin)) {
-        const resolvedBin = fs.realpathSync(globalBin);
-        const resolvedDist = fs.realpathSync(distCli);
-        if (resolvedBin === resolvedDist) {
-          return { available: true, linked: true, version: result.output.trim() };
+    if (process.platform === 'win32') {
+      // Windows: npm creates a .cmd shim that contains the path to the JS entry
+      const cmdShim = path.join(globalPrefix, 'kspec.cmd');
+      try {
+        if (fs.existsSync(cmdShim)) {
+          const shimContent = fs.readFileSync(cmdShim, 'utf8');
+          // .cmd shims contain the target JS path — check if it references our project
+          if (shimContent.includes(projectRoot.replace(/\//g, '\\'))) {
+            return { available: true, linked: true, version: result.output.trim() };
+          }
         }
+      } catch {
+        // Shim read failed — fall through to not linked
       }
-    } catch {
-      // Symlink resolution failed — fall through to not linked
+    } else {
+      // Unix: follow the symlink chain
+      const globalBin = path.join(globalPrefix, 'bin', 'kspec');
+      try {
+        if (fs.existsSync(globalBin)) {
+          const resolvedBin = fs.realpathSync(globalBin);
+          if (resolvedBin === resolvedDist) {
+            return { available: true, linked: true, version: result.output.trim() };
+          }
+        }
+      } catch {
+        // Symlink resolution failed — fall through to not linked
+      }
     }
   }
 
   return { available: true, linked: false, version: result.output.trim(), reason: 'kspec is not npm-linked to local project' };
-
-  return { available: true, linked: true, version: result.output.trim() };
 }
 
 /**


### PR DESCRIPTION
## Summary
- `checkKspecCli()` now verifies the `kspec` binary resolves to the local project's `dist/`, not just that any `kspec` command exists
- Ensures `npm link` always runs when a globally installed kspec (e.g. from container image) doesn't match the local build
- Fixes the ralph-container issue where bootstrap skipped `npm link` because the global kspec existed, then ran `kspec init` with an outdated version that lacked shallow clone support

## Test plan
- [x] Bootstrap detects global kspec and re-links to local build
- [x] `kspec init` uses locally built code with latest fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)