### PR TITLE
fix: use correct scoped package name for codex-acp adapter

### DIFF
--- a/src/agents/adapters.ts
+++ b/src/agents/adapters.ts
@@ -58,7 +58,7 @@ const ADAPTERS: Record<string, AgentAdapter> = {
    */
   "codex-acp": {
     command: "npx",
-    args: ["codex-acp"],
+    args: ["@zed-industries/codex-acp"],
     shell: process.platform === "win32",
     description: "Codex agent via ACP protocol",
     autoApproveArgs: [


### PR DESCRIPTION
## Summary
- Fix codex-acp adapter package name from `codex-acp` to `@zed-industries/codex-acp`
- The package exists on npm as `@zed-industries/codex-acp` (v0.9.4)

## Test plan
- [x] All ralph tests pass (107/107)
- [x] `npm view @zed-industries/codex-acp` confirms package exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)