### PR TITLE
fix(task): accept P1-P5 priority notation

### DIFF
--- a/src/cli/commands/task.ts
+++ b/src/cli/commands/task.ts
@@ -41,7 +41,7 @@ import {
   warn,
 } from "../output.js";
 import {
-  parseIntOption,
+  parsePriority,
   validateEnumOption,
   validateSpecRef,
 } from "../validators.js";
@@ -284,11 +284,7 @@ async function setTaskFields(
     }
 
     if (options.priority) {
-      const priorityResult = parseIntOption(options.priority, {
-        min: 1,
-        max: 5,
-        name: "Priority",
-      });
+      const priorityResult = parsePriority(options.priority);
       if (!priorityResult.ok) {
         return { success: false, error: priorityResult.error };
       }
@@ -605,7 +601,7 @@ export function registerTaskCommands(program: Command): void {
       "Reference to meta item (workflow, agent, or convention)",
     )
     .option("--plan-ref <ref>", "Reference to plan this task is derived from")
-    .option("--priority <n>", "Priority (1-5)", "3")
+    .option("--priority <n>", "Priority (1-5 or P1-P5)", "3")
     .option("--slug <slug>", "Human-friendly slug")
     .option("--tag <tag...>", "Tags")
     .option("--depends-on <refs...>", "Set task dependencies")
@@ -756,11 +752,7 @@ Examples:
         }
 
         // Validate priority
-        const priorityResult = parseIntOption(options.priority, {
-          min: 1,
-          max: 5,
-          name: "Priority",
-        });
+        const priorityResult = parsePriority(options.priority);
         if (!priorityResult.ok) {
           error(priorityResult.error);
           process.exit(EXIT_CODES.VALIDATION_FAILED);
@@ -824,7 +816,7 @@ Examples:
       "Link to meta item (use 'null' to clear)",
     )
     .option("--plan-ref <ref>", "Link to plan (use 'null' to clear)")
-    .option("--priority <n>", "Set priority (1-5)")
+    .option("--priority <n>", "Set priority (1-5 or P1-P5)")
     .option("--slug <slug>", "Add a slug alias")
     .option("--tag <tag...>", "Add tags")
     .option("--depends-on <refs...>", "Set dependencies (replaces existing)")

--- a/src/cli/validators.ts
+++ b/src/cli/validators.ts
@@ -63,6 +63,20 @@ export function parseIntOption(
   return { ok: true, value: num };
 }
 
+// ─── parsePriority ──────────────────────────────────────────
+
+/**
+ * Parse task priority supporting numeric form (1-5) and P-notation (P1-P5).
+ */
+export function parsePriority(value: string): Result<number> {
+  const normalized = value.replace(/^[Pp]/, "");
+  return parseIntOption(normalized, {
+    min: 1,
+    max: 5,
+    name: "Priority (1-5 or P1-P5)",
+  });
+}
+
 // ─── validateEnumOption ─────────────────────────────────────
 
 /**

--- a/tests/cli-validators.test.ts
+++ b/tests/cli-validators.test.ts
@@ -7,6 +7,7 @@
 import { describe, expect, it } from "vitest";
 import {
   parseIntOption,
+  parsePriority,
   validateEnumOption,
   validateSpecRef,
 } from "../src/cli/validators.js";
@@ -90,6 +91,36 @@ describe("parseIntOption", () => {
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.error).toContain("Limit");
+    }
+  });
+});
+
+describe("parsePriority", () => {
+  it("accepts numeric format", () => {
+    expect(parsePriority("2")).toEqual({ ok: true, value: 2 });
+  });
+
+  it("accepts uppercase P notation", () => {
+    expect(parsePriority("P1")).toEqual({ ok: true, value: 1 });
+  });
+
+  it("accepts lowercase p notation", () => {
+    expect(parsePriority("p3")).toEqual({ ok: true, value: 3 });
+  });
+
+  it("rejects out-of-range P notation", () => {
+    const result = parsePriority("P6");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("Priority (1-5 or P1-P5)");
+    }
+  });
+
+  it("rejects invalid P notation", () => {
+    const result = parsePriority("Px");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("Priority (1-5 or P1-P5)");
     }
   });
 });

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -310,6 +310,13 @@ describe('Integration: task add', () => {
     expect(task.tags).toContain('fix');
     expect(task.slugs).toContain('my-bug');
   });
+
+  it('should accept P-notation for --priority in task add', () => {
+    kspec('task add --title "P notation add" --priority p3 --slug p-notation-add', tempDir);
+
+    const task = kspecJson<{ priority: number }>('task get @p-notation-add', tempDir);
+    expect(task.priority).toBe(3);
+  });
 });
 
 describe('Integration: task set', () => {
@@ -399,10 +406,23 @@ describe('Integration: task set', () => {
     expect(task.priority).toBe(1);
   });
 
+  it('should accept P-notation for --priority in task set', () => {
+    kspec('task set @test-task-pending --priority P1', tempDir);
+
+    const task = kspecJson<{ priority: number }>('task get @test-task-pending', tempDir);
+    expect(task.priority).toBe(1);
+  });
+
   // AC: @task-set ac-task-set-6
   it('should reject invalid priority', () => {
     const result = kspecRun('task set @test-task-pending --priority 6', tempDir, { expectFail: true });
     expect(result.exitCode).not.toBe(0);
+  });
+
+  it('should reject invalid P-notation priority with clear guidance', () => {
+    const result = kspecRun('task set @test-task-pending --priority Px', tempDir, { expectFail: true });
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain('Priority (1-5 or P1-P5)');
   });
 
   it('should add slug to task', () => {


### PR DESCRIPTION
## Summary
- add `parsePriority()` in CLI validators to support both numeric and `P1`-style priority input
- switch `task add` and `task set` priority parsing to use `parsePriority`
- update task command help text to document `1-5 or P1-P5`
- add validator unit tests and integration coverage for `P` notation and invalid values

## Verification
- npm test -- --run tests/cli-validators.test.ts tests/integration.test.ts

Task: @01KJDQ15
Spec: @batch-exec
