### PR TITLE
fix: prevent unhandled rejection on iteration timeout (Node.js 22)

### DIFF
--- a/src/cli/commands/ralph.ts
+++ b/src/cli/commands/ralph.ts
@@ -1907,8 +1907,12 @@ export function registerRalphCommand(program: Command): void {
 
                 let timeoutHandle: NodeJS.Timeout | null = null;
                 try {
+                  const iterationPromptsPromise = runIterationPrompts();
+                  // Prevent unhandled rejection if timeout wins the race and
+                  // disposeSpawnedAgent() causes the pending prompt to reject.
+                  iterationPromptsPromise.catch(() => {});
                   await Promise.race([
-                    runIterationPrompts(),
+                    iterationPromptsPromise,
                     new Promise<never>((_resolve, reject) => {
                       timeoutHandle = setTimeout(() => {
                         reject(

--- a/tests/ralph.test.ts
+++ b/tests/ralph.test.ts
@@ -220,6 +220,7 @@ describe('ralph command', () => {
   });
 
   // AC: @cli-ralph ac-15
+  // AC: @cli-ralph ac-24
   it('shows iteration-timeout and focus instructions in dry-run output', async () => {
     const result = runRalph('--dry-run --iteration-timeout 15 --focus keep-pr-scope-narrow', tempDir);
 
@@ -227,6 +228,7 @@ describe('ralph command', () => {
     expect(result.stdout).toContain('keep-pr-scope-narrow');
   });
 
+  // AC: @cli-ralph ac-25
   it('fails fast for non-positive iteration-timeout values', async () => {
     const result = runRalph('--dry-run --iteration-timeout 0', tempDir);
 
@@ -310,6 +312,8 @@ describe('ralph command', () => {
     expect(result.output).toContain('Iteration 2/2');
   });
 
+  // AC: @cli-ralph ac-24
+  // AC: @cli-ralph ac-26
   it('times out stalled iteration attempts and logs iteration.timeout event', async () => {
     const result = runRalph(
       '--max-loops 1 --max-retries 0 --max-failures 1 --iteration-timeout 0.001',


### PR DESCRIPTION
## Summary
- Store `runIterationPrompts()` promise before `Promise.race` and attach `.catch(() => {})` to prevent unhandled rejection when the timeout wins the race and `disposeSpawnedAgent()` causes the pending prompt to reject in Node.js 22
- Add spec ACs ac-24/ac-25/ac-26 to `@cli-ralph` covering `--iteration-timeout` default behavior, validation, and timeout event logging
- Add `// AC:` annotations to tests at lines 222, 230, and 313 in `tests/ralph.test.ts`

## Background
PR #608 added the `--iteration-timeout` guard. A post-merge review identified a Node.js 22 crash: when the timeout fires first, `disposeSpawnedAgent()` closes the framing layer which causes the still-running `runIterationPrompts()` promise to reject with no catch handler, crashing the process before `session.end` and wrap-up.

## Test plan
- [ ] `npx vitest run tests/ralph.test.ts` — all 140 tests pass
- [ ] Existing timeout test (`times out stalled iteration attempts`) continues to pass
- [ ] No new unhandled rejections in Node.js 22 when iteration times out

Task: @01KJDQ17W
Spec: @cli-ralph

🤖 Generated with [Claude Code](https://claude.com/claude-code)