### PR TITLE
fix(sessions): exempt needs_work→in_progress from budget enforcement

### DIFF
--- a/src/cli/commands/task.ts
+++ b/src/cli/commands/task.ts
@@ -1131,15 +1131,20 @@ Examples:
           }
         }
 
-        // AC: @task-budget-enforcement ac-block-start, ac-no-session, ac-no-budget
-        // Check budget before starting — only when session is set
-        const budgetCheck = await checkBudget(
-          ctx.specDir,
-          sessionId || undefined,
-        );
-        if (!budgetCheck.allowed) {
-          error(budgetCheck.reason!);
-          process.exit(EXIT_CODES.VALIDATION_FAILED);
+        // AC: @task-budget-enforcement ac-block-start, ac-no-session, ac-no-budget, ac-needs-work-no-increment
+        // Check budget before starting — only when session is set.
+        // Skip budget check for needs_work→in_progress (fix cycles): the task
+        // already consumed a budget slot when originally started; blocking it
+        // would prevent completing already-assigned work.
+        if (foundTask.status !== "needs_work") {
+          const budgetCheck = await checkBudget(
+            ctx.specDir,
+            sessionId || undefined,
+          );
+          if (!budgetCheck.allowed) {
+            error(budgetCheck.reason!);
+            process.exit(EXIT_CODES.VALIDATION_FAILED);
+          }
         }
 
         // Update status
@@ -1158,11 +1163,12 @@ Examples:
           foundTask.slugs[0] || index.shortUlid(foundTask._ulid),
         );
 
-        // AC: @task-budget-enforcement ac-increment, ac-resume-no-increment
-        // Increment budget counter after successful start.
-        // Resume case (already in_progress) returns early above, so this only
-        // runs for genuine pending→in_progress or needs_work→in_progress transitions.
-        if (sessionId) {
+        // AC: @task-budget-enforcement ac-increment, ac-resume-no-increment, ac-needs-work-no-increment
+        // Increment budget counter after successful start, but only for
+        // genuine pending→in_progress transitions. Resume case returns early
+        // above. needs_work→in_progress is a fix cycle (task already consumed
+        // a budget slot when originally started) — don't double-count it.
+        if (sessionId && foundTask.status === "pending") {
           await incrementBudget(ctx.specDir, sessionId);
         }
 

--- a/tests/task-budget-enforcement.test.ts
+++ b/tests/task-budget-enforcement.test.ts
@@ -185,6 +185,53 @@ describe("Integration: task budget enforcement", () => {
     });
   });
 
+  // AC: @task-budget-enforcement ac-needs-work-no-increment
+  describe("ac-needs-work-no-increment: no increment when restarting a needs_work task", () => {
+    it("should not increment budget when transitioning needs_work to in_progress", async () => {
+      // Set up budget with 1 task started (consumed when task was originally started)
+      await createTestBudget(tempDir, SESSION_ID, 3, 1);
+
+      // Put task into needs_work state (start → submit → needs-work)
+      // These run without budget env to avoid budget interference during setup
+      kspec("task start @test-task-pending", tempDir);
+      kspec("task submit @test-task-pending", tempDir);
+      kspec(
+        'task needs-work @test-task-pending --reason "Fix cycle test"',
+        tempDir,
+      );
+
+      // Now restart from needs_work WITH session — should NOT increment
+      kspec("task start @test-task-pending", tempDir, {
+        env: { KSPEC_SESSION_ID: SESSION_ID },
+      });
+
+      // Budget should still be 1 — needs_work restart doesn't burn a new slot
+      const budget = await readTestBudget(tempDir, SESSION_ID);
+      expect(budget).not.toBeNull();
+      expect(budget!.started_this_cycle).toBe(1);
+    });
+
+    it("should allow needs_work restart even when budget is exhausted", async () => {
+      // Budget is at max — but needs_work restart should bypass this
+      await createTestBudget(tempDir, SESSION_ID, 1, 1);
+
+      // Put task into needs_work without budget env
+      kspec("task start @test-task-pending", tempDir);
+      kspec("task submit @test-task-pending", tempDir);
+      kspec(
+        'task needs-work @test-task-pending --reason "Fix cycle test"',
+        tempDir,
+      );
+
+      // Restart from needs_work even though budget is exhausted
+      const result = kspec("task start @test-task-pending", tempDir, {
+        env: { KSPEC_SESSION_ID: SESSION_ID },
+      });
+
+      expect(result.stdout + result.stderr).toContain("Started task");
+    });
+  });
+
   // AC: @task-budget-enforcement ac-resume-no-increment
   describe("ac-resume-no-increment: no increment when task already in_progress", () => {
     it("should not increment budget when resuming an in-progress task", async () => {


### PR DESCRIPTION
## Summary

- Fix cycles (`needs_work` tasks) no longer consume a new budget slot when restarted
- `kspec task start` now skips `checkBudget()` for `needs_work` tasks — fix cycles bypass the budget gate entirely
- `incrementBudget()` is now only called when the previous task status was `pending`, not `needs_work`
- Added `ac-needs-work-no-increment` AC to `@task-budget-enforcement` spec

## Problem

When a task enters a fix cycle (`pending_review → needs_work → in_progress`), calling `kspec task start` was:
1. Blocked by budget exhaustion (even though this is existing work, not a new task)
2. Incrementing the budget counter (double-counting a slot already consumed when originally started)

This caused ralph loop iterations to be wasted on tasks that were already in progress.

## Test plan

- [x] `ac-needs-work-no-increment`: `needs_work → in_progress` does not increment budget counter
- [x] Budget-exhausted sessions can still restart `needs_work` tasks
- [x] All 19 budget enforcement tests pass
- [x] All 9 needs_work tests pass
- [x] Full test shard 1 passes (1243 tests)

Task: @01KJ7CN8

Generated with [Claude Code](https://claude.ai/code)