### PR TITLE
Fix ralph adapter validation false-negative for codex-acp

### DIFF
--- a/src/cli/commands/ralph.ts
+++ b/src/cli/commands/ralph.ts
@@ -188,6 +188,7 @@ type RalphPromptPlatform = "claude-code" | "codex" | "unknown";
 type SkillOrigin = LoadedSkill["origin"];
 
 const FALLBACK_CORE_SKILLS = new Set(["task-work", "reflect", "review"]);
+const ADAPTER_VALIDATION_PROBES = [["--help"], ["--version"]];
 
 /**
  * Map adapter IDs to prompt rendering platforms.
@@ -400,25 +401,46 @@ Exit when reflection is complete.
 // ─── Adapter Validation ──────────────────────────────────────────────────────
 
 // AC: @ralph-adapter-validation valid-adapter-proceeds, invalid-adapter-error, validation-before-spawn
+type AdapterValidationRunner = (
+  command: string,
+  args: string[],
+  options: { encoding: "utf-8"; stdio: "pipe" },
+) => { status: number | null };
+
+/**
+ * Check whether an adapter package appears to be installed and executable.
+ * Uses multiple non-installing probes because CLIs differ on supported flags.
+ */
+export function isAdapterPackageAvailable(
+  adapterPackage: string,
+  runner: AdapterValidationRunner = spawnSync,
+): boolean {
+  for (const probeArgs of ADAPTER_VALIDATION_PROBES) {
+    const result = runner(
+      "npx",
+      ["--no-install", adapterPackage, ...probeArgs],
+      {
+        encoding: "utf-8",
+        stdio: "pipe",
+      },
+    );
+
+    if (result.status === 0) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 /**
  * Validate that the specified ACP adapter package exists.
- * Uses npx --no-install to check both global and local node_modules.
+ * Uses npx --no-install probes to check both global and local node_modules.
  *
  * @throws {Error} Never throws - exits process with code 3 if validation fails
  */
 function validateAdapter(adapterPackage: string): void {
-  // Use npx --no-install with --version to check if package exists
-  // This checks both global and local node_modules, handles scoped packages
-  const result = spawnSync(
-    "npx",
-    ["--no-install", adapterPackage, "--version"],
-    {
-      encoding: "utf-8",
-      stdio: "pipe",
-    },
-  );
-
-  if (result.status !== 0) {
+  if (!isAdapterPackageAvailable(adapterPackage)) {
     error(
       `Adapter package not found: ${adapterPackage}. Install with: npm install -g ${adapterPackage}`,
     );

--- a/tests/ralph.test.ts
+++ b/tests/ralph.test.ts
@@ -10,7 +10,11 @@ import * as path from 'node:path';
 import { spawnSync } from 'node:child_process';
 import { createTranslator } from '../src/ralph/events.js';
 import type { SessionUpdate } from '../src/acp/types.js';
-import { getPromptPlatformForAdapter, resolveRalphSkillInvocation } from '../src/cli/commands/ralph.js';
+import {
+  getPromptPlatformForAdapter,
+  isAdapterPackageAvailable,
+  resolveRalphSkillInvocation
+} from '../src/cli/commands/ralph.js';
 import { CLI_PATH, setupTempFixtures, cleanupTempDir } from './helpers/cli';
 
 const MOCK_ACP = path.join(__dirname, 'mocks', 'acp-mock.js');
@@ -2154,6 +2158,62 @@ describe('subagent module', () => {
 
       expect(workerSkill).toBe('$kspec-task-work');
       expect(reviewerSkill).toBe('/kspec:review');
+    });
+  });
+
+  describe('adapter validation probe strategy', () => {
+    // AC: @ralph-adapter-validation valid-adapter-proceeds
+    it('accepts adapters that support --help but not --version (codex-acp pattern)', () => {
+      const calls: string[][] = [];
+      const runner = (_command: string, args: string[]) => {
+        calls.push(args);
+        return { status: args.includes('--help') ? 0 : 2 };
+      };
+
+      const available = isAdapterPackageAvailable('@zed-industries/codex-acp', runner);
+
+      expect(available).toBe(true);
+      // Should succeed on first probe and not continue.
+      expect(calls).toEqual([
+        ['--no-install', '@zed-industries/codex-acp', '--help'],
+      ]);
+    });
+
+    // AC: @ralph-adapter-validation valid-adapter-proceeds
+    it('falls back to --version when --help is unsupported', () => {
+      const calls: string[][] = [];
+      const runner = (_command: string, args: string[]) => {
+        calls.push(args);
+        if (args.includes('--help')) {
+          return { status: 2 };
+        }
+        return { status: args.includes('--version') ? 0 : 2 };
+      };
+
+      const available = isAdapterPackageAvailable('some-adapter', runner);
+
+      expect(available).toBe(true);
+      expect(calls).toEqual([
+        ['--no-install', 'some-adapter', '--help'],
+        ['--no-install', 'some-adapter', '--version'],
+      ]);
+    });
+
+    // AC: @ralph-adapter-validation invalid-adapter-error
+    it('returns false when all probes fail', () => {
+      const calls: string[][] = [];
+      const runner = (_command: string, args: string[]) => {
+        calls.push(args);
+        return { status: 1 };
+      };
+
+      const available = isAdapterPackageAvailable('@nonexistent/adapter', runner);
+
+      expect(available).toBe(false);
+      expect(calls).toEqual([
+        ['--no-install', '@nonexistent/adapter', '--help'],
+        ['--no-install', '@nonexistent/adapter', '--version'],
+      ]);
     });
   });
 


### PR DESCRIPTION
## Summary
- update ralph adapter package validation to probe with `npx --no-install <pkg> --help` first and fall back to `--version`
- prevent false negatives for adapters like `@zed-industries/codex-acp` that reject `--version`
- add regression coverage for help-first success, version fallback, and all-probes-fail behavior

## Test plan
- [x] `npx vitest run tests/ralph.test.ts`

Task: @01KJF3XQ
Spec: @ralph-adapter-validation

Generated with Codex