### PR TITLE
test: cover config-aware init next-step messaging

### DIFF
--- a/tests/init-setup-integration.test.ts
+++ b/tests/init-setup-integration.test.ts
@@ -138,6 +138,24 @@ describe('Init Setup Integration', () => {
       const settingsExists = await fs.access(settingsPath).then(() => true).catch(() => false);
       expect(settingsExists).toBe(false);
     });
+
+    // AC: @init-setup-integration ac-4 - behavior unchanged without --setup
+    it('shows custom shadow directory and branch in next steps when configured', async () => {
+      await fs.writeFile(
+        path.join(testDir, 'kspec.config.yaml'),
+        `shadow:
+  directory: .specs
+  branch: specs-meta
+`
+      );
+
+      const result = kspec('init --no-prompt', testDir);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Next steps');
+      expect(result.stdout).toContain('Note: Spec files live in .specs/ (gitignored) and commit to specs-meta branch');
+      expect(result.stdout).not.toContain('Note: Spec files live in .kspec/ (gitignored) and commit to kspec-meta branch');
+    });
   });
 
   describe('kspec init --setup edge cases', () => {


### PR DESCRIPTION
## Summary
- add integration coverage for `kspec init --no-prompt` with custom `kspec.config.yaml` shadow settings
- assert next-step output uses `.specs` and `specs-meta` in the "Note: Spec files live in ..." line
- guard against regressions to hardcoded default `.kspec`/`kspec-meta` messaging

## Verification
- npx vitest run tests/init-setup-integration.test.ts
- kspec validate *(fails due to pre-existing repo-level schema/reference/alignment issues unrelated to this change)*

Task: @01KJGV65DSZBK2ZB27K8FQFXY9
Spec: @init-setup-integration
