### PR TITLE
fix(daemon): correct import paths in agent-dispatch.ts

### DIFF
--- a/packages/daemon/src/routes/agent-dispatch.ts
+++ b/packages/daemon/src/routes/agent-dispatch.ts
@@ -20,10 +20,10 @@
  */
 
 import { Elysia, t } from 'elysia';
-import { DispatchEngine } from '../../../agent-runtime/dispatch.js';
-import type { TaskStateChange, TaskStatus, InvocationEvent } from '../../../agent-runtime/dispatch.js';
-import { DEFAULT_KSPEC_CLI_PATH } from '../../../agent-runtime/invocation.js';
-import { initContext, loadMetaContext } from '../../../parser/index.js';
+import { DispatchEngine } from '../../agent-runtime/dispatch.js';
+import type { TaskStateChange, TaskStatus, InvocationEvent } from '../../agent-runtime/dispatch.js';
+import { DEFAULT_KSPEC_CLI_PATH } from '../../agent-runtime/invocation.js';
+import { initContext, loadMetaContext } from '../../parser/index.js';
 import type { PubSubManager } from '../websocket/pubsub.js';
 
 const VALID_TASK_STATUSES = new Set<string>([


### PR DESCRIPTION
## Summary

- Fixed four relative imports in `packages/daemon/src/routes/agent-dispatch.ts` that used `../../../` (resolving to project root) instead of `../../` (resolving to `dist/`, where `agent-runtime/` and `parser/` live)
- Affected imports: `agent-runtime/dispatch.js`, `agent-runtime/invocation.js`, `parser/index.js`
- Caused `kspec serve start` to fail with `Cannot find module '../../../agent-runtime/dispatch.js'` immediately after the daemon agent dispatch integration was merged

## Test plan

- [x] `npm run build:daemon` succeeds
- [x] `kspec serve start` starts without module resolution errors

Generated with [Claude Code](https://claude.ai/code)