### PR TITLE
fix(triage): consume promoted inbox items by default

### DIFF
--- a/src/cli/commands/triage.ts
+++ b/src/cli/commands/triage.ts
@@ -235,6 +235,7 @@ Examples:
   markMutating(triage.command("act <triage-ref>"))
     .description("Execute a triage decision")
     .option("--dry-run", "Show what would happen without executing")
+    .option("--keep", "Keep inbox item after promote")
     .action(async (triageRef: string, options) => {
       try {
         const ctx = await initContext();
@@ -258,12 +259,19 @@ Examples:
         // AC: @triage-cli-commands ac-17 — dry run
         if (options.dryRun) {
           info(`Dry run for triage record ${record._ulid.slice(0, 8)}:`);
-          await executeTriageAction(record, ctx, { dryRun: true, onInfo: info });
+          await executeTriageAction(record, ctx, {
+            dryRun: true,
+            consume: !options.keep,
+            onInfo: info,
+          });
           return;
         }
 
         // Execute the action
-        const result = await executeTriageAction(record, ctx, { onInfo: info });
+        const result = await executeTriageAction(record, ctx, {
+          consume: !options.keep,
+          onInfo: info,
+        });
 
         // Transition to acted_on
         record.status = "acted_on";

--- a/src/triage/actions.ts
+++ b/src/triage/actions.ts
@@ -28,6 +28,7 @@ export interface TriageActionResult {
  */
 export interface ExecuteTriageActionOptions {
   dryRun?: boolean;
+  consume?: boolean;
   onInfo?: (message: string) => void;
 }
 
@@ -44,7 +45,7 @@ export async function executeTriageAction(
   ctx: KspecContext,
   options: ExecuteTriageActionOptions = {},
 ): Promise<TriageActionResult> {
-  const { dryRun = false, onInfo } = options;
+  const { dryRun = false, consume = true, onInfo } = options;
   const action = record.action;
   if (!action) {
     throw new Error("Record has no action to execute");
@@ -55,6 +56,11 @@ export async function executeTriageAction(
       // AC: @triage-cli-commands ac-4
       if (dryRun) {
         onInfo?.(`Would create task from inbox item snapshot: "${truncateText(record.item_snapshot)}"`);
+        if (consume) {
+          onInfo?.(`Would delete promoted inbox item: ${record.inbox_ref.slice(0, 8)}`);
+        } else {
+          onInfo?.(`Would keep promoted inbox item: ${record.inbox_ref.slice(0, 8)}`);
+        }
         return {};
       }
       const task = createTask({
@@ -70,6 +76,14 @@ export async function executeTriageAction(
       const items = await loadAllItems(ctx);
       const index = new ReferenceIndex(tasks, items);
       const taskRef = `@${index.shortUlid(task._ulid)}`;
+      if (consume) {
+        const inboxItems = await loadInboxItems(ctx);
+        const inboxItem = findInboxItemByRef(inboxItems, record.inbox_ref);
+        if (inboxItem) {
+          await deleteInboxItem(ctx, inboxItem._ulid);
+          onInfo?.(`Deleted promoted inbox item: ${record.inbox_ref.slice(0, 8)}`);
+        }
+      }
       onInfo?.(`Created task: ${taskRef} - ${task.title}`);
       return { resultRef: taskRef };
     }

--- a/tests/triage-actions.test.ts
+++ b/tests/triage-actions.test.ts
@@ -68,7 +68,7 @@ describe("shared executeTriageAction via CLI", () => {
   // through the CLI consumer, which passes onInfo for logging.
 
   // AC: @triage-cli-commands ac-4
-  it("promote action should create a task from the triage record", () => {
+  it("promote action should create a task and consume the inbox item by default", () => {
     const inboxUlid = addInboxItem("Feature: add export button");
     const record = recordTriage(inboxUlid, "promote", "clear feature request");
 
@@ -78,6 +78,7 @@ describe("shared executeTriageAction via CLI", () => {
     );
     expect(actResult.exitCode).toBe(0);
     expect(actResult.stdout).toContain("Created task:");
+    expect(actResult.stdout).toContain("Deleted promoted inbox item");
     expect(actResult.stdout).toContain("Acted on triage record");
 
     // Verify task was created
@@ -87,6 +88,30 @@ describe("shared executeTriageAction via CLI", () => {
     );
     const created = tasks.find((t) => t.description?.includes("Feature: add export button"));
     expect(created).toBeDefined();
+
+    // Verify inbox item was consumed
+    const inbox = kspecJson<Array<{ _ulid: string }>>("inbox list", tempDir);
+    const found = inbox.find((i) => i._ulid === inboxUlid);
+    expect(found).toBeUndefined();
+  });
+
+  // AC: @triage-cli-commands ac-4
+  it("promote action should keep inbox item when --keep is provided", () => {
+    const inboxUlid = addInboxItem("Feature: keep inbox item");
+    const record = recordTriage(inboxUlid, "promote", "keep original");
+
+    const actResult = kspec(
+      `triage act @${record._ulid.slice(0, 8)} --keep`,
+      tempDir,
+    );
+    expect(actResult.exitCode).toBe(0);
+    expect(actResult.stdout).toContain("Created task:");
+    expect(actResult.stdout).toContain("Acted on triage record");
+    expect(actResult.stdout).not.toContain("Deleted promoted inbox item");
+
+    const inbox = kspecJson<Array<{ _ulid: string }>>("inbox list", tempDir);
+    const found = inbox.find((i) => i._ulid === inboxUlid);
+    expect(found).toBeDefined();
   });
 
   // AC: @triage-cli-commands ac-5
@@ -167,6 +192,14 @@ describe("shared executeTriageAction via CLI", () => {
     );
     expect(actResult.exitCode).toBe(0);
     expect(actResult.stdout).toContain("Would create task");
+    expect(actResult.stdout).toContain("Would delete promoted inbox item");
+
+    const keepResult = kspec(
+      `triage act @${record._ulid.slice(0, 8)} --dry-run --keep`,
+      tempDir,
+    );
+    expect(keepResult.exitCode).toBe(0);
+    expect(keepResult.stdout).toContain("Would keep promoted inbox item");
 
     // Verify no task was actually created
     const tasks = kspecJson<Array<{ description: string }>>(

--- a/tests/triage-cli.test.ts
+++ b/tests/triage-cli.test.ts
@@ -242,7 +242,7 @@ describe("kspec triage list", () => {
 
 describe("kspec triage act", () => {
   // AC: @triage-cli-commands ac-4
-  it("should execute promote action creating a task from snapshot", () => {
+  it("should execute promote action creating a task and consuming inbox item by default", () => {
     const inboxUlid = addInboxItem("Create this as a task");
     const record = recordTriage(inboxUlid, "promote", "clear feature");
 
@@ -252,6 +252,7 @@ describe("kspec triage act", () => {
     );
     expect(result.stdout).toContain("Acted on triage record");
     expect(result.stdout).toContain("promote");
+    expect(result.stdout).toContain("Deleted promoted inbox item");
 
     // Verify record transitioned to acted_on
     const records = kspecJson<Array<{ _ulid: string; status: string; acted_at: string; result_ref: string }>>(
@@ -263,6 +264,35 @@ describe("kspec triage act", () => {
     expect(acted!.status).toBe("acted_on");
     expect(acted!.acted_at).toBeDefined();
     expect(acted!.result_ref).toBeDefined();
+
+    // Verify inbox item was consumed
+    const inbox = kspecJson<Array<{ _ulid: string }>>(
+      "inbox list",
+      tempDir,
+    );
+    const found = inbox.find((item) => item._ulid === inboxUlid);
+    expect(found).toBeUndefined();
+  });
+
+  // AC: @triage-cli-commands ac-4
+  it("should keep promoted inbox item when --keep is provided", () => {
+    const inboxUlid = addInboxItem("Keep this inbox item");
+    const record = recordTriage(inboxUlid, "promote", "keep item");
+
+    const result = kspec(
+      `triage act @${record._ulid.slice(0, 8)} --keep`,
+      tempDir,
+    );
+    expect(result.stdout).toContain("Acted on triage record");
+    expect(result.stdout).toContain("promote");
+    expect(result.stdout).not.toContain("Deleted promoted inbox item");
+
+    const inbox = kspecJson<Array<{ _ulid: string }>>(
+      "inbox list",
+      tempDir,
+    );
+    const found = inbox.find((item) => item._ulid === inboxUlid);
+    expect(found).toBeDefined();
   });
 
   // AC: @triage-cli-commands ac-5
@@ -421,6 +451,13 @@ describe("kspec triage act", () => {
     );
     expect(result.stdout).toContain("Dry run");
     expect(result.stdout).toContain("Would create task");
+    expect(result.stdout).toContain("Would delete promoted inbox item");
+
+    const keepResult = kspec(
+      `triage act @${record._ulid.slice(0, 8)} --dry-run --keep`,
+      tempDir,
+    );
+    expect(keepResult.stdout).toContain("Would keep promoted inbox item");
 
     // Verify record was NOT transitioned
     const records = kspecJson<Array<{ _ulid: string; status: string }>>(


### PR DESCRIPTION
## Summary
- add consume control to shared triage action execution and default promote actions to consume the source inbox item
- add `--keep` on `kspec triage act` to opt out of promote-consume behavior
- extend dry-run messaging to show whether promoted inbox items would be deleted or kept
- add regression coverage for default consume, `--keep`, and dry-run messaging in triage action/CLI tests

## Verification
- npm test -- tests/triage-actions.test.ts tests/triage-cli.test.ts
- kspec validate *(fails with pre-existing project-wide meta/reference/alignment/completeness issues around observations and unrelated specs/tasks)*

Task: @01KJDQ1EKVV4V60V7WT6DCK3H3
Spec: @triage-cli-commands