### PR TITLE
fix(validate): isolate scoped mode checks

### DIFF
--- a/src/cli/commands/validate.ts
+++ b/src/cli/commands/validate.ts
@@ -841,15 +841,20 @@ export function registerValidateCommand(program: Command): void {
         // Track warnings from all sources for exit code determination
         let additionalWarningCount = 0;
 
-        // Determine which checks to run
-        const runAll =
-          !options.schema &&
-          !options.refs &&
-          !options.orphans &&
-          !options.alignment &&
-          !options.completeness &&
-          !options.conventions &&
-          !options.skills;
+        // Determine which checks to run. Coerce to booleans so we pass explicit
+        // false values to parser validation when a check is not selected.
+        const selectedChecks = {
+          schema: Boolean(options.schema),
+          refs: Boolean(options.refs),
+          orphans: Boolean(options.orphans),
+          alignment: Boolean(options.alignment),
+          completeness: Boolean(options.completeness),
+          conventions: Boolean(options.conventions),
+          staleness: Boolean(options.staleness),
+          skills: Boolean(options.skills),
+          drift: Boolean(options.drift),
+        };
+        const runAll = !Object.values(selectedChecks).some(Boolean);
 
         // AC: @config-validation ac-4 — CLI --strict overrides config strict_refs
         // If --strict is passed, use strict behavior regardless of config
@@ -858,10 +863,10 @@ export function registerValidateCommand(program: Command): void {
         const requireAcceptance = ctx.config.validation.require_acceptance;
 
         const validateOptions = {
-          schema: runAll || options.schema,
-          refs: runAll || options.refs,
-          orphans: runAll || options.orphans,
-          completeness: runAll || options.completeness,
+          schema: runAll || selectedChecks.schema,
+          refs: runAll || selectedChecks.refs,
+          orphans: runAll || selectedChecks.orphans,
+          completeness: runAll || selectedChecks.completeness,
           // AC: @config-validation ac-2 ac-3 ac-4 — wire config into validation
           strictRefs,
           requireAcceptance,
@@ -899,7 +904,7 @@ export function registerValidateCommand(program: Command): void {
         }
 
         // Run alignment check if requested or running all checks
-        if (options.alignment || runAll) {
+        if (selectedChecks.alignment || runAll) {
           const tasks = await loadAllTasks(ctx);
           const items = await loadAllItems(ctx);
           const refIndex = new ReferenceIndex(tasks, items);
@@ -932,7 +937,7 @@ export function registerValidateCommand(program: Command): void {
 
         // Run convention validation if requested
         // AC: @convention-definitions ac-3, ac-4
-        if (options.conventions) {
+        if (selectedChecks.conventions) {
           try {
             const metaCtx = await loadMetaContext(ctx);
             if (metaCtx && metaCtx.conventions.length > 0) {
@@ -965,7 +970,7 @@ export function registerValidateCommand(program: Command): void {
         // Run staleness checks if requested
         // AC: @stale-status-detection ac-4, ac-5
         let stalenessWarningCount = 0;
-        if (options.staleness) {
+        if (selectedChecks.staleness) {
           const tasks = await loadAllTasks(ctx);
           const items = await loadAllItems(ctx);
           const refIndex = new ReferenceIndex(tasks, items);
@@ -982,7 +987,7 @@ export function registerValidateCommand(program: Command): void {
         }
 
         // Run skill file validation if requested or running all checks
-        if (runAll || options.skills) {
+        if (runAll || selectedChecks.skills) {
           const skillResult = await validateSkills(ctx.rootDir);
           formatSkillValidationResult(skillResult, options.verbose);
 
@@ -993,7 +998,7 @@ export function registerValidateCommand(program: Command): void {
 
         // Run AC schema drift checks if requested
         let driftWarningCount = 0;
-        if (options.drift) {
+        if (selectedChecks.drift) {
           const items = await loadAllItems(ctx);
           const driftWarnings = checkACSchemaReferences(items);
           formatDriftWarnings(driftWarnings, options.verbose);
@@ -1055,21 +1060,23 @@ export function registerValidateCommand(program: Command): void {
           process.exit(EXIT_CODES.ERROR);
         }
 
-        const runAll =
-          !options.schema &&
-          !options.refs &&
-          !options.orphans &&
-          !options.completeness;
+        const selectedChecks = {
+          schema: Boolean(options.schema),
+          refs: Boolean(options.refs),
+          orphans: Boolean(options.orphans),
+          completeness: Boolean(options.completeness),
+        };
+        const runAll = !Object.values(selectedChecks).some(Boolean);
 
         // AC: @config-validation ac-4 — CLI --strict overrides config strict_refs
         const strictRefs = options.strict ? true : ctx.config.validation.strict_refs;
         const requireAcceptance = ctx.config.validation.require_acceptance;
 
         const validateOptions = {
-          schema: runAll || options.schema,
-          refs: runAll || options.refs,
-          orphans: runAll || options.orphans,
-          completeness: runAll || options.completeness,
+          schema: runAll || selectedChecks.schema,
+          refs: runAll || selectedChecks.refs,
+          orphans: runAll || selectedChecks.orphans,
+          completeness: runAll || selectedChecks.completeness,
           strictRefs,
           requireAcceptance,
         };

--- a/src/parser/validate.ts
+++ b/src/parser/validate.ts
@@ -1605,9 +1605,10 @@ export async function validate(
   // AC: @plan-validation ac-10
   const allPlans = await loadPlans(ctx);
 
-  // Reference validation
+  // Build reference index when any downstream check needs it.
+  const needsRefIndex = runRefs || runOrphans || runCompleteness;
   if (
-    runRefs &&
+    needsRefIndex &&
     (allTasks.length > 0 ||
       allItems.length > 0 ||
       allMetaItems.length > 0 ||
@@ -1619,40 +1620,43 @@ export async function validate(
       allMetaItems,
       allPlans,
     );
-    const refResult = validateRefs(index, allTasks, allItems);
 
-    // AC: @config-validation ac-2 ac-3 — strict_refs controls error vs warning
-    // When strictRefs is false, demote "not_found" ref errors to warnings
-    if (options.strictRefs === false) {
-      // Move not_found errors to warnings
-      const notFoundErrors = refResult.errors.filter((e) => e.error === "not_found");
-      const otherErrors = refResult.errors.filter((e) => e.error !== "not_found");
+    if (runRefs) {
+      const refResult = validateRefs(index, allTasks, allItems);
 
-      result.refErrors = otherErrors;
-      result.refWarnings = [
-        ...refResult.warnings,
-        ...notFoundErrors.map((e) => ({
-          ref: e.ref,
-          sourceFile: e.sourceFile,
-          sourceUlid: e.sourceUlid,
-          field: e.field,
-          warning: "deprecated_target" as const, // Reuse existing warning type
-          message: e.message,
-        })),
-      ];
-    } else {
-      // Default/strict behavior: not_found refs are errors
-      result.refErrors = refResult.errors;
-      result.refWarnings = refResult.warnings;
+      // AC: @config-validation ac-2 ac-3 — strict_refs controls error vs warning
+      // When strictRefs is false, demote "not_found" ref errors to warnings
+      if (options.strictRefs === false) {
+        // Move not_found errors to warnings
+        const notFoundErrors = refResult.errors.filter((e) => e.error === "not_found");
+        const otherErrors = refResult.errors.filter((e) => e.error !== "not_found");
+
+        result.refErrors = otherErrors;
+        result.refWarnings = [
+          ...refResult.warnings,
+          ...notFoundErrors.map((e) => ({
+            ref: e.ref,
+            sourceFile: e.sourceFile,
+            sourceUlid: e.sourceUlid,
+            field: e.field,
+            warning: "deprecated_target" as const, // Reuse existing warning type
+            message: e.message,
+          })),
+        ];
+      } else {
+        // Default/strict behavior: not_found refs are errors
+        result.refErrors = refResult.errors;
+        result.refWarnings = refResult.warnings;
+      }
+
+      // AC: @skill-validation ac-2 - validate skill depends_on references
+      const skillDependsOnWarnings = validateSkillDependsOn(metaCtx.skills, index);
+      result.refWarnings.push(...skillDependsOnWarnings);
+
+      // AC: @trait-edge-cases ac-2
+      // Detect circular trait references
+      result.traitCycleErrors = detectTraitCycles(allItems, index);
     }
-
-    // AC: @skill-validation ac-2 - validate skill depends_on references
-    const skillDependsOnWarnings = validateSkillDependsOn(metaCtx.skills, index);
-    result.refWarnings.push(...skillDependsOnWarnings);
-
-    // AC: @trait-edge-cases ac-2
-    // Detect circular trait references
-    result.traitCycleErrors = detectTraitCycles(allItems, index);
 
     // Orphan detection
     if (runOrphans) {

--- a/tests/ac-schema-drift.test.ts
+++ b/tests/ac-schema-drift.test.ts
@@ -269,6 +269,10 @@ includes:
 
     // Should contain drift warnings
     expect(resultWithFlag).toContain("AC Schema Drift");
+    // Scoped mode should not run unrelated warning checks
+    expect(resultWithFlag).not.toContain("Alignment warnings");
+    expect(resultWithFlag).not.toContain("Completeness warnings");
+    expect(resultWithFlag).not.toContain("Staleness warnings");
   });
 
   it("should exit with code 6 for warnings, code 4 with --strict", async () => {

--- a/tests/staleness.test.ts
+++ b/tests/staleness.test.ts
@@ -256,6 +256,9 @@ tasks:
 
     // Should contain staleness warnings
     expect(resultWithFlag).toContain("Staleness warnings");
+    // Should not include unrelated warning sections in scoped mode
+    expect(resultWithFlag).not.toContain("Alignment warnings");
+    expect(resultWithFlag).not.toContain("Completeness warnings");
   });
 
   // AC: @stale-status-detection staleness-exit-code

--- a/tests/validate-mode-selection.test.ts
+++ b/tests/validate-mode-selection.test.ts
@@ -1,0 +1,137 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  cleanupTempDir,
+  createTempDir,
+  initGitRepo,
+  kspecWithStatus,
+  testUlid,
+} from "./helpers/cli";
+
+describe("validate mode selection", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await createTempDir("kspec-validate-mode-");
+    initGitRepo(tmpDir);
+    await setupProjectWithTargetedWarnings(tmpDir);
+  });
+
+  afterEach(async () => {
+    if (tmpDir) {
+      await cleanupTempDir(tmpDir);
+    }
+  });
+
+  async function setupProjectWithTargetedWarnings(rootDir: string): Promise<void> {
+    const specDir = path.join(rootDir, "spec");
+    await fs.mkdir(specDir, { recursive: true });
+
+    const specUlid = testUlid("SPEC01");
+    const taskUlid = testUlid("TASK01");
+
+    await fs.writeFile(
+      path.join(rootDir, "kynetic.yaml"),
+      `kynetic: "1.0"
+project:
+  name: validate-mode-test
+  version: 0.1.0
+includes:
+  - "spec/module.yaml"
+tasks:
+  - "spec/project.tasks.yaml"
+`,
+    );
+
+    // Missing acceptance_criteria triggers completeness warnings.
+    // completed task against not_started spec triggers staleness + alignment mismatch.
+    await fs.writeFile(
+      path.join(specDir, "module.yaml"),
+      `- _ulid: ${specUlid}
+  slugs:
+    - mode-spec
+  title: Mode Spec
+  type: feature
+  description: Spec used to verify validate mode isolation
+  status:
+    implementation: not_started
+`,
+    );
+
+    await fs.writeFile(
+      path.join(specDir, "project.tasks.yaml"),
+      `tasks:
+  - _ulid: ${taskUlid}
+    slugs:
+      - task-mode-spec
+    title: Completed task for mode spec
+    status: completed
+    spec_ref: "@mode-spec"
+`,
+    );
+  }
+
+  it("runs only schema checks for --schema", () => {
+    const result = kspecWithStatus("validate --schema", tmpDir);
+    const output = `${result.stdout}\n${result.stderr}`;
+
+    expect(result.exitCode).toBe(0);
+    expect(output).not.toContain("Completeness warnings");
+    expect(output).not.toContain("Alignment warnings");
+    expect(output).not.toContain("Staleness warnings");
+  });
+
+  it("runs only reference checks for --refs", () => {
+    const result = kspecWithStatus("validate --refs", tmpDir);
+    const output = `${result.stdout}\n${result.stderr}`;
+
+    expect(result.exitCode).toBe(0);
+    expect(output).not.toContain("Completeness warnings");
+    expect(output).not.toContain("Alignment warnings");
+    expect(output).not.toContain("Staleness warnings");
+  });
+
+  it("runs only alignment checks for --alignment", () => {
+    const result = kspecWithStatus("validate --alignment", tmpDir);
+    const output = `${result.stdout}\n${result.stderr}`;
+
+    expect(result.exitCode).toBe(6);
+    expect(output).toContain("Alignment warnings");
+    expect(output).not.toContain("Completeness warnings");
+    expect(output).not.toContain("Staleness warnings");
+  });
+
+  it("runs only completeness checks for --completeness", () => {
+    const result = kspecWithStatus("validate --completeness", tmpDir);
+    const output = `${result.stdout}\n${result.stderr}`;
+
+    expect(result.exitCode).toBe(6);
+    expect(output).toContain("Completeness warnings");
+    expect(output).not.toContain("Alignment warnings");
+    expect(output).not.toContain("Staleness warnings");
+  });
+
+  it("runs only staleness checks for --staleness", () => {
+    const result = kspecWithStatus("validate --staleness", tmpDir);
+    const output = `${result.stdout}\n${result.stderr}`;
+
+    expect(result.exitCode).toBe(6);
+    expect(output).toContain("Staleness warnings");
+    expect(output).not.toContain("Alignment warnings");
+    expect(output).not.toContain("Completeness warnings");
+  });
+
+  it("runs combined scopes when flags are combined", () => {
+    const result = kspecWithStatus(
+      "validate --alignment --completeness",
+      tmpDir,
+    );
+    const output = `${result.stdout}\n${result.stderr}`;
+
+    expect(result.exitCode).toBe(6);
+    expect(output).toContain("Alignment warnings");
+    expect(output).toContain("Completeness warnings");
+    expect(output).not.toContain("Staleness warnings");
+  });
+});


### PR DESCRIPTION
## Summary
- fix validate mode selection to use explicit scoped flag semantics (single flag = isolated check, combined flags = union)
- include `--staleness` and `--drift` in `runAll` detection to prevent accidental extra checks
- decouple parser completeness/orphan checks from the refs gate so scoped completeness/orphans still execute correctly
- add regression coverage for mode isolation and combined-mode behavior
- strengthen staleness/drift tests to assert unrelated warning sections are not emitted in scoped mode

## Test plan
- [x] `npm run build`
- [x] `npx vitest run tests/validate-mode-selection.test.ts tests/staleness.test.ts tests/ac-schema-drift.test.ts`
- [ ] `npm test` *(currently has unrelated pre-existing failures in `tests/ralph/session-budget-integration.test.ts` due timeout waiting for "Ralph loop completed")*

Task: @task-stabilize-kspec-validate-baseline
Spec: N/A (spike task without `spec_ref`)
