### PR TITLE
fix(item): suggest meta observe get for observation refs

### DIFF
--- a/src/cli/commands/item.ts
+++ b/src/cli/commands/item.ts
@@ -16,10 +16,12 @@ import {
   initContext,
   type LoadedSpecItem,
   loadAllItems,
+  loadMetaContext,
   loadAllTasks,
   type PatchOperation,
   patchSpecItems,
   ReferenceIndex,
+  resolveMetaRef,
   updateSpecItem,
 } from "../../parser/index.js";
 import type { ItemFilter } from "../../parser/items.js";
@@ -452,7 +454,18 @@ export function registerItemCommands(program: Command): void {
         const result = refIndex.resolve(ref);
 
         if (!result.ok) {
-          error(errors.reference.itemNotFound(ref));
+          let notFoundMessage = errors.reference.itemNotFound(ref);
+          try {
+            const metaCtx = await loadMetaContext(ctx);
+            const resolvedMetaRef = resolveMetaRef(metaCtx, ref);
+            if (resolvedMetaRef?.type === "observation") {
+              notFoundMessage = `Item not found: ${ref}\nHint: ${ref} is an observation. Use: kspec meta observe get ${ref}`;
+            }
+          } catch {
+            // Fall back to the standard item-not-found error when meta context is unavailable.
+          }
+
+          error(notFoundMessage);
           process.exit(EXIT_CODES.ERROR);
         }
 

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -570,6 +570,23 @@ describe('Integration: items', () => {
     expect(output).toContain('requirement');
   });
 
+  it('should suggest meta observe get for observation refs', () => {
+    const observation = kspecJson<{ _ulid: string }>(
+      'meta observe idea "Observation for item-get guidance"',
+      tempDir
+    );
+    const observationRef = `@${observation._ulid.slice(0, 8)}`;
+
+    const result = kspecRun(`item get ${observationRef}`, tempDir, {
+      expectFail: true,
+    });
+
+    expect(result.stderr).toContain(`Item not found: ${observationRef}`);
+    expect(result.stderr).toContain(
+      `Hint: ${observationRef} is an observation. Use: kspec meta observe get ${observationRef}`
+    );
+  });
+
   // AC: @item-get ac-1
   it('should display acceptance criteria in item get output', () => {
     // First add an AC to the item


### PR DESCRIPTION
## Summary
- add observation-aware fallback in `item get` when spec reference resolution fails
- if unresolved ref maps to a meta observation, return a hint to use `kspec meta observe get <ref>`
- add integration coverage for the new guidance path

## Verification
- npm test -- --run tests/integration.test.ts -t "suggest meta observe get for observation refs"

Task: @01KJDQ173
