### PR TITLE
feat: add stale auto-abandon metadata helpers

### DIFF
--- a/src/sessions/store.ts
+++ b/src/sessions/store.ts
@@ -18,6 +18,7 @@ import * as path from "node:path";
 import { createHash, randomUUID } from "node:crypto";
 import { parse as parseTOML, stringify as stringifyTOML } from "smol-toml";
 import * as YAML from "yaml";
+import { shadowAutoCommit } from "../parser/shadow.js";
 import {
   type SessionEvent,
   type SessionEventInput,
@@ -1442,6 +1443,7 @@ export interface AutoAbandonMetadataResult {
   dryRun: boolean;
   updatedCount: number;
   updates: AutoAbandonMetadataPreview[];
+  shadowCommitted?: boolean;
 }
 
 /**
@@ -1472,7 +1474,7 @@ export function buildAutoAbandonedCloseReason(
 export async function applyAutoAbandonMetadata(
   specDir: string,
   selection: Pick<StaleSessionCandidateSelection, "criteria" | "candidates">,
-  options?: { dryRun?: boolean; nowMs?: number },
+  options?: { dryRun?: boolean; nowMs?: number; shadowCommitMessage?: string },
 ): Promise<AutoAbandonMetadataResult> {
   const dryRun = options?.dryRun === true;
   const endedAt = new Date(options?.nowMs ?? Date.now()).toISOString();
@@ -1511,10 +1513,16 @@ export async function applyAutoAbandonMetadata(
     await fsPromises.writeFile(metadataPath, content, "utf-8");
   }
 
+  let shadowCommitted: boolean | undefined;
+  if (!dryRun && updates.length > 0 && options?.shadowCommitMessage) {
+    shadowCommitted = await shadowAutoCommit(specDir, options.shadowCommitMessage);
+  }
+
   return {
     dryRun,
     updatedCount: updates.length,
     updates,
+    shadowCommitted,
   };
 }
 

--- a/tests/session-stale-criteria.test.ts
+++ b/tests/session-stale-criteria.test.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
+import { execSync } from "node:child_process";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   applyAutoAbandonMetadata,
@@ -157,6 +158,33 @@ describe("stale session criteria", () => {
     expect(result.skipped[0].detail).toContain("invalid line 2");
   });
 
+  // AC: @session-stale-criteria ac-7
+  it("skips and reports sessions with unreadable events.jsonl", async () => {
+    const sessionId = "01KJHSTAL3CR1T3R1A000000A";
+    await createSession(specDir, {
+      id: sessionId,
+      agent_type: "ralph",
+      status: "active",
+      started_at: "2026-02-24T00:00:00.000Z",
+    });
+    await fs.mkdir(getSessionEventsPath(specDir, sessionId), {
+      recursive: true,
+    });
+
+    const result = await selectStaleActiveSessions(
+      specDir,
+      { olderThan: "24h", inactiveFor: "6h" },
+      nowMs,
+    );
+    expect(result.candidates).toHaveLength(0);
+    expect(result.skippedCount).toBe(1);
+    expect(result.failureCount).toBe(1);
+    expect(result.skipped[0].sessionId).toBe(sessionId);
+    expect(result.skipped[0].reason).toBe("events_unreadable");
+    expect(result.skipped[0].detail).toContain("Unable to read events.jsonl");
+    expect(result.skipped[0].detail).toContain(sessionId);
+  });
+
   // AC: @session-stale-criteria ac-8
   it("blocks closure when session has recent activity inside liveness guard window", async () => {
     const sessionId = "01KJHSTAL3CR1T3R1A0000005";
@@ -261,6 +289,73 @@ describe("stale session criteria", () => {
     expect(updatedB?.status).toBe("abandoned");
     expect(updatedA?.ended_at).toBe(nowIso);
     expect(updatedB?.ended_at).toBe(nowIso);
+  });
+
+  // AC: @session-stale-close-metadata ac-3
+  it("records one shadow commit with command-specific message for multi-session close", async () => {
+    execSync("git init", { cwd: specDir, stdio: "pipe" });
+    execSync('git config user.name "Test User"', { cwd: specDir, stdio: "pipe" });
+    execSync('git config user.email "test@example.com"', {
+      cwd: specDir,
+      stdio: "pipe",
+    });
+
+    const sessionA = "01KJHSTAL3CR1T3R1A000000B";
+    const sessionB = "01KJHSTAL3CR1T3R1A000000C";
+    await createSession(specDir, {
+      id: sessionA,
+      agent_type: "ralph",
+      status: "active",
+      started_at: "2026-02-20T00:00:00.000Z",
+    });
+    await createSession(specDir, {
+      id: sessionB,
+      agent_type: "ralph",
+      status: "active",
+      started_at: "2026-02-19T00:00:00.000Z",
+    });
+
+    execSync("git add -A", { cwd: specDir, stdio: "pipe" });
+    execSync('git commit -m "test: seed sessions"', {
+      cwd: specDir,
+      stdio: "pipe",
+      env: { ...process.env, KSPEC_SHADOW_COMMIT: "1" },
+    });
+    const beforeCount = Number.parseInt(
+      execSync("git rev-list --count HEAD", {
+        cwd: specDir,
+        encoding: "utf-8",
+      }).trim(),
+      10,
+    );
+
+    const selection = await selectStaleActiveSessions(
+      specDir,
+      { olderThan: "24h", inactiveFor: "6h" },
+      nowMs,
+    );
+    const commitMessage = "session stale close auto-abandoned metadata";
+    const applied = await applyAutoAbandonMetadata(specDir, selection, {
+      nowMs,
+      shadowCommitMessage: commitMessage,
+    });
+
+    const afterCount = Number.parseInt(
+      execSync("git rev-list --count HEAD", {
+        cwd: specDir,
+        encoding: "utf-8",
+      }).trim(),
+      10,
+    );
+    const lastMessage = execSync("git log -1 --pretty=%s", {
+      cwd: specDir,
+      encoding: "utf-8",
+    }).trim();
+
+    expect(applied.updatedCount).toBe(2);
+    expect(applied.shadowCommitted).toBe(true);
+    expect(afterCount - beforeCount).toBe(1);
+    expect(lastMessage).toBe(commitMessage);
   });
 
   // AC: @session-stale-close-metadata ac-4


### PR DESCRIPTION
## Summary
- add stale-session auto-abandon metadata apply helper in session store
- add canonical parseable close_reason format with auto-abandoned prefix and criteria fields
- add AC-annotated tests for persisted metadata, multi-session batch updates, and dry-run preview non-mutation

## Verification
- npx vitest run tests/session-stale-criteria.test.ts
- npx vitest run tests/sessions.test.ts tests/session-stale-criteria.test.ts
- npm test
- kspec validate (known pre-existing repo validation issues unrelated to this task)

Task: @implement-auto-abandon-metadata-and-audit-trail
Spec: @session-stale-close-metadata

(Replaces #606 which could not be reopened after base branch deletion)