### PR TITLE
fix: fail fast for empty batch --commands input

### DIFF
--- a/src/cli/commands/batch.ts
+++ b/src/cli/commands/batch.ts
@@ -145,7 +145,7 @@ Examples:
       let source: { type: "stdin" } | { type: "file"; path: string } | { type: "inline"; json: string };
       if (options.file) {
         source = { type: "file", path: options.file };
-      } else if (options.commands) {
+      } else if (options.commands !== undefined) {
         source = { type: "inline", json: options.commands };
       } else {
         source = { type: "stdin" };

--- a/tests/batch-exec-engine.test.ts
+++ b/tests/batch-exec-engine.test.ts
@@ -459,6 +459,33 @@ describe("batch command integration", () => {
     expect(result.stderr).toMatch(/position \d+/i);
   });
 
+  // AC: @batch-exec ac-inline — empty --commands still uses inline source
+  // AC: @batch-exec ac-invalid-json
+  // AC: @trait-semantic-exit-codes ac-2 — validation error exits non-zero
+  it("rejects empty --commands value instead of falling back to stdin", () => {
+    const result = kspec(
+      "batch --commands ''",
+      tempDir,
+      { expectFail: true },
+    );
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("Invalid JSON");
+    expect(result.stderr).not.toContain("No input received on stdin");
+  });
+
+  // AC: @batch-exec ac-inline — whitespace --commands still uses inline source
+  // AC: @batch-exec ac-invalid-json
+  it("rejects whitespace-only --commands value instead of falling back to stdin", () => {
+    const result = kspec(
+      "batch --commands '   '",
+      tempDir,
+      { expectFail: true },
+    );
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("Invalid JSON");
+    expect(result.stderr).not.toContain("No input received on stdin");
+  });
+
   // AC: @batch-exec ac-invalid-json — JSON mode returns structured error
   // AC: @trait-json-output ac-3 — error returned as JSON with error field
   it("returns structured JSON error for malformed JSON in --json mode", () => {


### PR DESCRIPTION
## Summary
- treat --commands as inline input whenever the flag is present (options.commands !== undefined)
- prevent fallback to stdin path for empty or whitespace inline values
- add regression tests for --commands '' and --commands '   ' asserting Invalid JSON

## Verification
- npm test -- tests/batch-exec-engine.test.ts
- node dist/cli/index.js batch --commands '' (exits 1 immediately with Invalid JSON)

Task: @01KJDQ18
Spec: @batch-exec