### PR TITLE
fix(ralph): prevent event-log OOM from seq scans and update bursts

### DIFF
--- a/src/cli/commands/ralph.ts
+++ b/src/cli/commands/ralph.ts
@@ -203,6 +203,7 @@ const TERMINAL_PREVIEW_MAX_BYTES = 64 * 1024;
 const TOOL_OUTPUT_DIR = "tool-output";
 const RECENT_TASK_REF_LIMIT = 50;
 const DEFAULT_ITERATION_TIMEOUT_MINUTES = 20;
+const MAX_SESSION_UPDATE_QUEUE = 1000;
 
 type SpawnedAgentLike = Pick<SpawnedAgent, "client" | "kill">;
 
@@ -238,15 +239,43 @@ export function createSessionUpdateLogger(
     update: SessionUpdate,
   ) => Promise<void> | void,
 ): (sessionId: string, update: SessionUpdate) => void {
+  const queue: SessionUpdate[] = [];
+  let draining = false;
+
+  const drainQueue = async (): Promise<void> => {
+    if (draining) {
+      return;
+    }
+    draining = true;
+    try {
+      while (queue.length > 0) {
+        const nextUpdate = queue.shift();
+        if (!nextUpdate) {
+          continue;
+        }
+        try {
+          await logUpdate(iteration, nextUpdate);
+        } catch {
+          // Ignore logging errors during streaming
+        }
+      }
+    } finally {
+      draining = false;
+      if (queue.length > 0) {
+        void drainQueue();
+      }
+    }
+  };
+
   return (sessionId: string, update: SessionUpdate) => {
     if (sessionId !== acpSessionId) {
       return;
     }
-    Promise.resolve()
-      .then(() => logUpdate(iteration, update))
-      .catch(() => {
-      // Ignore logging errors during streaming
-      });
+    if (queue.length >= MAX_SESSION_UPDATE_QUEUE) {
+      queue.shift();
+    }
+    queue.push(update);
+    void drainQueue();
   };
 }
 

--- a/src/sessions/store.ts
+++ b/src/sessions/store.ts
@@ -44,6 +44,7 @@ const BLOBS_DIR = "blobs";
 const EVENT_LINE_MAX_BYTES = 256 * 1024;
 const EVENT_FIELD_EXTERNALIZE_BYTES = 16 * 1024;
 const EVENT_PREVIEW_MAX_BYTES = 512;
+const EVENT_SEQ_TAIL_READ_BYTES = EVENT_LINE_MAX_BYTES + 1024;
 
 // ─── Path Helpers ────────────────────────────────────────────────────────────
 
@@ -632,26 +633,80 @@ export async function resolveSessionBlobPointers(
   return value;
 }
 
+function extractLastEventSeq(content: string): number | null {
+  const lines = content.split("\n");
+  for (let i = lines.length - 1; i >= 0; i -= 1) {
+    const line = lines[i].trim();
+    if (line.length === 0) {
+      continue;
+    }
+
+    try {
+      const parsed = JSON.parse(line);
+      if (
+        isRecord(parsed) &&
+        typeof parsed.seq === "number" &&
+        Number.isInteger(parsed.seq) &&
+        parsed.seq >= 0
+      ) {
+        return parsed.seq;
+      }
+    } catch {
+      // Ignore malformed lines and continue scanning backward.
+    }
+  }
+
+  return null;
+}
+
 /**
- * Get the current event count for a session (for seq assignment).
+ * Get next sequence number from the last stored event.
  *
- * @param specDir - The .kspec directory path
- * @param sessionId - Session ID
- * @returns Number of events in the session
+ * Reads a bounded tail slice for O(1) seq lookup; falls back to full scan only
+ * if the tail slice cannot be parsed (for example, partial line boundary).
  */
-async function getEventCount(
+async function getNextEventSeq(
   specDir: string,
   sessionId: string,
 ): Promise<number> {
   const eventsPath = getSessionEventsPath(specDir, sessionId);
 
+  let fileHandle: fsPromises.FileHandle | null = null;
   try {
-    const content = await fsPromises.readFile(eventsPath, "utf-8");
-    const lines = content
-      .trim()
-      .split("\n")
-      .filter((line) => line.length > 0);
-    return lines.length;
+    fileHandle = await fsPromises.open(eventsPath, "r");
+    const stats = await fileHandle.stat();
+    if (stats.size === 0) {
+      return 0;
+    }
+
+    const readBytes = Math.min(stats.size, EVENT_SEQ_TAIL_READ_BYTES);
+    const startOffset = stats.size - readBytes;
+    const buffer = Buffer.alloc(readBytes);
+    await fileHandle.read(buffer, 0, readBytes, startOffset);
+
+    let tailContent = buffer.toString("utf-8");
+    if (startOffset > 0) {
+      // Drop potential partial first line from tail slice.
+      const firstNewline = tailContent.indexOf("\n");
+      tailContent = firstNewline === -1 ? "" : tailContent.slice(firstNewline + 1);
+    }
+
+    const tailSeq = extractLastEventSeq(tailContent);
+    if (tailSeq !== null) {
+      return tailSeq + 1;
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return 0;
+    }
+  } finally {
+    await fileHandle?.close().catch(() => undefined);
+  }
+
+  try {
+    const fullContent = await fsPromises.readFile(eventsPath, "utf-8");
+    const fullSeq = extractLastEventSeq(fullContent);
+    return fullSeq === null ? 0 : fullSeq + 1;
   } catch {
     return 0;
   }
@@ -685,8 +740,8 @@ export async function appendEvent(
   // Ensure session directory exists (lazy creation)
   await fsPromises.mkdir(sessionDir, { recursive: true });
 
-  // Get current event count for seq assignment
-  const seq = input.seq ?? (await getEventCount(specDir, input.session_id));
+  // Derive next sequence number from the last stored event.
+  const seq = input.seq ?? (await getNextEventSeq(specDir, input.session_id));
 
   // Build full event
   const event: SessionEvent = {

--- a/tests/ralph.test.ts
+++ b/tests/ralph.test.ts
@@ -792,9 +792,51 @@ describe('ralph memory-safety helpers', () => {
 
     logger('session-1', update1);
     logger('session-2', update2);
-    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
 
     expect(logged).toEqual([{ iteration: 2, update: update2 }]);
+  });
+
+  // AC: @cli-ralph ac-27
+  it('createSessionUpdateLogger queues updates and drains sequentially', async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const observed: string[] = [];
+
+    const logger = createSessionUpdateLogger(
+      'session-1',
+      1,
+      async (_iteration, update) => {
+        inFlight += 1;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        if (
+          update.sessionUpdate === 'agent_message_chunk' &&
+          update.content?.type === 'text'
+        ) {
+          observed.push(update.content.text);
+        }
+        inFlight -= 1;
+      },
+    );
+
+    logger('session-1', {
+      sessionUpdate: 'agent_message_chunk',
+      content: { type: 'text', text: 'one' },
+    } satisfies SessionUpdate);
+    logger('session-1', {
+      sessionUpdate: 'agent_message_chunk',
+      content: { type: 'text', text: 'two' },
+    } satisfies SessionUpdate);
+    logger('session-1', {
+      sessionUpdate: 'agent_message_chunk',
+      content: { type: 'text', text: 'three' },
+    } satisfies SessionUpdate);
+
+    await new Promise((resolve) => setTimeout(resolve, 60));
+
+    expect(maxInFlight).toBe(1);
+    expect(observed).toEqual(['one', 'two', 'three']);
   });
 
   it('createSessionUpdateLogger swallows logging errors', () => {

--- a/tests/sessions.test.ts
+++ b/tests/sessions.test.ts
@@ -438,6 +438,43 @@ describe('Event storage', () => {
       expect(event3.seq).toBe(2);
     });
 
+    // AC: @session-events ac-2
+    it('should derive next seq from the last stored event seq', async () => {
+      const sessionDir = getSessionDir(testDir, sessionId);
+      const eventsPath = getSessionEventsPath(testDir, sessionId);
+      await fs.mkdir(sessionDir, { recursive: true });
+
+      const existing = [
+        {
+          ts: 1000,
+          seq: 5,
+          type: 'session.start',
+          session_id: sessionId,
+          data: null,
+        },
+        {
+          ts: 2000,
+          seq: 9,
+          type: 'session.update',
+          session_id: sessionId,
+          data: { message: 'existing tail event' },
+        },
+      ];
+      await fs.writeFile(
+        eventsPath,
+        `${existing.map((event) => JSON.stringify(event)).join('\n')}\n`,
+        'utf-8',
+      );
+
+      const next = await appendEvent(testDir, {
+        type: 'prompt.sent',
+        session_id: sessionId,
+        data: { prompt: 'new event' },
+      });
+
+      expect(next.seq).toBe(10);
+    });
+
     // AC: @session-events ac-3
     it('should create session directory if it does not exist (lazy creation)', async () => {
       const event = await appendEvent(testDir, {


### PR DESCRIPTION
## Summary
- replace appendEvent sequence assignment from full-file line counting to tail-based last-seq lookup in src/sessions/store.ts (bounded read, fallback full parse only on unparsable tail)
- add bounded sequential queue in createSessionUpdateLogger so rapid session updates are drained with backpressure and do not accumulate unbounded in-flight appendEvent promises
- add regression tests for last-seq derivation and AC coverage for queued sequential update logging (@cli-ralph ac-27)

## Verification
- npm test -- tests/sessions.test.ts tests/ralph.test.ts (pass)
- npm test (fails on pre-existing tests/cli/session-note-limit.test.ts timeouts at lines 34 and 104)
- npm test -- tests/cli/session-note-limit.test.ts (same pre-existing timeouts reproduced)
- kspec validate (pre-existing project validation failures: @observations ambiguity + missing observations skill file)

Task: @01KJKBB9
Spec: @cli-ralph
