### PR TITLE
feat: make ralph skill invocation adapter-aware

### DIFF
--- a/src/cli/commands/ralph.ts
+++ b/src/cli/commands/ralph.ts
@@ -34,10 +34,13 @@ import {
   initContext,
   type KspecContext,
   loadAllItems,
+  loadMetaContext,
+  type LoadedSkill,
   loadAllTasks,
   type LoadedTask,
   ReferenceIndex,
 } from "../../parser/index.js";
+import { resolveSkillReferenceTokensForPlatform } from "../../parser/skill-render.js";
 import {
   buildWrapUpContext,
   createCliRenderer,
@@ -179,6 +182,112 @@ async function allExplicitTasksDone(
 }
 
 // ─── Prompt Template ─────────────────────────────────────────────────────────
+
+type RalphPromptPlatform = "claude-code" | "codex" | "unknown";
+
+type SkillOrigin = LoadedSkill["origin"];
+
+const FALLBACK_CORE_SKILLS = new Set(["task-work", "reflect", "review"]);
+
+/**
+ * Map adapter IDs to prompt rendering platforms.
+ */
+export function getPromptPlatformForAdapter(adapterId: string): RalphPromptPlatform {
+  switch (adapterId) {
+    case "claude-agent-acp":
+    case "claude-code-acp":
+      return "claude-code";
+    case "codex-acp":
+      return "codex";
+    default:
+      return "unknown";
+  }
+}
+
+/**
+ * Build skill origin map from meta skills.
+ */
+async function loadSkillOriginsForRalph(ctx: KspecContext): Promise<Map<string, SkillOrigin>> {
+  const meta = await loadMetaContext(ctx);
+  const origins = new Map<string, SkillOrigin>();
+  for (const skill of meta.skills) {
+    origins.set(skill.id, skill.origin);
+  }
+  // Fallback for core skills frequently used by ralph, even if core skills
+  // were not loaded into project meta for any reason.
+  for (const coreSkill of FALLBACK_CORE_SKILLS) {
+    if (!origins.has(coreSkill)) {
+      origins.set(coreSkill, "core");
+    }
+  }
+  return origins;
+}
+
+/**
+ * Normalize legacy literal invocation syntax for a target platform.
+ * Keeps backward compatibility for existing slash-style config values.
+ */
+function normalizeLegacyInvocation(
+  invocation: string,
+  platform: RalphPromptPlatform,
+): string {
+  if (platform === "codex") {
+    if (/^\/kspec:([a-z0-9][a-z0-9-]*)$/.test(invocation)) {
+      return invocation.replace(
+        /^\/kspec:([a-z0-9][a-z0-9-]*)$/,
+        (_m, skillId: string) => `$kspec-${skillId}`,
+      );
+    }
+    if (/^\/([a-z0-9][a-z0-9-]*)$/.test(invocation)) {
+      return invocation.replace(
+        /^\/([a-z0-9][a-z0-9-]*)$/,
+        (_m, skillId: string) => `$${skillId}`,
+      );
+    }
+  }
+
+  if (platform === "claude-code") {
+    if (/^\$kspec-([a-z0-9][a-z0-9-]*)$/.test(invocation)) {
+      return invocation.replace(
+        /^\$kspec-([a-z0-9][a-z0-9-]*)$/,
+        (_m, skillId: string) => `/kspec:${skillId}`,
+      );
+    }
+    if (/^\$([a-z0-9][a-z0-9-]*)$/.test(invocation)) {
+      return invocation.replace(
+        /^\$([a-z0-9][a-z0-9-]*)$/,
+        (_m, skillId: string) => `/${skillId}`,
+      );
+    }
+  }
+
+  return invocation;
+}
+
+/**
+ * Resolve configured skill invocation string for a specific platform.
+ * Supports portable {skill:<id>} syntax and legacy literal strings.
+ */
+export function resolveRalphSkillInvocation(
+  invocation: string,
+  platform: RalphPromptPlatform,
+  skillOrigins: Map<string, SkillOrigin>,
+): string {
+  if (platform === "unknown") {
+    return invocation;
+  }
+
+  const tokenResolved = resolveSkillReferenceTokensForPlatform(
+    invocation,
+    platform,
+    skillOrigins,
+  );
+  if (tokenResolved !== invocation) {
+    return tokenResolved;
+  }
+
+  return normalizeLegacyInvocation(invocation, platform);
+}
 
 // AC: @ralph-skill-delegation ac-1, ac-2, ac-3
 function buildTaskWorkPrompt(
@@ -691,6 +800,7 @@ async function processPendingReviewTasks(
     cwd: string;
     subagentTimeout: number;
     autoApproveArgs?: string[];
+    prReviewSkillName: string;
   },
   consecutiveFailures: { count: number },
 ): Promise<boolean> {
@@ -724,7 +834,7 @@ async function processPendingReviewTasks(
         {
           timeout: options.subagentTimeout,
           outputPrefix: DEFAULT_SUBAGENT_PREFIX,
-          skillName: ctx.config.ralph.skills.pr_review,
+          skillName: options.prReviewSkillName,
         },
         {
           yolo: options.yolo,
@@ -1021,6 +1131,25 @@ export function registerRalphCommand(program: Command): void {
           }
         }
 
+        const skillOrigins = await loadSkillOriginsForRalph(ctx);
+        const workerPromptPlatform = getPromptPlatformForAdapter(workerAdapterId);
+        const reviewerPromptPlatform = getPromptPlatformForAdapter(reviewerAdapterId);
+        const workerTaskWorkSkill = resolveRalphSkillInvocation(
+          ctx.config.ralph.skills.task_work,
+          workerPromptPlatform,
+          skillOrigins,
+        );
+        const workerReflectSkill = resolveRalphSkillInvocation(
+          ctx.config.ralph.skills.reflect,
+          workerPromptPlatform,
+          skillOrigins,
+        );
+        const reviewerPrReviewSkill = resolveRalphSkillInvocation(
+          ctx.config.ralph.skills.pr_review,
+          reviewerPromptPlatform,
+          skillOrigins,
+        );
+
         const taskScopeInfo = explicitTaskScope
           ? `, tasks=${explicitTaskScope.refs.join(",")}`
           : "";
@@ -1196,6 +1325,7 @@ export function registerRalphCommand(program: Command): void {
                 cwd: process.cwd(),
                 subagentTimeout: subagentTimeout * 60 * 1000,
                 autoApproveArgs: reviewerAutoApproveArgs,
+                prReviewSkillName: reviewerPrReviewSkill,
               },
               failureTracker,
             );
@@ -1262,7 +1392,7 @@ export function registerRalphCommand(program: Command): void {
               iteration,
               maxLoops,
               sessionId,
-              ctx.config.ralph.skills.task_work,
+              workerTaskWorkSkill,
               options.focus,
               explicitTaskScope,
             );
@@ -1270,7 +1400,7 @@ export function registerRalphCommand(program: Command): void {
               iteration,
               maxLoops,
               sessionId,
-              ctx.config.ralph.skills.reflect,
+              workerReflectSkill,
             );
 
             // AC: @cli-ralph ac-21
@@ -1286,6 +1416,9 @@ export function registerRalphCommand(program: Command): void {
               console.log(`  max-retries: ${maxRetries}`);
               console.log(`  max-failures: ${maxFailures}`);
               console.log(`  restart-every: ${restartEvery === 0 ? "never" : restartEvery}`);
+              console.log(`  worker-task-work-skill: ${workerTaskWorkSkill}`);
+              console.log(`  worker-reflect-skill: ${workerReflectSkill}`);
+              console.log(`  reviewer-pr-review-skill: ${reviewerPrReviewSkill}`);
               if (explicitTaskScope) {
                 console.log(`  explicit-tasks: ${explicitTaskScope.refs.join(", ")}`);
               }

--- a/src/parser/skill-render.ts
+++ b/src/parser/skill-render.ts
@@ -259,7 +259,7 @@ async function loadSkillOrigins(ctx: KspecContext): Promise<Map<string, LoadedSk
  * - Claude: core skills use /kspec:<id>, others use /<id>
  * - Codex: uses $<rendered-name>, where rendered-name may include core namespace
  */
-function formatSkillInvocation(skillId: string, platform: string, origin?: LoadedSkill["origin"]): string {
+export function formatSkillInvocation(skillId: string, platform: string, origin?: LoadedSkill["origin"]): string {
   switch (platform) {
     case "claude-code":
       return origin === "core" ? `/kspec:${skillId}` : `/${skillId}`;
@@ -268,6 +268,26 @@ function formatSkillInvocation(skillId: string, platform: string, origin?: Loade
     default:
       return `/${skillId}`;
   }
+}
+
+/**
+ * Resolve portable reference tokens in text for a target platform.
+ * Token syntax: {skill:<id>}
+ *
+ * `currentSkillOrigin` is optional and used as a fallback when a referenced
+ * skill isn't present in `skillOrigins` (primarily for core template rendering).
+ */
+export function resolveSkillReferenceTokensForPlatform(
+  body: string,
+  platform: string,
+  skillOrigins: Map<string, LoadedSkill["origin"]> = new Map(),
+  currentSkillOrigin?: LoadedSkill["origin"]
+): string {
+  return body.replace(SKILL_REFERENCE_TOKEN_RE, (_match, refId: string) => {
+    // If reference isn't in loaded meta, core templates usually point to core skills.
+    const referencedOrigin = skillOrigins.get(refId) ?? (currentSkillOrigin === "core" ? "core" : undefined);
+    return formatSkillInvocation(refId, platform, referencedOrigin);
+  });
 }
 
 /**
@@ -280,11 +300,7 @@ function resolveSkillReferenceTokens(
   skill: LoadedSkill,
   skillOrigins: Map<string, LoadedSkill["origin"]>
 ): string {
-  return body.replace(SKILL_REFERENCE_TOKEN_RE, (_match, refId: string) => {
-    // If reference isn't in loaded meta, core templates usually point to core skills.
-    const referencedOrigin = skillOrigins.get(refId) ?? (skill.origin === "core" ? "core" : undefined);
-    return formatSkillInvocation(refId, platform, referencedOrigin);
-  });
+  return resolveSkillReferenceTokensForPlatform(body, platform, skillOrigins, skill.origin);
 }
 
 /**

--- a/tests/ralph.test.ts
+++ b/tests/ralph.test.ts
@@ -10,6 +10,7 @@ import * as path from 'node:path';
 import { spawnSync } from 'node:child_process';
 import { createTranslator } from '../src/ralph/events.js';
 import type { SessionUpdate } from '../src/acp/types.js';
+import { getPromptPlatformForAdapter, resolveRalphSkillInvocation } from '../src/cli/commands/ralph.js';
 import { CLI_PATH, setupTempFixtures, cleanupTempDir } from './helpers/cli';
 
 const MOCK_ACP = path.join(__dirname, 'mocks', 'acp-mock.js');
@@ -2099,6 +2100,60 @@ describe('subagent module', () => {
 
       expect(output).toContain('worker=claude-code-acp');
       expect(output).toContain('reviewer=claude-agent-acp');
+    });
+  });
+
+  describe('adapter-aware skill invocation resolution', () => {
+    const skillOrigins = new Map([
+      ['task-work', 'core'],
+      ['reflect', 'core'],
+      ['review', 'core'],
+      ['project-review', 'project'],
+    ] as const);
+
+    // AC: @ralph-adapter-aware-skill-invocation ac-2
+    it('normalizes legacy core slash invocations to codex syntax for worker prompts', () => {
+      const platform = getPromptPlatformForAdapter('codex-acp');
+      const taskWork = resolveRalphSkillInvocation('/kspec:task-work', platform, skillOrigins);
+      const reflect = resolveRalphSkillInvocation('/kspec:reflect', platform, skillOrigins);
+
+      expect(taskWork).toBe('$kspec-task-work');
+      expect(reflect).toBe('$kspec-reflect');
+    });
+
+    // AC: @ralph-adapter-aware-skill-invocation ac-3
+    it('renders reviewer skill using codex syntax when reviewer adapter is codex', () => {
+      const platform = getPromptPlatformForAdapter('codex-acp');
+      const review = resolveRalphSkillInvocation('{skill:review}', platform, skillOrigins);
+      expect(review).toBe('$kspec-review');
+    });
+
+    // AC: @ralph-adapter-aware-skill-invocation ac-4
+    it('resolves portable {skill:*} references using platform and skill origins', () => {
+      const claudePlatform = getPromptPlatformForAdapter('claude-agent-acp');
+      const codexPlatform = getPromptPlatformForAdapter('codex-acp');
+
+      expect(
+        resolveRalphSkillInvocation('{skill:task-work}', claudePlatform, skillOrigins)
+      ).toBe('/kspec:task-work');
+      expect(
+        resolveRalphSkillInvocation('{skill:task-work}', codexPlatform, skillOrigins)
+      ).toBe('$kspec-task-work');
+      expect(
+        resolveRalphSkillInvocation('{skill:project-review}', codexPlatform, skillOrigins)
+      ).toBe('$project-review');
+    });
+
+    // AC: @ralph-adapter-aware-skill-invocation ac-6
+    it('resolves worker and reviewer skills independently by role adapter', () => {
+      const workerPlatform = getPromptPlatformForAdapter('codex-acp');
+      const reviewerPlatform = getPromptPlatformForAdapter('claude-agent-acp');
+
+      const workerSkill = resolveRalphSkillInvocation('{skill:task-work}', workerPlatform, skillOrigins);
+      const reviewerSkill = resolveRalphSkillInvocation('{skill:review}', reviewerPlatform, skillOrigins);
+
+      expect(workerSkill).toBe('$kspec-task-work');
+      expect(reviewerSkill).toBe('/kspec:review');
     });
   });
 


### PR DESCRIPTION
## Summary
- resolve ralph prompt skill invocations per role adapter platform (Claude vs Codex)
- support portable `{skill:<id>}` resolution in runtime prompt strings using skill origin metadata
- preserve backward compatibility by normalizing legacy slash-style core invocations for Codex
- apply reviewer-specific invocation formatting for subagent PR review prompts
- add tests for codex normalization and mixed worker/reviewer platform resolution

## Test plan
- [x] `npm run build`
- [x] `npx vitest run tests/ralph.test.ts`
- [x] `kspec validate` (fails on pre-existing repo issues, including duplicate `@observations` slug/alignment warnings; no new issues from this change)

Task: @task-adapter-aware-skill-invocation-formatting-for-ralp
Spec: @ralph-adapter-aware-skill-invocation
