### PR TITLE
fix: prevent task patch TTY hang without --data

### DIFF
--- a/src/cli/commands/task.ts
+++ b/src/cli/commands/task.ts
@@ -995,12 +995,25 @@ Examples:
         if (options.data) {
           jsonData = options.data;
         } else {
+          const isTTY =
+            process.env.KSPEC_TEST_TTY === "1" ||
+            process.env.KSPEC_TEST_TTY === "true" ||
+            process.stdin.isTTY;
+          if (isTTY) {
+            error(errors.validation.noPatchData);
+            process.exit(EXIT_CODES.VALIDATION_FAILED);
+          }
+
           // Read from stdin
           const chunks: Buffer[] = [];
           for await (const chunk of process.stdin) {
             chunks.push(chunk);
           }
           jsonData = Buffer.concat(chunks).toString("utf-8");
+          if (!jsonData.trim()) {
+            error(errors.validation.noPatchData);
+            process.exit(EXIT_CODES.VALIDATION_FAILED);
+          }
         }
 
         // Parse JSON

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -502,6 +502,23 @@ describe('Integration: task patch', () => {
     const task = kspecJson<{ priority: number }>('task get @test-task-pending', tempDir);
     expect(task.priority).toBe(2); // Original value from fixture
   });
+
+  it('should read patch JSON from stdin when no --data is provided', () => {
+    // AC: @task-patch ac-1
+    kspec('task patch @test-task-pending', tempDir, { stdin: '{"priority":1}' });
+
+    const task = kspecJson<{ priority: number }>('task get @test-task-pending', tempDir);
+    expect(task.priority).toBe(1);
+  });
+
+  it('should fail fast in interactive mode when no --data is provided', () => {
+    const result = kspecRun('task patch @test-task-pending', tempDir, {
+      expectFail: true,
+      env: { KSPEC_TEST_TTY: 'true' },
+    });
+    expect(result.exitCode).toBe(4);
+    expect(result.stderr).toContain('No patch data. Use --data or pipe JSON to stdin.');
+  });
 });
 
 describe('Integration: items', () => {


### PR DESCRIPTION
## Summary
- fail fast for \ when \ is omitted on interactive TTY stdin
- return validation error for empty stdin instead of attempting JSON parse
- add integration coverage for piped stdin success and interactive no-input fast fail

## Verification
- npm run build
- npx vitest run tests/integration.test.ts -t "Integration: task patch"
- npx vitest run tests/batch-exec-engine.test.ts

Task: @01KJDQ10
Spec: @task-patch