### PR TITLE
fix: keep warning-only plan import successful in batch

### DIFF
--- a/src/cli/commands/plan-import.ts
+++ b/src/cli/commands/plan-import.ts
@@ -684,7 +684,9 @@ async function importPlan(
   // Exit code logic
   // AC: @plan-import ac-15 - Dry run exits 0
   // AC: @plan-import ac-23 - Success with some errors still exits 0
-  process.exit(EXIT_CODES.SUCCESS);
+  // Return normally so batch mode treats this as success instead of
+  // intercepting process.exit(0) as an exception path.
+  return;
 }
 
 /**

--- a/tests/batch-exec-engine.test.ts
+++ b/tests/batch-exec-engine.test.ts
@@ -537,6 +537,43 @@ describe("batch command integration", () => {
     expect(result.summary.succeeded).toBe(1);
   });
 
+  // AC: @plan-import ac-34
+  // AC: @plan-import ac-23
+  it("treats warning-only plan import as success in batch mode", async () => {
+    const { writeFile } = await import("node:fs/promises");
+    const { join } = await import("node:path");
+    const planPath = join(tempDir, "warning-only-plan.md");
+    kspec('module add --title "Batch Module" --slug batch-module', tempDir);
+    await writeFile(
+      planPath,
+      `# Warning Only Plan
+
+## Specs
+
+No fenced YAML block in this section.
+`,
+    );
+
+    const commands = JSON.stringify([
+      {
+        command: "plan import",
+        args: { path: planPath, module: "@batch-module" },
+      },
+    ]);
+
+    const result = kspecJson<BatchExecResult>(
+      `batch --commands '${commands}'`,
+      tempDir,
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.summary.succeeded).toBe(1);
+    expect(result.results[0].success).toBe(true);
+    expect(String(result.results[0].output)).toContain(
+      "Specs section found but contains no YAML code block",
+    );
+  });
+
   // AC: @batch-exec ac-file
   it("accepts file input", async () => {
     const { writeFile } = await import("node:fs/promises");


### PR DESCRIPTION
## Summary
- remove success-path `process.exit(0)` from `plan import` so batch execution does not treat it as an exception
- keep warning-only imports successful while preserving warning output
- add regression coverage in batch integration tests for warning-only `plan import`

## Testing
- npm run build
- npx vitest run tests/batch-exec-engine.test.ts
- npx vitest run tests/cli-plan-import.test.ts

Task: @01KJDQ1B9C62DT55EK8WK01BP0
Spec: @plan-import
