### PR TITLE
feat: use per-adapter auto-approve args instead of hardcoded flags

### DIFF
--- a/src/agents/spawner.ts
+++ b/src/agents/spawner.ts
@@ -17,6 +17,8 @@ export interface SpawnAgentOptions {
   cwd: string;
   /** Additional environment variables */
   env?: Record<string, string>;
+  /** Extra arguments to append (e.g., auto-approve flags) */
+  extraArgs?: string[];
   /** ACP client options */
   clientOptions?: Omit<ACPClientOptions, "stdin" | "stdout">;
 }
@@ -47,7 +49,7 @@ export function spawnAgent(
   adapter: AgentAdapter,
   options: SpawnAgentOptions,
 ): SpawnedAgent {
-  const { cwd, env = {}, clientOptions = {} } = options;
+  const { cwd, env = {}, extraArgs, clientOptions = {} } = options;
 
   // Merge environment variables
   const processEnv = {
@@ -56,8 +58,11 @@ export function spawnAgent(
     ...env,
   };
 
+  // Build args from fresh copy to prevent cross-call leakage
+  const args = [...adapter.args, ...(extraArgs || [])];
+
   // Spawn the agent process
-  const child = spawn(adapter.command, adapter.args, {
+  const child = spawn(adapter.command, args, {
     cwd,
     env: processEnv,
     shell: adapter.shell,

--- a/src/cli/commands/ralph.ts
+++ b/src/cli/commands/ralph.ts
@@ -690,6 +690,7 @@ async function processPendingReviewTasks(
     maxFailures: number;
     cwd: string;
     subagentTimeout: number;
+    autoApproveArgs?: string[];
   },
   consecutiveFailures: { count: number },
 ): Promise<boolean> {
@@ -728,6 +729,7 @@ async function processPendingReviewTasks(
         {
           yolo: options.yolo,
           cwd: options.cwd,
+          extraArgs: options.autoApproveArgs,
           handleRequest: (client, reqId, method, params) =>
             handleRequest(client, reqId, method, params, options.yolo),
         },
@@ -988,10 +990,10 @@ export function registerRalphCommand(program: Command): void {
           validateAdapter(adapter.args[0]);
         }
 
-        // Add yolo flag to adapter args if needed (accept both new and deprecated names)
-        if (options.yolo && isDefaultAdapter) {
-          adapter.args = [...adapter.args, "--dangerously-skip-permissions"];
-        }
+        // Build auto-approve extra args from adapter (applied per-spawn to prevent cross-role leakage)
+        const autoApproveArgs = options.yolo
+          ? adapter.autoApproveArgs
+          : undefined;
 
         const restartInfo =
           restartEvery > 0 ? `, restart every ${restartEvery}` : "";
@@ -1165,6 +1167,7 @@ export function registerRalphCommand(program: Command): void {
                 maxFailures,
                 cwd: process.cwd(),
                 subagentTimeout: subagentTimeout * 60 * 1000,
+                autoApproveArgs,
               },
               failureTracker,
             );
@@ -1298,9 +1301,11 @@ export function registerRalphCommand(program: Command): void {
                 if (!agent) {
                   info("Spawning ACP agent...");
                   // AC: @ralph-session-budget-integration ac-env-inject
+                  // AC: @ralph-adapter-auto-approve ac-1, ac-2, ac-3
                   agent = await spawnAndInitialize(adapter, {
                     cwd: process.cwd(),
                     env: { KSPEC_SESSION_ID: sessionId },
+                    extraArgs: autoApproveArgs,
                     clientOptions: {
                       clientInfo: {
                         name: "kspec-ralph",
@@ -1576,6 +1581,7 @@ export function registerRalphCommand(program: Command): void {
               {
                 yolo: options.yolo,
                 cwd: process.cwd(),
+                extraArgs: autoApproveArgs,
                 handleRequest: (client, reqId, method, params) =>
                   handleRequest(client, reqId, method, params, options.yolo),
               },

--- a/src/ralph/subagent.ts
+++ b/src/ralph/subagent.ts
@@ -62,6 +62,8 @@ export interface SubagentOptions {
   yolo: boolean;
   /** Working directory */
   cwd: string;
+  /** Extra arguments to append to adapter args (e.g., auto-approve flags) */
+  extraArgs?: string[];
   /** Tool request handler */
   handleRequest: (
     client: SpawnedAgent["client"],
@@ -208,8 +210,10 @@ export async function runSubagent(
 
   try {
     // AC: @ralph-subagent-spawning ac-1 - Spawn new ACP process
+    // AC: @ralph-adapter-auto-approve ac-4
     agent = await spawnAndInitialize(adapter, {
       cwd: options.cwd,
+      extraArgs: options.extraArgs,
       clientOptions: {
         clientInfo: {
           name: "kspec-ralph-subagent",

--- a/src/ralph/wrap-up.ts
+++ b/src/ralph/wrap-up.ts
@@ -85,6 +85,8 @@ export interface WrapUpOptions {
   yolo: boolean;
   /** Working directory */
   cwd: string;
+  /** Extra arguments to append to adapter args (e.g., auto-approve flags) */
+  extraArgs?: string[];
   /** Tool request handler */
   handleRequest: (
     client: SpawnedAgent["client"],
@@ -321,6 +323,7 @@ export async function runWrapUpAgent(
     // AC: @ralph-wrap-up-agent-on-loop-exit ac-1 - Spawn wrap-up agent
     agent = await spawnAndInitialize(adapter, {
       cwd: options.cwd,
+      extraArgs: options.extraArgs,
       clientOptions: {
         clientInfo: {
           name: "kspec-ralph-wrapup",

--- a/tests/mocks/acp-mock.js
+++ b/tests/mocks/acp-mock.js
@@ -18,6 +18,7 @@
  * - MOCK_ACP_COMPLETE_TASK: Task ref to complete after successful prompt (e.g., "@task-slug")
  * - MOCK_ACP_PROJECT_DIR: Working directory for kspec commands
  * - MOCK_ACP_CLI_PATH: Path to kspec CLI entry point (required in CI where kspec isn't global)
+ * - MOCK_ACP_VERIFY_ARGS_FILE: Write process.argv to this file for verifying command-line args
  */
 
 import * as fs from 'node:fs';
@@ -43,6 +44,8 @@ const cliPath = process.env.MOCK_ACP_CLI_PATH || 'kspec';
 // Write specified env var values to a file for test verification
 const verifyEnvFile = process.env.MOCK_ACP_VERIFY_ENV_FILE;
 const verifyEnvVars = process.env.MOCK_ACP_VERIFY_ENV_VARS; // comma-separated var names
+// Write process.argv to a file for verifying command-line args
+const verifyArgsFile = process.env.MOCK_ACP_VERIFY_ARGS_FILE;
 
 // ─── JSON-RPC Helpers ────────────────────────────────────────────────────────
 
@@ -92,6 +95,11 @@ function shouldFail() {
 
 async function handleInitialize(id, _params) {
   initialized = true;
+
+  // Write process.argv to file for test verification of command-line args
+  if (verifyArgsFile) {
+    fs.writeFileSync(verifyArgsFile, JSON.stringify(process.argv, null, 2));
+  }
 
   // Write requested env var values to file for test verification
   if (verifyEnvFile && verifyEnvVars) {

--- a/tests/ralph/adapter-auto-approve.test.ts
+++ b/tests/ralph/adapter-auto-approve.test.ts
@@ -1,0 +1,240 @@
+/**
+ * Tests for per-adapter auto-approve arguments.
+ *
+ * Verifies that each adapter has correct autoApproveArgs,
+ * the spawner applies extraArgs correctly, and no cross-role leakage occurs.
+ *
+ * AC: @ralph-adapter-auto-approve
+ */
+import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll } from "vitest";
+import * as path from "node:path";
+import * as fs from "node:fs/promises";
+import {
+  getAdapter,
+  resolveAdapter,
+  type AgentAdapter,
+} from "../../src/agents/adapters.js";
+import { spawnAgent, type SpawnedAgent } from "../../src/agents/spawner.js";
+import { setupTempFixtures, cleanupTempDir } from "../helpers/cli";
+
+const MOCK_ACP = path.join(__dirname, "..", "mocks", "acp-mock.js");
+
+// Suppress EPIPE errors from ACP framing during test cleanup
+// The framing layer may try to write to a dead child process pipe during shutdown
+const originalListeners = process.listeners("uncaughtException");
+function epipeHandler(err: Error & { code?: string }) {
+  if (err.code === "EPIPE") return; // Suppress EPIPE during cleanup
+  throw err;
+}
+beforeAll(() => {
+  process.on("uncaughtException", epipeHandler);
+});
+afterAll(() => {
+  process.removeListener("uncaughtException", epipeHandler);
+});
+
+/**
+ * Helper to cleanly shut down a spawned agent, waiting for process exit.
+ */
+async function cleanShutdown(agent: SpawnedAgent): Promise<void> {
+  return new Promise<void>((resolve) => {
+    agent.process.on("exit", () => resolve());
+    agent.client.close();
+    // Give the client a moment to close, then force-kill
+    setTimeout(() => {
+      if (!agent.process.killed) agent.kill();
+    }, 50);
+  });
+}
+
+// ============================================================================
+// Adapter Registry Tests
+// ============================================================================
+
+describe("Adapter auto-approve args registry", () => {
+  // AC: @ralph-adapter-auto-approve ac-1
+  it("codex-acp has correct autoApproveArgs", () => {
+    const adapter = getAdapter("codex-acp");
+    expect(adapter).toBeDefined();
+    expect(adapter!.autoApproveArgs).toEqual([
+      "-c",
+      'approval_policy="never"',
+      "-c",
+      'sandbox_mode="danger-full-access"',
+    ]);
+  });
+
+  // AC: @ralph-adapter-auto-approve ac-2
+  it("claude-agent-acp has --dangerously-skip-permissions", () => {
+    const adapter = getAdapter("claude-agent-acp");
+    expect(adapter).toBeDefined();
+    expect(adapter!.autoApproveArgs).toEqual([
+      "--dangerously-skip-permissions",
+    ]);
+  });
+
+  // AC: @ralph-adapter-auto-approve ac-2
+  it("claude-code-acp (deprecated alias) has same autoApproveArgs", () => {
+    const adapter = getAdapter("claude-code-acp");
+    expect(adapter).toBeDefined();
+    expect(adapter!.autoApproveArgs).toEqual([
+      "--dangerously-skip-permissions",
+    ]);
+  });
+
+  it("mock-acp has no autoApproveArgs", () => {
+    const adapter = getAdapter("mock-acp");
+    expect(adapter).toBeDefined();
+    expect(adapter!.autoApproveArgs).toBeUndefined();
+  });
+
+  it("ad-hoc adapters have no autoApproveArgs", () => {
+    const adapter = resolveAdapter("some-unknown-package");
+    expect(adapter.autoApproveArgs).toBeUndefined();
+  });
+});
+
+// ============================================================================
+// Spawner extraArgs Tests
+// ============================================================================
+
+describe("Spawner extraArgs handling", () => {
+  // AC: @ralph-adapter-auto-approve ac-4
+  it("does not mutate adapter.args when extraArgs provided", () => {
+    const adapter: AgentAdapter = {
+      command: "echo",
+      args: ["base-arg"],
+      description: "test adapter",
+      autoApproveArgs: ["--auto-approve"],
+    };
+
+    const originalArgs = [...adapter.args];
+
+    // spawnAgent will succeed (echo exits immediately) but adapter.args must remain unchanged
+    try {
+      const agent = spawnAgent(adapter, {
+        cwd: process.cwd(),
+        extraArgs: adapter.autoApproveArgs,
+      });
+      agent.kill();
+    } catch {
+      // Expected - echo doesn't speak ACP protocol
+    }
+
+    expect(adapter.args).toEqual(originalArgs);
+  });
+});
+
+// ============================================================================
+// Integration Tests - Args passed to spawned process
+// ============================================================================
+
+describe("Auto-approve args integration", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await setupTempFixtures();
+  });
+
+  afterEach(async () => {
+    await cleanupTempDir(tempDir);
+  });
+
+  // AC: @ralph-adapter-auto-approve ac-1, ac-2
+  it("passes adapter autoApproveArgs to spawned agent with --yolo", async () => {
+    const argsFile = path.join(tempDir, "verify-args.json");
+
+    const adapter: AgentAdapter = {
+      command: "node",
+      args: [MOCK_ACP],
+      autoApproveArgs: ["--test-auto-approve-flag"],
+    };
+
+    const agent = spawnAgent(adapter, {
+      cwd: tempDir,
+      extraArgs: adapter.autoApproveArgs,
+      env: { MOCK_ACP_VERIFY_ARGS_FILE: argsFile },
+    });
+
+    // Send initialize to trigger the mock to write args
+    await agent.client.initialize();
+    await cleanShutdown(agent);
+
+    const args = JSON.parse(await fs.readFile(argsFile, "utf-8"));
+    // process.argv includes [node, script, ...extraArgs]
+    expect(args).toContain("--test-auto-approve-flag");
+    // Original mock ACP path should be there too
+    expect(args.some((a: string) => a.includes("acp-mock.js"))).toBe(true);
+  });
+
+  // AC: @ralph-adapter-auto-approve ac-3
+  it("passes no extra args when extraArgs is undefined", async () => {
+    const argsFile = path.join(tempDir, "verify-args.json");
+
+    const adapter: AgentAdapter = {
+      command: "node",
+      args: [MOCK_ACP],
+      autoApproveArgs: ["--should-not-appear"],
+    };
+
+    // Spawn WITHOUT extraArgs (simulates --no-yolo)
+    const agent = spawnAgent(adapter, {
+      cwd: tempDir,
+      env: { MOCK_ACP_VERIFY_ARGS_FILE: argsFile },
+    });
+
+    await agent.client.initialize();
+    await cleanShutdown(agent);
+
+    const args = JSON.parse(await fs.readFile(argsFile, "utf-8"));
+    expect(args).not.toContain("--should-not-appear");
+  });
+
+  // AC: @ralph-adapter-auto-approve ac-4
+  it("worker and reviewer get independent auto-approve args (no leakage)", async () => {
+    const workerArgsFile = path.join(tempDir, "worker-args.json");
+    const reviewerArgsFile = path.join(tempDir, "reviewer-args.json");
+
+    const adapter: AgentAdapter = {
+      command: "node",
+      args: [MOCK_ACP],
+      autoApproveArgs: ["--auto-flag-1", "--auto-flag-2"],
+    };
+
+    // Spawn "worker" with auto-approve args
+    const worker = spawnAgent(adapter, {
+      cwd: tempDir,
+      extraArgs: adapter.autoApproveArgs,
+      env: { MOCK_ACP_VERIFY_ARGS_FILE: workerArgsFile },
+    });
+
+    await worker.client.initialize();
+    await cleanShutdown(worker);
+
+    // Spawn "reviewer" with auto-approve args (independent spawn)
+    const reviewer = spawnAgent(adapter, {
+      cwd: tempDir,
+      extraArgs: adapter.autoApproveArgs,
+      env: { MOCK_ACP_VERIFY_ARGS_FILE: reviewerArgsFile },
+    });
+
+    await reviewer.client.initialize();
+    await cleanShutdown(reviewer);
+
+    // Both should have the auto-approve args
+    const workerArgs = JSON.parse(
+      await fs.readFile(workerArgsFile, "utf-8"),
+    );
+    const reviewerArgs = JSON.parse(
+      await fs.readFile(reviewerArgsFile, "utf-8"),
+    );
+
+    expect(workerArgs).toContain("--auto-flag-1");
+    expect(workerArgs).toContain("--auto-flag-2");
+    expect(reviewerArgs).toContain("--auto-flag-1");
+    expect(reviewerArgs).toContain("--auto-flag-2");
+
+    // Verify adapter.args was NOT mutated (no leakage from worker to reviewer)
+    expect(adapter.args).toEqual([MOCK_ACP]);
+  });
+});


### PR DESCRIPTION
## Summary

- Replace hardcoded `--dangerously-skip-permissions` logic in ralph.ts with generic `adapter.autoApproveArgs`
- Add `extraArgs` to `SpawnAgentOptions` so auto-approve args are applied per-spawn (no cross-role leakage)
- Propagate `extraArgs` through `SubagentOptions` and `WrapUpOptions` to all spawn sites
- Add `MOCK_ACP_VERIFY_ARGS_FILE` to the mock ACP for command-line arg verification in tests
- 9 tests covering all 4 ACs: registry values, extraArgs propagation, no-yolo exclusion, cross-role isolation

## Test plan

- [x] Registry tests verify codex-acp and claude-agent-acp have correct `autoApproveArgs`
- [x] Spawner unit test verifies `adapter.args` isn't mutated when `extraArgs` provided
- [x] Integration tests verify args are passed to the spawned process with `--yolo`
- [x] Integration tests verify no extra args passed without `--yolo` (`--no-yolo`)
- [x] Integration tests verify worker and reviewer get independent args (no leakage)
- [x] Full test suite passes (pre-existing failures in session-budget and version bump tests unchanged)

Task: @implement-per-adapter-auto-approve-arguments
Spec: @ralph-adapter-auto-approve

🤖 Generated with [Claude Code](https://claude.com/claude-code)