### PR TITLE
feat(web-ui): persist triage filters in URL

### DIFF
--- a/packages/web-ui/src/routes/triage/+page.svelte
+++ b/packages/web-ui/src/routes/triage/+page.svelte
@@ -2,6 +2,9 @@
 	// AC: @interactive-triage-ui ac-1, ac-2, ac-3, ac-4, ac-5, ac-6, ac-7, ac-8
 	// AC: @trait-websocket-protocol ac-1, ac-2, ac-3
 	import { onMount, onDestroy } from 'svelte';
+	import { goto } from '$app/navigation';
+	import { base } from '$app/paths';
+	import { page } from '$app/stores';
 	import type { InboxItem, BroadcastEvent } from '@kynetic-ai/shared';
 	import type { TriageRecord, TriageAction } from '$lib/types/triage';
 	import {
@@ -38,12 +41,6 @@
 	let selectedAction = $state<TriageAction | ''>('');
 	let reasoning = $state('');
 
-	// Filter state
-	// AC: @interactive-triage-ui ac-7
-	let filterTag = $state<string | ''>('');
-	let filterStatus = $state<'all' | 'untriaged' | 'triaged' | 'acted_on'>('all');
-	let filterAction = $state<TriageAction | ''>('');
-
 	// Action labels
 	const ACTION_LABELS: Record<TriageAction, string> = {
 		promote: 'Promote to Task',
@@ -60,6 +57,46 @@
 		'spec-gap': 'bg-purple-500',
 		duplicate: 'bg-gray-500'
 	};
+
+	type TriageFilterStatus = 'all' | 'untriaged' | 'triaged' | 'acted_on';
+	const TRIAGE_STATUS_VALUES: readonly TriageFilterStatus[] = ['all', 'untriaged', 'triaged', 'acted_on'];
+	const TRIAGE_ACTION_VALUES = Object.keys(ACTION_LABELS) as TriageAction[];
+
+	// Filter state
+	// AC: @interactive-triage-ui ac-7
+	let filterTag = $state<string | ''>('');
+	let filterStatus = $state<TriageFilterStatus>('all');
+	let filterAction = $state<TriageAction | ''>('');
+
+	function parseFilterStatus(rawStatus: string | null): TriageFilterStatus {
+		if (rawStatus && TRIAGE_STATUS_VALUES.includes(rawStatus as TriageFilterStatus)) {
+			return rawStatus as TriageFilterStatus;
+		}
+		return 'all';
+	}
+
+	function parseFilterAction(rawAction: string | null): TriageAction | '' {
+		if (rawAction && TRIAGE_ACTION_VALUES.includes(rawAction as TriageAction)) {
+			return rawAction as TriageAction;
+		}
+		return '';
+	}
+
+	$effect(() => {
+		const nextTag = $page.url.searchParams.get('tag') || '';
+		const nextStatus = parseFilterStatus($page.url.searchParams.get('status'));
+		const nextAction = parseFilterAction($page.url.searchParams.get('action'));
+
+		if (filterTag !== nextTag) {
+			filterTag = nextTag;
+		}
+		if (filterStatus !== nextStatus) {
+			filterStatus = nextStatus;
+		}
+		if (filterAction !== nextAction) {
+			filterAction = nextAction;
+		}
+	});
 
 	// Merged view: inbox items with their triage records
 	interface TriageCardItem {
@@ -171,6 +208,20 @@
 		} catch (err) {
 			console.error('Failed to reload triage records:', err);
 		}
+	}
+
+	function updateFilterParam(key: 'status' | 'action' | 'tag', value: string) {
+		const params = new URLSearchParams($page.url.searchParams);
+
+		if (!value || value === 'all') {
+			params.delete(key);
+		} else {
+			params.set(key, value);
+		}
+
+		const query = params.toString();
+		const nextUrl = query ? `${base}/triage?${query}` : `${base}/triage`;
+		goto(nextUrl, { replaceState: false, keepFocus: true, noScroll: true });
 	}
 
 	// AC: @interactive-triage-ui ac-5 - Navigation
@@ -331,6 +382,7 @@
 		<div class="flex gap-2 items-center" data-testid="triage-filters">
 			<select
 				bind:value={filterStatus}
+				onchange={(event) => updateFilterParam('status', (event.currentTarget as HTMLSelectElement).value)}
 				class="rounded-md border bg-background px-3 py-1.5 text-sm"
 				data-testid="triage-status-filter"
 			>
@@ -341,6 +393,7 @@
 			</select>
 			<select
 				bind:value={filterAction}
+				onchange={(event) => updateFilterParam('action', (event.currentTarget as HTMLSelectElement).value)}
 				class="rounded-md border bg-background px-3 py-1.5 text-sm"
 				data-testid="triage-action-filter"
 			>
@@ -352,6 +405,7 @@
 			{#if allTags.length > 0}
 				<select
 					bind:value={filterTag}
+					onchange={(event) => updateFilterParam('tag', (event.currentTarget as HTMLSelectElement).value)}
 					class="rounded-md border bg-background px-3 py-1.5 text-sm"
 					data-testid="triage-tag-filter"
 				>

--- a/packages/web-ui/tests/e2e/triage.spec.ts
+++ b/packages/web-ui/tests/e2e/triage.spec.ts
@@ -154,6 +154,50 @@ test.describe('Interactive Triage UI', () => {
   });
 
   // AC: @interactive-triage-ui ac-7
+  test('filter selections update URL query params', async ({ page }) => {
+    const statusFilter = page.getByTestId('triage-status-filter');
+    const actionFilter = page.getByTestId('triage-action-filter');
+    const tagFilter = page.getByTestId('triage-tag-filter');
+
+    await statusFilter.selectOption('triaged');
+    await expect(page).toHaveURL(/\/triage\?.*status=triaged/);
+
+    await actionFilter.selectOption('defer');
+    await expect(page).toHaveURL(/\/triage\?.*status=triaged/);
+    await expect(page).toHaveURL(/\/triage\?.*action=defer/);
+
+    const optionCount = await tagFilter.locator('option').count();
+    if (optionCount > 1) {
+      const firstTag = await tagFilter.locator('option').nth(1).getAttribute('value');
+      if (firstTag) {
+        await tagFilter.selectOption(firstTag);
+        const encodedTag = encodeURIComponent(firstTag);
+        await expect(page).toHaveURL(new RegExp(`\\/triage\\?.*tag=${encodedTag}`));
+      }
+    }
+  });
+
+  // AC: @interactive-triage-ui ac-7
+  test('restores filter selections from URL and supports back-forward history', async ({ page }) => {
+    await page.goto('/triage?status=triaged&action=defer');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByTestId('triage-status-filter')).toHaveValue('triaged');
+    await expect(page.getByTestId('triage-action-filter')).toHaveValue('defer');
+
+    await page.getByTestId('triage-status-filter').selectOption('acted_on');
+    await expect(page).toHaveURL(/\/triage\?.*status=acted_on/);
+
+    await page.goBack();
+    await expect(page).toHaveURL(/\/triage\?.*status=triaged/);
+    await expect(page.getByTestId('triage-status-filter')).toHaveValue('triaged');
+
+    await page.goForward();
+    await expect(page).toHaveURL(/\/triage\?.*status=acted_on/);
+    await expect(page.getByTestId('triage-status-filter')).toHaveValue('acted_on');
+  });
+
+  // AC: @interactive-triage-ui ac-7
   test('action filter narrows cards by triage action and resets card index', async ({ page, request }) => {
     let targetAction = 'defer';
     const triageListResponse = await request.get('http://localhost:3456/api/triage?limit=1000');


### PR DESCRIPTION
## Summary
- sync triage `status`, `action`, and `tag` filter state with URL query params
- restore triage filter controls from URL on load and browser history navigation
- add AC-7 E2E coverage for URL updates and back/forward restoration

## Verification
- `npm run build -w packages/web-ui`
- `npx playwright test tests/e2e/triage.spec.ts -g "filter selections update URL query params|restores filter selections from URL and supports back-forward history|action filter narrows cards by triage action and resets card index" --workers=1`
- `kspec validate` *(fails with pre-existing project-wide schema/reference/alignment issues unrelated to this task)*

Task: @01KJDQ1F
Spec: @web-ui
