### PR TITLE
feat: add ralph iteration-timeout guard

### DIFF
--- a/src/cli/commands/ralph.ts
+++ b/src/cli/commands/ralph.ts
@@ -201,8 +201,18 @@ const ADAPTER_VALIDATION_PROBES = [["--help"], ["--version"]];
 const TERMINAL_PREVIEW_MAX_BYTES = 64 * 1024;
 const TOOL_OUTPUT_DIR = "tool-output";
 const RECENT_TASK_REF_LIMIT = 50;
+const DEFAULT_ITERATION_TIMEOUT_MINUTES = 20;
 
 type SpawnedAgentLike = Pick<SpawnedAgent, "client" | "kill">;
+
+class IterationTimeoutError extends Error {
+  constructor(public readonly timeoutMinutes: number, public readonly timeoutMs: number) {
+    super(
+      `Iteration timed out after ${timeoutMinutes} minute${timeoutMinutes === 1 ? "" : "s"}`,
+    );
+    this.name = "IterationTimeoutError";
+  }
+}
 
 export function pushRecentTaskRef(
   recentTaskRefs: string[],
@@ -1243,6 +1253,11 @@ export function registerRalphCommand(program: Command): void {
       "Max consecutive failed iterations before exit",
       "3",
     )
+    .option(
+      "--iteration-timeout <minutes>",
+      "Max minutes per iteration attempt before aborting",
+      String(DEFAULT_ITERATION_TIMEOUT_MINUTES),
+    )
     .option("--dry-run", "Show prompt without executing")
     .option("--yolo", "Use dangerously-skip-permissions (default)", true)
     .option("--no-yolo", "Require normal permission prompts")
@@ -1291,6 +1306,11 @@ export function registerRalphCommand(program: Command): void {
         const maxLoops = parseInt(options.maxLoops, 10);
         const maxRetries = parseInt(options.maxRetries, 10);
         const maxFailures = parseInt(options.maxFailures, 10);
+        const iterationTimeoutMinutes = Number(options.iterationTimeout);
+        const iterationTimeoutMs = Math.max(
+          1,
+          Math.round(iterationTimeoutMinutes * 60 * 1000),
+        );
 
         if (Number.isNaN(maxLoops) || maxLoops < 1) {
           error(errors.usage.maxLoopsPositive);
@@ -1304,6 +1324,11 @@ export function registerRalphCommand(program: Command): void {
 
         if (Number.isNaN(maxFailures) || maxFailures < 1) {
           error(errors.usage.maxFailuresPositive);
+          process.exit(EXIT_CODES.ERROR);
+        }
+
+        if (!Number.isFinite(iterationTimeoutMinutes) || iterationTimeoutMinutes <= 0) {
+          error("--iteration-timeout must be a positive number of minutes");
           process.exit(EXIT_CODES.ERROR);
         }
 
@@ -1418,6 +1443,7 @@ export function registerRalphCommand(program: Command): void {
         info(
           `Starting ralph loop (${adapterInfo}, max ${maxLoops} iterations, ${maxRetries} retries, ${maxFailures} max failures${restartInfo}, max-tasks=${maxTasksInfo}${taskScopeInfo})`,
         );
+        info(`Iteration timeout: ${iterationTimeoutMinutes} minute(s)`);
         if (options.focus) {
           info(`Focus: ${options.focus}`);
         }
@@ -1544,6 +1570,7 @@ export function registerRalphCommand(program: Command): void {
               maxLoops,
               maxRetries,
               maxFailures,
+              iterationTimeoutMinutes,
               maxTasks,
               yolo: options.yolo,
               focus: options.focus,
@@ -1691,6 +1718,7 @@ export function registerRalphCommand(program: Command): void {
               console.log(`  max-tasks: ${maxTasks === 0 ? "unlimited" : maxTasks}`);
               console.log(`  max-retries: ${maxRetries}`);
               console.log(`  max-failures: ${maxFailures}`);
+              console.log(`  iteration-timeout: ${iterationTimeoutMinutes} minute(s)`);
               console.log(`  restart-every: ${restartEvery === 0 ? "never" : restartEvery}`);
               console.log(`  worker-task-work-skill: ${workerTaskWorkSkill}`);
               console.log(`  worker-reflect-skill: ${workerReflectSkill}`);
@@ -1810,7 +1838,8 @@ export function registerRalphCommand(program: Command): void {
                   );
                 }
 
-                // Create fresh ACP session per iteration to keep context clean
+                // AC: @cli-ralph ac-14 - Create fresh ACP session per iteration
+                // to keep context clean.
                 info("Creating ACP session...");
                 acpSessionId = await agent.client.newSession({
                   cwd: process.cwd(),
@@ -1818,60 +1847,83 @@ export function registerRalphCommand(program: Command): void {
                 });
                 setSessionIteration(sessionIterationMap, acpSessionId, iteration);
 
-                // Phase 1: Task Work
-                info("Sending task-work prompt to agent...");
-                const taskWorkResponse = await agent.client.prompt({
-                  sessionId: acpSessionId!,
-                  prompt: [{ type: "text", text: taskWorkPrompt }],
-                });
+                const runIterationPrompts = async () => {
+                  // Phase 1: Task Work
+                  info("Sending task-work prompt to agent...");
+                  const taskWorkResponse = await agent!.client.prompt({
+                    sessionId: acpSessionId!,
+                    prompt: [{ type: "text", text: taskWorkPrompt }],
+                  });
 
-                // Log task-work completion
-                await appendEvent(specDir, {
-                  session_id: sessionId,
-                  type: "session.update",
-                  data: {
-                    iteration,
-                    phase: "task-work",
-                    stopReason: taskWorkResponse.stopReason,
-                    completed: true,
-                  },
-                });
+                  // Log task-work completion
+                  await appendEvent(specDir, {
+                    session_id: sessionId,
+                    type: "session.update",
+                    data: {
+                      iteration,
+                      phase: "task-work",
+                      stopReason: taskWorkResponse.stopReason,
+                      completed: true,
+                    },
+                  });
 
-                if (taskWorkResponse.stopReason === "cancelled") {
-                  throw new Error(errors.usage.agentPromptCancelled);
-                }
+                  if (taskWorkResponse.stopReason === "cancelled") {
+                    throw new Error(errors.usage.agentPromptCancelled);
+                  }
 
-                // Phase 2: Reflect (always sent after task-work completes)
-                info("Sending reflect prompt to agent...");
-                await appendEvent(specDir, {
-                  session_id: sessionId,
-                  type: "prompt.sent",
-                  data: {
-                    iteration,
-                    phase: "reflect",
-                    prompt: reflectPrompt,
-                  },
-                });
+                  // Phase 2: Reflect (always sent after task-work completes)
+                  info("Sending reflect prompt to agent...");
+                  await appendEvent(specDir, {
+                    session_id: sessionId,
+                    type: "prompt.sent",
+                    data: {
+                      iteration,
+                      phase: "reflect",
+                      prompt: reflectPrompt,
+                    },
+                  });
 
-                const reflectResponse = await agent.client.prompt({
-                  sessionId: acpSessionId!,
-                  prompt: [{ type: "text", text: reflectPrompt }],
-                });
+                  const reflectResponse = await agent!.client.prompt({
+                    sessionId: acpSessionId!,
+                    prompt: [{ type: "text", text: reflectPrompt }],
+                  });
 
-                // Log reflect completion
-                await appendEvent(specDir, {
-                  session_id: sessionId,
-                  type: "session.update",
-                  data: {
-                    iteration,
-                    phase: "reflect",
-                    stopReason: reflectResponse.stopReason,
-                    completed: true,
-                  },
-                });
+                  // Log reflect completion
+                  await appendEvent(specDir, {
+                    session_id: sessionId,
+                    type: "session.update",
+                    data: {
+                      iteration,
+                      phase: "reflect",
+                      stopReason: reflectResponse.stopReason,
+                      completed: true,
+                    },
+                  });
 
-                if (reflectResponse.stopReason === "cancelled") {
-                  throw new Error(errors.usage.agentPromptCancelled);
+                  if (reflectResponse.stopReason === "cancelled") {
+                    throw new Error(errors.usage.agentPromptCancelled);
+                  }
+                };
+
+                let timeoutHandle: NodeJS.Timeout | null = null;
+                try {
+                  await Promise.race([
+                    runIterationPrompts(),
+                    new Promise<never>((_resolve, reject) => {
+                      timeoutHandle = setTimeout(() => {
+                        reject(
+                          new IterationTimeoutError(
+                            iterationTimeoutMinutes,
+                            iterationTimeoutMs,
+                          ),
+                        );
+                      }, iterationTimeoutMs);
+                    }),
+                  ]);
+                } finally {
+                  if (timeoutHandle) {
+                    clearTimeout(timeoutHandle);
+                  }
                 }
 
                 acpSessionId = endAcpSession(agent, acpSessionId);
@@ -1879,6 +1931,18 @@ export function registerRalphCommand(program: Command): void {
                 break;
               } catch (err) {
                 lastError = err as Error;
+                if (lastError instanceof IterationTimeoutError) {
+                  await appendEvent(specDir, {
+                    session_id: sessionId,
+                    type: "iteration.timeout",
+                    data: {
+                      iteration,
+                      attempt,
+                      timeout_minutes: lastError.timeoutMinutes,
+                      timeout_ms: lastError.timeoutMs,
+                    },
+                  });
+                }
                 error(errors.failures.iterationFailed(lastError.message));
 
                 // Clean up agent on error - will respawn next attempt
@@ -1910,8 +1974,8 @@ export function registerRalphCommand(program: Command): void {
               lastIterationCtx = sessionCtx;
 
 
-              // Periodic agent restart to prevent OOM
-              // AC: @cli-ralph ac-restart-periodic
+              // Periodic agent restart to prevent OOM.
+              // AC: @cli-ralph ac-17
               if (
                 restartEvery > 0 &&
                 iteration % restartEvery === 0 &&

--- a/src/sessions/types.ts
+++ b/src/sessions/types.ts
@@ -79,6 +79,7 @@ export type SessionMetadataInput = z.infer<typeof SessionMetadataInputSchema>;
 export const EventTypeSchema = z.enum([
   "session.start",
   "session.update",
+  "iteration.timeout",
   "session.end",
   "session.wrapup",
   "prompt.sent",

--- a/tests/ralph.test.ts
+++ b/tests/ralph.test.ts
@@ -219,6 +219,21 @@ describe('ralph command', () => {
     expect(result.stdout).not.toContain('Completed iteration');
   });
 
+  // AC: @cli-ralph ac-15
+  it('shows iteration-timeout and focus instructions in dry-run output', async () => {
+    const result = runRalph('--dry-run --iteration-timeout 15 --focus keep-pr-scope-narrow', tempDir);
+
+    expect(result.stdout).toContain('iteration-timeout: 15 minute(s)');
+    expect(result.stdout).toContain('keep-pr-scope-narrow');
+  });
+
+  it('fails fast for non-positive iteration-timeout values', async () => {
+    const result = runRalph('--dry-run --iteration-timeout 0', tempDir);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.output).toContain('--iteration-timeout must be a positive number of minutes');
+  });
+
   // AC: @ralph-skill-delegation ac-1
   it('includes iteration N/M, session ID, and no-human flag in prompt', async () => {
     const result = runRalph('--dry-run --max-loops 5', tempDir);
@@ -241,6 +256,9 @@ describe('ralph command', () => {
   });
 
   // AC: @ralph-skill-delegation ac-3
+  // AC: @cli-ralph ac-3
+  // AC: @cli-ralph ac-4
+  // AC: @cli-ralph ac-5
   it('contains kspec: namespace skill invocations by default', async () => {
     const result = runRalph('--dry-run', tempDir);
 
@@ -290,6 +308,47 @@ describe('ralph command', () => {
     expect(result.output).toContain('failed after 2 attempts');
     expect(result.output).toContain('Continuing to next iteration');
     expect(result.output).toContain('Iteration 2/2');
+  });
+
+  it('times out stalled iteration attempts and logs iteration.timeout event', async () => {
+    const result = runRalph(
+      '--max-loops 1 --max-retries 0 --max-failures 1 --iteration-timeout 0.001',
+      tempDir,
+      {
+        MOCK_ACP_DELAY_MS: '500',
+      },
+    );
+
+    expect(result.output).toContain('Iteration timed out after 0.001 minutes');
+    expect(result.output).toContain('Reached 1 consecutive failures');
+
+    const sessionsDir = path.join(tempDir, 'sessions');
+    const sessions = await fs.readdir(sessionsDir).catch(() => []);
+    expect(sessions.length).toBeGreaterThan(0);
+
+    const eventsPath = path.join(sessionsDir, sessions[0], 'events.jsonl');
+    const eventsRaw = await fs.readFile(eventsPath, 'utf-8');
+    const events = eventsRaw
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line));
+
+    const timeoutEvent = events.find(
+      (event: { type: string; data?: { timeout_minutes?: number } }) =>
+        event.type === 'iteration.timeout',
+    );
+    expect(timeoutEvent).toBeTruthy();
+    expect(timeoutEvent.data.timeout_minutes).toBe(0.001);
+  });
+
+  // AC: @cli-ralph ac-18
+  it('does not restart the agent when --restart-every 0 is configured', async () => {
+    const result = runRalph('--max-loops 3 --restart-every 0', tempDir, {
+      MOCK_ACP_EXIT_CODE: '0',
+    });
+
+    const spawnCount = (result.output.match(/Spawning ACP agent\.\.\./g) || []).length;
+    expect(spawnCount).toBe(1);
   });
 
   // AC: @cli-ralph ac-8 - Consecutive failure guard
@@ -561,6 +620,7 @@ describe('ralph command', () => {
   // ─── Event Logging Iteration Attribution ──────────────────────────────────
 
   describe('event logging iteration attribution', () => {
+    // AC: @cli-ralph ac-14
     it('tags streaming update events with the correct iteration number', async () => {
       // Run 2 iterations — the update handler persists across both.
       // Each iteration creates a fresh ACP session; the handler must attribute
@@ -603,6 +663,7 @@ describe('ralph command', () => {
       );
       expect(iterationNumbers.has(1)).toBe(true);
       expect(iterationNumbers.has(2)).toBe(true);
+
     });
 
     it('never tags events with iteration 0 (stale/unmapped fallback)', async () => {
@@ -739,6 +800,28 @@ describe('ralph memory-safety helpers', () => {
     );
     expect(result).toBeNull();
     expect(calls).toEqual(['removeAllListeners', 'kill', 'close']);
+  });
+});
+
+describe('restart behavior', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await setupTempFixtures();
+  });
+
+  afterEach(async () => {
+    await cleanupTempDir(tempDir);
+  });
+
+  // AC: @cli-ralph ac-17
+  it('restarts worker agent process every N iterations when restart-every > 0', async () => {
+    const result = runRalph('--max-loops 3 --restart-every 1', tempDir, {
+      MOCK_ACP_EXIT_CODE: '0',
+    });
+
+    const restartCount = (result.output.match(/Restarting agent to prevent memory buildup/g) || []).length;
+    expect(restartCount).toBe(2);
   });
 });
 

--- a/tests/sessions.test.ts
+++ b/tests/sessions.test.ts
@@ -57,6 +57,7 @@ describe('EventTypeSchema', () => {
   it('should accept valid event types', () => {
     expect(EventTypeSchema.safeParse('session.start').success).toBe(true);
     expect(EventTypeSchema.safeParse('session.update').success).toBe(true);
+    expect(EventTypeSchema.safeParse('iteration.timeout').success).toBe(true);
     expect(EventTypeSchema.safeParse('session.end').success).toBe(true);
     expect(EventTypeSchema.safeParse('prompt.sent').success).toBe(true);
     expect(EventTypeSchema.safeParse('tool.call').success).toBe(true);


### PR DESCRIPTION
## Summary
- add `--iteration-timeout <minutes>` to `kspec ralph` with default 20 minutes and input validation
- enforce an iteration-level timeout across task-work + reflect prompt phases via `Promise.race`
- emit `iteration.timeout` session events and keep existing retry/max-failure flow intact
- add/align `@cli-ralph` AC annotations/tests for ac-3, ac-4, ac-5, ac-14, ac-15, ac-17, ac-18

## Verification
- `npx vitest run tests/ralph.test.ts tests/sessions.test.ts`
- `kspec validate` (fails with pre-existing project-level schema/reference/alignment/completeness issues unrelated to this task)

Task: @01KJDQ17W
Spec: @cli-ralph
