### PR TITLE
fix: clarify same-version core skill update guidance

### DIFF
--- a/src/cli/commands/skill-install.ts
+++ b/src/cli/commands/skill-install.ts
@@ -52,6 +52,7 @@ interface CoreSkillUpdateResult {
   newVersion?: string;
   currentVersion?: string;
   reason?: string;
+  guidance?: string;
 }
 
 /**
@@ -661,11 +662,19 @@ export function registerSkillInstallCommands(skill: Command): void {
           // AC: @core-skill-update ac-2 - Skip if already at current version
           // If kspecVersion is null or skill has no version, always update
           if (kspecVersion && skill.version === kspecVersion) {
+            const targetDir = path.dirname(getSkillContentPath(ctx, skill.id));
+            const sourceDir = path.join(getTemplatesDir(), skill.id);
+            const isTemplateInSync = await sourceMatchesDest(sourceDir, targetDir);
             results.push({
               id: skill.id,
               action: "skipped",
-              reason: "already at current version",
+              reason: isTemplateInSync
+                ? "already at current version"
+                : "already at current version; template content differs from local files",
               currentVersion: skill.version,
+              guidance: isTemplateInSync
+                ? undefined
+                : "Run `kspec skill install-core` to sync core skill templates at the same version",
             });
             continue;
           }
@@ -758,6 +767,9 @@ export function registerSkillInstallCommands(skill: Command): void {
                 console.log(
                   `  ${chalk.gray("-")} ${r.id}: ${r.reason}${r.currentVersion ? ` (v${r.currentVersion})` : ""}`
                 );
+                if (r.guidance) {
+                  console.log(`    ${chalk.yellow("→")} ${r.guidance}`);
+                }
               }
             }
 

--- a/tests/core-skill-update.test.ts
+++ b/tests/core-skill-update.test.ts
@@ -138,6 +138,35 @@ describe('Core Skill Update', () => {
       expect(kspecHelp?.action).toBe('skipped');
       expect(kspecHelp?.reason).toContain('already at current version');
     });
+
+    it('should provide install-core guidance when same-version templates drift', async () => {
+      // AC: @core-skill-update ac-2
+      kspecFull('skill install-core', tempDir);
+
+      const skillMdPath = path.join(tempDir, 'skills', 'help', 'SKILL.md');
+      await fs.writeFile(skillMdPath, '# Local drift\n', 'utf-8');
+
+      const result = kspecFull('skill update', tempDir);
+
+      expect(result.stdout).toContain('help');
+      expect(result.stdout).toContain('template content differs from local files');
+      expect(result.stdout).toContain('kspec skill install-core');
+      expect(result.stdout).toContain('No skills needed updating');
+    });
+
+    it('should provide the same drift guidance in dry-run output', async () => {
+      // AC: @core-skill-update ac-2
+      kspecFull('skill install-core', tempDir);
+
+      const skillMdPath = path.join(tempDir, 'skills', 'help', 'SKILL.md');
+      await fs.writeFile(skillMdPath, '# Local drift\n', 'utf-8');
+
+      const result = kspecFull('skill update --dry-run', tempDir);
+
+      expect(result.stdout).toContain('DRY RUN');
+      expect(result.stdout).toContain('template content differs from local files');
+      expect(result.stdout).toContain('kspec skill install-core');
+    });
   });
 
   // AC: @core-skill-update ac-3


### PR DESCRIPTION
## Summary
- detect local template drift when `skill update` sees a core skill already at the current kspec version
- keep skip behavior but report explicit guidance to run `kspec skill install-core` when same-version drift is present
- add regression coverage for drift guidance in normal and `--dry-run` update output

## Verification
- npm run build
- npx vitest run tests/core-skill-update.test.ts tests/core-skill-install.test.ts
- manual CLI scenario: drifted same-version skill reports `kspec skill install-core` guidance in both normal and dry-run output

Task: @01KJGQVK
Spec: @core-skill-update
