### PR TITLE
chore: add rendered kspec-observations skill

### DIFF
--- a/.agents/skills/kspec-observations/SKILL.md
+++ b/.agents/skills/kspec-observations/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: kspec-observations
+description: Capture and act on systemic patterns — friction, successes,
+  questions, and ideas. The feedback loop that drives process improvement.
+---
+<!-- kspec-managed -->
+
+# Observations
+
+Capture and act on systemic patterns — friction, successes, questions, and ideas. The feedback loop that drives process improvement.


### PR DESCRIPTION
## Summary
- Commits the `kspec-observations/SKILL.md` rendered skill file that was generated by `kspec skill render` but never committed to the repository
- `kspec-observations` is an alias for `kspec-observe` (same description, plural form), referenced in `kspec-agents.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)