### PR TITLE
fix(ralph): surface subagent process exit code and signal in failure errors

### DIFF
--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -372,10 +372,15 @@ export class ACPClient extends EventEmitter {
    * Close the client connection
    *
    * Rejects any pending requests and cleans up resources.
+   *
+   * @param reason - Optional reason message for pending request rejections.
+   *   Defaults to "JsonRpcFraming closed". Pass process exit info here so
+   *   callers see "Subagent process exited with signal SIGKILL" instead of
+   *   the opaque framing error.
    */
-  close(): void {
+  close(reason?: string): void {
     this.sessions.clear();
-    this.framing.close();
+    this.framing.close(reason);
   }
 
   /**

--- a/src/acp/framing.ts
+++ b/src/acp/framing.ts
@@ -212,15 +212,21 @@ export class JsonRpcFraming extends EventEmitter {
 
   /**
    * Close the framing layer
+   *
+   * @param reason - Optional reason message for pending request rejections.
+   *   Defaults to "JsonRpcFraming closed". Use this to surface process exit
+   *   information (e.g., "Subagent process exited with signal SIGKILL").
    */
-  close(): void {
+  close(reason?: string): void {
     if (this.closed) return;
     this.closed = true;
+
+    const errorMessage = reason ?? "JsonRpcFraming closed";
 
     // Reject all pending requests
     for (const [id, pending] of this.pending.entries()) {
       clearTimeout(pending.timer);
-      pending.reject(new Error("JsonRpcFraming closed"));
+      pending.reject(new Error(errorMessage));
       this.pending.delete(id);
     }
 

--- a/src/agents/spawner.ts
+++ b/src/agents/spawner.ts
@@ -85,10 +85,18 @@ export function spawnAgent(
     stdout: child.stdin as NodeJS.WritableStream, // We write to child's stdin
   });
 
-  // Forward process exit to client close
-  child.on("exit", () => {
+  // Forward process exit to client close, surfacing exit code/signal
+  child.on("exit", (code, signal) => {
     if (!client.isClosed()) {
-      client.close();
+      let reason: string;
+      if (signal !== null) {
+        reason = `Subagent process exited with signal ${signal}`;
+      } else if (code !== null) {
+        reason = `Subagent process exited with code ${code}`;
+      } else {
+        reason = "Subagent process exited unexpectedly";
+      }
+      client.close(reason);
     }
   });
 

--- a/tests/acp.test.ts
+++ b/tests/acp.test.ts
@@ -326,6 +326,20 @@ describe('JsonRpcFraming', () => {
     expect(() => framing.sendResponse(1, {})).toThrow('closed');
   });
 
+  it('should reject pending requests with default message when closed without reason', async () => {
+    const requestPromise = framing.sendRequest('test/method');
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    framing.close();
+    await expect(requestPromise).rejects.toThrow('JsonRpcFraming closed');
+  });
+
+  it('should reject pending requests with provided reason when closed with reason', async () => {
+    const requestPromise = framing.sendRequest('test/method');
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    framing.close('Subagent process exited with signal SIGKILL');
+    await expect(requestPromise).rejects.toThrow('Subagent process exited with signal SIGKILL');
+  });
+
   // AC: @acp-client ac-6
   it('should reset pending timers on incoming activity', async () => {
     // Create framing with short timeout
@@ -738,6 +752,42 @@ describe('ACPClient', () => {
 
       client.close();
       expect(client.getAllSessions()).toHaveLength(0);
+    });
+
+    it('rejects pending requests with default message when no reason given', async () => {
+      const initPromise = client.initialize();
+      await respondToNext({ protocolVersion: 1, agentCapabilities: {} });
+      await initPromise;
+
+      const sessionPromise = client.newSession({ cwd: '/' });
+      // Don't respond — leave the request pending, then close
+      const closeAndCheck = new Promise<void>((resolve) => {
+        setTimeout(() => {
+          client.close();
+          resolve();
+        }, 10);
+      });
+
+      await closeAndCheck;
+      await expect(sessionPromise).rejects.toThrow('JsonRpcFraming closed');
+    });
+
+    it('rejects pending requests with provided reason on process exit', async () => {
+      const initPromise = client.initialize();
+      await respondToNext({ protocolVersion: 1, agentCapabilities: {} });
+      await initPromise;
+
+      const sessionPromise = client.newSession({ cwd: '/' });
+      // Don't respond — simulate process exit with signal
+      const closeAndCheck = new Promise<void>((resolve) => {
+        setTimeout(() => {
+          client.close('Subagent process exited with signal SIGKILL');
+          resolve();
+        }, 10);
+      });
+
+      await closeAndCheck;
+      await expect(sessionPromise).rejects.toThrow('Subagent process exited with signal SIGKILL');
     });
   });
 });


### PR DESCRIPTION
## Summary

- When a subagent dies unexpectedly, the error now says `Subagent process exited with signal SIGKILL` (or exit code) instead of the opaque `JsonRpcFraming closed`
- Added optional `reason` parameter to `JsonRpcFraming.close()` and `ACPClient.close()` for descriptive rejection messages
- Updated `spawner.ts` exit handler to capture `(code, signal)` and pass a descriptive reason through the close path

## Test plan

- [ ] `npx vitest run tests/acp.test.ts` — 49 tests pass including 4 new tests for close reason behavior
- [ ] Full test suite passes (2 pre-existing failures in enhanced-setup.test.ts are unrelated)
- [ ] Framing: pending requests rejected with correct reason on `close(reason)`
- [ ] ACPClient: pending requests rejected with correct reason on `close(reason)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)