### PR TITLE
feat: add stale auto-abandon metadata helpers

### DIFF
--- a/src/sessions/store.ts
+++ b/src/sessions/store.ts
@@ -1431,6 +1431,93 @@ export async function selectStaleActiveSessions(
   };
 }
 
+export interface AutoAbandonMetadataPreview {
+  sessionId: string;
+  status: "abandoned";
+  endedAt: string;
+  closeReason: string;
+}
+
+export interface AutoAbandonMetadataResult {
+  dryRun: boolean;
+  updatedCount: number;
+  updates: AutoAbandonMetadataPreview[];
+}
+
+/**
+ * Build canonical close_reason for stale auto-abandon updates.
+ *
+ * Canonical format:
+ * auto-abandoned:older-than=<duration>,inactive-for=<duration>,liveness-guard=<duration>,last-activity=<iso>
+ */
+export function buildAutoAbandonedCloseReason(
+  criteria: StaleSessionCriteria,
+  evaluation: Pick<StaleSessionEvaluation, "lastActivityAt">,
+): string {
+  const segments = [
+    `older-than=${criteria.olderThan}`,
+    `inactive-for=${criteria.inactiveFor}`,
+    `liveness-guard=${criteria.livenessGuard}`,
+    `last-activity=${evaluation.lastActivityAt}`,
+  ];
+  return `auto-abandoned:${segments.join(",")}`;
+}
+
+/**
+ * Apply abandoned metadata to stale session candidates.
+ *
+ * All updates in a single invocation share one ended_at timestamp, which lets
+ * the caller persist and commit the batch atomically with one shadow commit.
+ */
+export async function applyAutoAbandonMetadata(
+  specDir: string,
+  selection: Pick<StaleSessionCandidateSelection, "criteria" | "candidates">,
+  options?: { dryRun?: boolean; nowMs?: number },
+): Promise<AutoAbandonMetadataResult> {
+  const dryRun = options?.dryRun === true;
+  const endedAt = new Date(options?.nowMs ?? Date.now()).toISOString();
+  const updates: AutoAbandonMetadataPreview[] = [];
+
+  for (const candidate of selection.candidates) {
+    const closeReason = buildAutoAbandonedCloseReason(
+      selection.criteria,
+      candidate,
+    );
+    updates.push({
+      sessionId: candidate.sessionId,
+      status: "abandoned",
+      endedAt,
+      closeReason,
+    });
+
+    if (dryRun) continue;
+
+    const metadata = await getSession(specDir, candidate.sessionId);
+    if (!metadata) continue;
+
+    const updated: SessionMetadata = {
+      ...metadata,
+      status: "abandoned",
+      ended_at: endedAt,
+      close_reason: closeReason,
+    };
+
+    const metadataPath = getSessionMetadataPath(specDir, candidate.sessionId);
+    const content = YAML.stringify(updated, {
+      indent: 2,
+      lineWidth: 100,
+      sortMapEntries: false,
+    });
+    await fsPromises.writeFile(metadataPath, content, "utf-8");
+  }
+
+  return {
+    dryRun,
+    updatedCount: updates.length,
+    updates,
+  };
+}
+
 // ─── Session Log Summaries ───────────────────────────────────────────────────
 
 /**

--- a/tests/session-stale-criteria.test.ts
+++ b/tests/session-stale-criteria.test.ts
@@ -3,8 +3,10 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+  applyAutoAbandonMetadata,
   appendEvent,
   createSession,
+  getSession,
   getSessionEventsPath,
   resolveStaleSessionCriteria,
   selectStaleActiveSessions,
@@ -181,5 +183,121 @@ describe("stale session criteria", () => {
     expect(result.evaluations[0].meetsInactivityThreshold).toBe(true);
     expect(result.evaluations[0].blockedByLivenessGuard).toBe(true);
     expect(result.candidates).toHaveLength(0);
+  });
+
+  // AC: @session-stale-close-metadata ac-1
+  // AC: @session-stale-close-metadata ac-2
+  it("writes abandoned status with canonical auto-abandoned close_reason", async () => {
+    const sessionId = "01KJHSTAL3CR1T3R1A0000006";
+    await createSession(specDir, {
+      id: sessionId,
+      agent_type: "ralph",
+      status: "active",
+      started_at: "2026-02-20T00:00:00.000Z",
+    });
+    await appendEvent(specDir, {
+      session_id: sessionId,
+      type: "session.update",
+      ts: new Date("2026-02-27T12:00:00.000Z").getTime(),
+      data: { update: "idle" },
+    });
+
+    const selection = await selectStaleActiveSessions(
+      specDir,
+      { olderThan: "24h", inactiveFor: "6h" },
+      nowMs,
+    );
+    const applied = await applyAutoAbandonMetadata(specDir, selection, {
+      nowMs,
+    });
+
+    expect(applied.updatedCount).toBe(1);
+    const updated = await getSession(specDir, sessionId);
+    expect(updated?.status).toBe("abandoned");
+    expect(updated?.ended_at).toBe(nowIso);
+    expect(updated?.close_reason?.startsWith("auto-abandoned:")).toBe(true);
+    expect(updated?.close_reason).toContain("older-than=24h");
+    expect(updated?.close_reason).toContain("inactive-for=6h");
+    expect(updated?.close_reason).toContain("liveness-guard=5m");
+    expect(updated?.close_reason).toContain("last-activity=2026-02-27T12:00:00.000Z");
+  });
+
+  // AC: @session-stale-close-metadata ac-3
+  it("applies batch metadata updates for multiple sessions in one invocation", async () => {
+    const sessionA = "01KJHSTAL3CR1T3R1A0000007";
+    const sessionB = "01KJHSTAL3CR1T3R1A0000008";
+    await createSession(specDir, {
+      id: sessionA,
+      agent_type: "ralph",
+      status: "active",
+      started_at: "2026-02-20T00:00:00.000Z",
+    });
+    await createSession(specDir, {
+      id: sessionB,
+      agent_type: "ralph",
+      status: "active",
+      started_at: "2026-02-19T00:00:00.000Z",
+    });
+
+    const selection = await selectStaleActiveSessions(
+      specDir,
+      { olderThan: "24h", inactiveFor: "6h" },
+      nowMs,
+    );
+    const applied = await applyAutoAbandonMetadata(specDir, selection, {
+      nowMs,
+    });
+
+    expect(applied.updatedCount).toBe(2);
+    expect(applied.updates).toHaveLength(2);
+    expect(applied.updates[0].endedAt).toBe(nowIso);
+    expect(applied.updates[1].endedAt).toBe(nowIso);
+    expect(applied.updates[0].closeReason.startsWith("auto-abandoned:")).toBe(true);
+    expect(applied.updates[1].closeReason.startsWith("auto-abandoned:")).toBe(true);
+
+    const updatedA = await getSession(specDir, sessionA);
+    const updatedB = await getSession(specDir, sessionB);
+    expect(updatedA?.status).toBe("abandoned");
+    expect(updatedB?.status).toBe("abandoned");
+    expect(updatedA?.ended_at).toBe(nowIso);
+    expect(updatedB?.ended_at).toBe(nowIso);
+  });
+
+  // AC: @session-stale-close-metadata ac-4
+  it("returns preview close_reason in dry-run mode without changing files", async () => {
+    const sessionId = "01KJHSTAL3CR1T3R1A0000009";
+    await createSession(specDir, {
+      id: sessionId,
+      agent_type: "ralph",
+      status: "active",
+      started_at: "2026-02-20T00:00:00.000Z",
+    });
+    await appendEvent(specDir, {
+      session_id: sessionId,
+      type: "session.update",
+      ts: new Date("2026-02-27T12:00:00.000Z").getTime(),
+      data: { update: "idle" },
+    });
+
+    const before = await getSession(specDir, sessionId);
+    const selection = await selectStaleActiveSessions(
+      specDir,
+      { olderThan: "24h", inactiveFor: "6h" },
+      nowMs,
+    );
+    const applied = await applyAutoAbandonMetadata(specDir, selection, {
+      dryRun: true,
+      nowMs,
+    });
+    const after = await getSession(specDir, sessionId);
+
+    expect(applied.dryRun).toBe(true);
+    expect(applied.updatedCount).toBe(1);
+    expect(applied.updates[0].closeReason.startsWith("auto-abandoned:")).toBe(true);
+    expect(applied.updates[0].closeReason).toContain("older-than=24h");
+
+    expect(after?.status).toBe(before?.status);
+    expect(after?.ended_at).toBe(before?.ended_at);
+    expect(after?.close_reason).toBe(before?.close_reason);
   });
 });


### PR DESCRIPTION
## Summary
- add stale-session auto-abandon metadata apply helper in session store
- add canonical parseable close_reason format with auto-abandoned prefix and criteria fields
- add AC-annotated tests for persisted metadata, multi-session batch updates, and dry-run preview non-mutation

## Verification
- npx vitest run tests/session-stale-criteria.test.ts
- npx vitest run tests/sessions.test.ts tests/session-stale-criteria.test.ts
- npm test
- kspec validate (known pre-existing repo validation issues unrelated to this task)

Task: @implement-auto-abandon-metadata-and-audit-trail
Spec: @session-stale-close-metadata