### PR TITLE
fix(validate): derive drift detection field sets from Zod schemas at runtime

### DIFF
--- a/src/parser/validate.ts
+++ b/src/parser/validate.ts
@@ -1097,69 +1097,16 @@ async function checkCompleteness(
 // ============================================================
 
 /**
- * Known schema fields for SpecItem
- * These are the actual fields defined in SpecItemSchema
+ * Known schema fields for SpecItem — derived at runtime from SpecItemSchema.shape
+ * to prevent drift from the actual schema definition.
  */
-const SPEC_ITEM_FIELDS = new Set([
-  "_ulid",
-  "slugs",
-  "title",
-  "type",
-  "status",
-  "maturity",
-  "implementation",
-  "priority",
-  "tags",
-  "description",
-  "acceptance_criteria",
-  "depends_on",
-  "implements",
-  "relates_to",
-  "tests",
-  "traits",
-  "supersedes",
-  "traceability",
-  "created",
-  "created_by",
-  "deprecated_in",
-  "superseded_by",
-  "verified_at",
-  "verified_by",
-  "notes",
-]);
+const SPEC_ITEM_FIELDS = new Set(Object.keys(SpecItemSchema.shape));
 
 /**
- * Known schema fields for Task
- * These are the actual fields defined in TaskSchema
+ * Known schema fields for Task — derived at runtime from TaskSchema.shape
+ * to prevent drift from the actual schema definition.
  */
-const TASK_FIELDS = new Set([
-  "_ulid",
-  "slugs",
-  "title",
-  "type",
-  "description",
-  "spec_ref",
-  "derivation",
-  "meta_ref",
-  "plan_ref",
-  "origin",
-  "status",
-  "blocked_by",
-  "closed_reason",
-  "depends_on",
-  "context",
-  "priority",
-  "complexity",
-  "tags",
-  "assignee",
-  "vcs_refs",
-  "created_at",
-  "started_at",
-  "completed_at",
-  "notes",
-  "todos",
-  "automation",
-]);
+const TASK_FIELDS = new Set(Object.keys(TaskSchema.shape));
 
 /**
  * Known fields that are referenced but are parse-time or conceptual only


### PR DESCRIPTION
## Summary

- Replace hardcoded `SPEC_ITEM_FIELDS` and `TASK_FIELDS` Sets in the AC schema drift detector with runtime derivation from `SpecItemSchema.shape` and `TaskSchema.shape`
- Fixes the self-defeating bug where the drift detector itself could drift from the schemas it was supposed to protect
- Incidentally fixes a latent gap: `TaskSchema` had `session_id` and `submitted_at` fields missing from the hardcoded set — these are now auto-included
- Both schemas were already imported in `validate.ts`, so no new imports needed

## Test plan

- [x] All 8 existing drift detection tests pass (`tests/ac-schema-drift.test.ts`)
- [x] Full shard 1 test suite passes (1241 tests)
- [x] Build succeeds with no TypeScript errors
- [x] Pre-existing `enhanced-setup.test.ts` failure confirmed unrelated to this change

Task: @01KHF34F

Generated with [Claude Code](https://claude.ai/code)