### PR TITLE
test(batch): add ac-7 flush failure test and document Phase 2 limitation

### DIFF
--- a/src/cli/batch-write-buffer.ts
+++ b/src/cli/batch-write-buffer.ts
@@ -108,6 +108,13 @@ export class WriteBuffer {
    * 3. Rename all staging files to final paths
    * 4. If any rename fails: report error with committed/uncommitted file list
    *
+   * Phase 1 is fully atomic: a staging write failure means no files reach disk.
+   * Phase 2 is best-effort: rename failures are reported with a detailed error, but
+   * files already renamed in Phase 2 before the failure are committed. On healthy
+   * filesystems, Phase 2 rename failures are extremely rare (same-device, same-dir
+   * renames are near-atomic). Partial Phase 2 failure is always an explicit error,
+   * never a silent commit.
+   *
    * AC: @batch-write-buffer ac-3 — only buffered files are written
    * AC: @batch-write-buffer ac-7 — flush failure reported; .kspec/ not silently corrupted
    */

--- a/tests/batch-write-buffer.test.ts
+++ b/tests/batch-write-buffer.test.ts
@@ -147,6 +147,35 @@ describe("WriteBuffer.flush()", () => {
     expect(stagingFiles).toHaveLength(0);
   });
 
+  // AC: @batch-write-buffer ac-7 — flush failure: error reported, pre-batch state preserved
+  it("flush() reports error and leaves no partial writes when staging write fails", async () => {
+    const buf = new WriteBuffer(tempDir);
+
+    // Pre-existing file that should remain unchanged
+    const existingFile = path.join(tempDir, "existing.yaml");
+    await fs.writeFile(existingFile, "original: true", "utf-8");
+
+    // Buffer a write to a path whose parent is a FILE (not a dir) — mkdir will fail,
+    // causing Phase 1 to throw. This exercises the "staging failed, nothing committed" path.
+    const blockingFile = path.join(tempDir, "not-a-dir");
+    await fs.writeFile(blockingFile, "i am a file, not a directory", "utf-8");
+    const fileInsideBlocker = path.join(blockingFile, "nested.yaml");
+
+    buf.write(fileInsideBlocker, "should not appear");
+
+    // flush() should throw with "staging failed" message
+    await expect(buf.flush()).rejects.toThrow("Batch flush staging failed");
+
+    // existingFile should be completely unchanged
+    const content = await fs.readFile(existingFile, "utf-8");
+    expect(content).toBe("original: true");
+
+    // No staging files should remain after cleanup
+    const entries = await fs.readdir(tempDir);
+    const stagingFiles = entries.filter((e) => e.includes(".kspec-batch-staging"));
+    expect(stagingFiles).toHaveLength(0);
+  });
+
   // AC: @batch-write-buffer ac-4 — discard leaves disk unchanged
   it("discard() does not write anything to disk", async () => {
     const buf = new WriteBuffer(tempDir);


### PR DESCRIPTION
## Summary

- Add test for `WriteBuffer.flush()` failure path (ac-7): verifies that when a staging write fails (mkdir fails because path's parent is a regular file), the error is reported and no partial writes reach disk
- Document Phase 2 partial commit limitation in `flush()` JSDoc — staging phase is fully atomic; rename-phase errors are always reported but files already renamed before failure remain committed
- Drops unused `vi` import (ESM can't spy on `node:fs/promises` — used real-failure approach instead)

## Fix Cycle Context

This is a fix cycle for task @01KJQKVZ after PR #636 review found MUST-FIX: ac-7 had no test annotation and no test for the flush failure path. PR #636 was merged but the task remained in `needs_work`.

## Test plan

- [x] `tests/batch-write-buffer.test.ts` — 21/21 tests pass
- [x] `npm run test:shard1` — only pre-existing `daemon-executable.test.ts` failure, unrelated to this change

Task: @01KJQKVZ
Spec: @batch-write-buffer

🤖 Generated with [Claude Code](https://claude.com/claude-code)