### PR TITLE
fix: add ac-6 behavioral test and fix session-close-error test reliability

### DIFF
--- a/packages/web-ui/tests/e2e/triage.spec.ts
+++ b/packages/web-ui/tests/e2e/triage.spec.ts
@@ -16,8 +16,16 @@
  * - @interactive-triage-ui ac-8: Static mode: read-only, action buttons hidden
  */
 
-// Trait N/A annotations — @interactive-triage-ui inherits no traits directly.
-// WebSocket behavior for triage:updates is tested via @trait-websocket-protocol in api-websocket.spec.ts.
+// Trait N/A annotations — @interactive-triage-ui inherits @trait-websocket-protocol.
+// Server-side WebSocket protocol behaviors are tested in api-websocket.spec.ts.
+// AC: @trait-websocket-protocol ac-1 — N/A: server connection ID assignment tested in api-websocket.spec.ts
+// AC: @trait-websocket-protocol ac-2 — N/A: server subscribe ack tested in api-websocket.spec.ts
+// AC: @trait-websocket-protocol ac-3 — N/A: server broadcast format tested in api-websocket.spec.ts
+// AC: @trait-websocket-protocol ac-4 — N/A: server heartbeat timing tested in api-websocket.spec.ts
+// AC: @trait-websocket-protocol ac-5 — N/A: server ping/pong timeout close with code 1001 tested in api-websocket.spec.ts
+// AC: @trait-websocket-protocol ac-6 — N/A: server backpressure handling tested in api-websocket.spec.ts
+// AC: @trait-websocket-protocol ac-7 — N/A: server close codes tested in api-websocket.spec.ts
+// AC: @trait-websocket-protocol ac-8 — N/A: client sequence reset on reconnect tested in api-websocket.spec.ts
 
 import { test, expect } from '../fixtures/test-base';
 
@@ -183,6 +191,44 @@ test.describe('Interactive Triage UI', () => {
         await page.waitForTimeout(200);
       }
     }
+  });
+});
+
+test.describe('Triage real-time updates via WebSocket', () => {
+  // AC: @interactive-triage-ui ac-6
+  test('triage page updates progress count in real-time when another client submits a triage decision', async ({ page, request }) => {
+    // Open triage page — Svelte component subscribes to triage:updates on mount
+    await page.goto('/triage');
+    await page.waitForLoadState('networkidle');
+
+    // Record initial progress count from the triage-progress element
+    const progressEl = page.getByTestId('triage-progress');
+    await expect(progressEl).toBeVisible();
+    const initialProgress = await progressEl.textContent();
+
+    // Create a fresh inbox item to triage (so we don't conflict with fixture records)
+    const inboxResp = await request.post('http://localhost:3456/api/inbox', {
+      data: { text: `Real-time update test item ${Date.now()}` },
+    });
+    expect(inboxResp.status()).toBe(200);
+    const inboxBody = await inboxResp.json();
+    const newInboxUlid = inboxBody.item._ulid;
+
+    // POST triage decision via API (simulates another client acting on the item).
+    // The daemon broadcasts triage:updates after mutation, which the triage page
+    // receives and calls loadTriageData() to refresh the displayed count.
+    const triageResp = await request.post('http://localhost:3456/api/triage', {
+      data: {
+        inbox_ref: `@${newInboxUlid}`,
+        action: 'defer',
+        reasoning: 'E2E real-time test',
+      },
+    });
+    expect(triageResp.status()).toBe(200);
+
+    // Wait for the triage page to receive the WebSocket broadcast and re-render.
+    // The progress count should increase since we added a new triaged record.
+    await expect(progressEl).not.toHaveText(initialProgress ?? '', { timeout: 5000 });
   });
 });
 

--- a/tests/ralph/session-budget-integration.test.ts
+++ b/tests/ralph/session-budget-integration.test.ts
@@ -520,19 +520,18 @@ describe("ac-session-close-all-paths: ralph cleans up budget on exit", () => {
     const crashAgent = path.join(FIXTURES_DIR, "mock-acp-agent-crash.mjs");
 
     // Use --max-failures 1 so ralph exits due to failure rather than completing iterations.
-    const result = await spawnRalphUntil(
+    // The crash agent always exits immediately, causing every attempt (iteration or review
+    // subagent) to fail. With --max-failures 1, the first consecutive failure exits the loop.
+    await spawnRalphUntil(
       ["--adapter-cmd", `node ${crashAgent}`, "--max-loops", "999", "--max-failures", "1", "--max-tasks", "2"],
       "Ralph loop completed",
     );
-
-    // Ralph should have logged failure and max-failures exit
-    expect(result.output).toContain("Iteration failed");
 
     const sessionsDir = path.join(tempDir, "sessions");
     const sessionDirs = await fs.readdir(sessionsDir);
     expect(sessionDirs.length).toBe(1);
 
-    // Session should be closed as abandoned with Max failures close_reason
+    // Session should be closed as abandoned with Max failures close_reason.
     // AC: @session-end-loop-signal ac-session-close-error
     const sessionPath = path.join(sessionsDir, sessionDirs[0], "session.yaml");
     const content = await fs.readFile(sessionPath, "utf-8");


### PR DESCRIPTION
## Summary

- **Add `@interactive-triage-ui ac-6` behavioral E2E test**: The triage.spec.ts file had ac-6 mentioned only in the header comment but had no actual test with a machine-parseable `// AC:` annotation. Added a proper behavioral E2E test in a new `test.describe('Triage real-time updates via WebSocket')` block that verifies the triage page's progress count updates in real-time when another client submits a triage decision via the API (which triggers a `triage:updates` WebSocket broadcast).

- **Add N/A annotations for inherited `@trait-websocket-protocol` ACs**: Since `@interactive-triage-ui` inherits `@trait-websocket-protocol`, all 8 trait ACs needed machine-parseable N/A annotations with explanations (server-side behaviors are tested in api-websocket.spec.ts).

- **Fix `should close session as abandoned with error reason on max failures` test reliability**: Removed a fragile `expect(result.output).toContain("Iteration failed")` assertion that was causing shard3 failures. When `pending_review` tasks exist in tempDir (from previous tests in the same describe block), the review subagent fails first instead of the main iteration, logging a different message. The behavioral intent is fully covered by the session YAML assertions (`status: abandoned`, `Max failures` in `close_reason`).

## Test plan

- [ ] `npm run test:e2e` passes for triage.spec.ts (ac-6 test verifies WebSocket real-time update behavior)
- [ ] `npm run test:shard3` passes for session-budget-integration.test.ts (no more flaky assertion)
- [ ] `kspec validate` shows no uncovered ACs for @interactive-triage-ui

🤖 Generated with [Claude Code](https://claude.com/claude-code)