### PR TITLE
test: strengthen AC-6 item list parity test with real status verification

### DIFF
--- a/tests/multi-value-status-filter.test.ts
+++ b/tests/multi-value-status-filter.test.ts
@@ -76,10 +76,30 @@ describe('Integration: multi-value status filter', () => {
 
   // AC: @multi-value-status-filter ac-item-list-parity
   it('should support comma-separated status on item list', () => {
-    const result = kspec('item list --status implemented,verified', tempDir);
-    expect(result.exitCode).toBe(0);
-    // Should not error — even if fixture has no items with those statuses,
-    // the command should complete successfully
+    // Create items with known statuses
+    kspec('item add --under @test-core --title "Implemented Feature" --slug impl-feature --type feature', tempDir);
+    kspec('item add --under @test-core --title "Verified Feature" --slug verified-feature --type feature', tempDir);
+    kspec('item add --under @test-core --title "Not Started Feature" --slug not-started-feature --type feature', tempDir);
+
+    kspec('item set @impl-feature --status implemented', tempDir);
+    kspec('item set @verified-feature --status verified', tempDir);
+    // @not-started-feature stays not_started (default)
+
+    const result = kspecJson<{
+      items: Array<{ slugs: string[]; status?: { implementation?: string } }>;
+    }>('item list --status implemented,verified --json', tempDir);
+    const items = result.items;
+    expect(Array.isArray(items)).toBe(true);
+
+    const slugs = items.flatMap((item) => item.slugs);
+    expect(slugs).toContain('impl-feature');
+    expect(slugs).toContain('verified-feature');
+    expect(slugs).not.toContain('not-started-feature');
+
+    // All returned items must have status implemented or verified
+    for (const item of items) {
+      expect(['implemented', 'verified']).toContain(item.status?.implementation);
+    }
   });
 
   // AC: @multi-value-status-filter ac-json-output


### PR DESCRIPTION
## Summary

- **Fix vacuous test**: The ac-item-list-parity test for `@multi-value-status-filter` previously only checked exit code 0 without verifying filtered results actually matched requested statuses. Since the fixture had no items with `implemented` or `verified` status, the test passed vacuously with an empty result set.
- **Now tests real behavior**: Creates items with known statuses, sets them explicitly via `kspec item set`, then asserts items with matching status appear in results, items with non-matching status are excluded, and all returned items have one of the requested statuses.
- **Fixes JSON structure handling**: Corrected type annotation from `any[]` to `{ items: Array<...> }` since `item list --json` outputs `{"items": [...]}` not a flat array. Also uses `item.status.implementation` (nested object) not `item.status` (string).

## Test plan

- [x] 10/10 tests pass in `tests/multi-value-status-filter.test.ts`
- [x] Pre-existing failures in `enhanced-setup.test.ts` and `core-skill-install.test.ts` are unrelated (codex config.toml not created)
- [x] Full shards 1, 2, 3 pass (only pre-existing failures)

Task: @01KHF2BR

🤖 Generated with [Claude Code](https://claude.com/claude-code)