### PR TITLE
fix(config): route ralph pr reviews to pr-review skill

### DIFF
--- a/kspec.config.yaml
+++ b/kspec.config.yaml
@@ -1,0 +1,3 @@
+ralph:
+  skills:
+    pr_review: "{skill:pr-review}"


### PR DESCRIPTION
## Summary
- add `kspec.config.yaml` override for `ralph.skills.pr_review`
- set reviewer skill token to `{skill:pr-review}` so Codex reviewer runs `$pr-review`
- avoid defaulting to `/kspec:review` when the goal is full PR-process review behavior

## Test plan
- [x] `npm run dev -- ralph run --adapter codex --dry-run`
- [x] confirm dry-run shows `reviewer-pr-review-skill: {skill:pr-review}`
