### PR TITLE
fix(agents): include package version in freshness hash

### DIFF
--- a/src/cli/commands/agents.ts
+++ b/src/cli/commands/agents.ts
@@ -127,10 +127,12 @@ export function computeMetaHash(
   conventions: LoadedConvention[],
   workflows: LoadedWorkflow[],
   templateSections?: string[],
+  metaVersion: string = version,
 ): string {
   // Create a stable representation of the meta content
   // AC: @cross-platform-and-version-robustness ac-4 - includes templates for staleness detection
   const data: Record<string, unknown> = {
+    version: metaVersion,
     skills: skills.map((s) => ({
       id: s.id,
       name: s.name,

--- a/tests/agent-data-sections.test.ts
+++ b/tests/agent-data-sections.test.ts
@@ -555,4 +555,27 @@ describe("computeMetaHash", () => {
 
     expect(hashWithout).not.toBe(hashWith);
   });
+
+  it("should produce different hashes when only package version differs", () => {
+    const skills: LoadedSkill[] = [];
+    const conventions: LoadedConvention[] = [];
+    const workflows: LoadedWorkflow[] = [];
+
+    const hashV1 = computeMetaHash(
+      skills,
+      conventions,
+      workflows,
+      undefined,
+      "0.9.0",
+    );
+    const hashV2 = computeMetaHash(
+      skills,
+      conventions,
+      workflows,
+      undefined,
+      "0.9.1",
+    );
+
+    expect(hashV1).not.toBe(hashV2);
+  });
 });

--- a/tests/agents-instruction-gen.test.ts
+++ b/tests/agents-instruction-gen.test.ts
@@ -7,8 +7,11 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as crypto from 'node:crypto';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
+import { computeMetaHash, getPackageRoot, loadTemplateSections } from '../src/cli/commands/agents.js';
+import { initContext, loadMetaContext } from '../src/parser/index.js';
 import {
   kspec as kspecFull,
   kspecJson,
@@ -293,6 +296,57 @@ describe('Agent Instruction Generation', () => {
       const result = kspecFull('agents status', tempDir);
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain('stale');
+    });
+
+    it('should report stale when stored hash was computed without version', async () => {
+      kspecFull('agents generate', tempDir);
+
+      const ctx = await initContext(tempDir);
+      const meta = await loadMetaContext(ctx);
+      const templateSections = await loadTemplateSections(getPackageRoot());
+
+      const hashPath = path.join(tempDir, '.kspec', '.kspec-agents-hash');
+      const hashData = JSON.parse(await fs.readFile(hashPath, 'utf-8'));
+
+      const legacyData = {
+        skills: meta.skills.map((s) => ({
+          id: s.id,
+          name: s.name,
+          description: s.description,
+        })),
+        conventions: meta.conventions.map((c) => ({
+          domain: c.domain,
+          rules: c.rules,
+          examples: (c.examples ?? []).map((e) => ({ good: e.good, bad: e.bad })),
+        })),
+        workflows: meta.workflows.map((w) => ({
+          id: w.id,
+          trigger: w.trigger,
+          description: w.description,
+        })),
+        templates: templateSections,
+      };
+      const legacyHash = crypto
+        .createHash('sha256')
+        .update(JSON.stringify(legacyData), 'utf-8')
+        .digest('hex');
+      const currentHash = computeMetaHash(
+        meta.skills,
+        meta.conventions,
+        meta.workflows,
+        templateSections
+      );
+
+      expect(legacyHash).not.toBe(currentHash);
+      await fs.writeFile(
+        hashPath,
+        JSON.stringify({ ...hashData, metaHash: legacyHash }, null, 2) + '\n',
+        'utf-8'
+      );
+
+      const status = kspecFull('agents status', tempDir);
+      expect(status.exitCode).toBe(0);
+      expect(status.stdout).toContain('stale');
     });
 
     it('should return status in JSON output', async () => {


### PR DESCRIPTION
## Summary
- include package version in computeMetaHash so kspec agents generate freshness checks invalidate after release version bumps
- add unit coverage proving hash changes when only version changes
- add CLI integration coverage proving legacy no-version stored hashes are reported stale

## Verification
- npx vitest run tests/agent-data-sections.test.ts tests/agents-instruction-gen.test.ts tests/enhanced-setup.test.ts tests/setup-pipeline-unification.test.ts
- npm test

Task: @01KJDQ13
Spec: @agents-cli