### PR TITLE
infra: auto-build dist before CLI subprocess tests run

### DIFF
--- a/tests/global-setup.ts
+++ b/tests/global-setup.ts
@@ -1,0 +1,13 @@
+import { execSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+export default function setup() {
+  const root = join(import.meta.dirname, '..');
+  const distCli = join(root, 'dist', 'cli', 'index.js');
+
+  if (!existsSync(distCli)) {
+    console.log('[global-setup] dist/cli/index.js not found — building...');
+    execSync('npm run build', { cwd: root, stdio: 'inherit' });
+  }
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     globals: true,
     environment: 'node',
     testTimeout: 15_000,
+    globalSetup: './tests/global-setup.ts',
     exclude: [
       '**/node_modules/**',
       '**/dist/**',


### PR DESCRIPTION
## Summary
- Add `tests/global-setup.ts` as vitest globalSetup that checks for `dist/cli/index.js` and triggers `npm run build` if missing
- Wire globalSetup in `vitest.config.ts` so it runs before all test suites regardless of invocation path
- Covers shard scripts (`npm run test:shard1/2/3`) and direct `vitest` invocation that previously bypassed the `pretest` npm hook

## Test plan
- [x] Verified globalSetup loads correctly with `vitest run tests/util.test.ts`
- [x] Confirmed shard1 passes (pre-existing `daemon-executable.test.ts` failure is unrelated)
- [x] Pre-existing failure confirmed by checking without changes via git stash

Task: @01KJR8FK