### PR TITLE
fix(agent-runtime): handle ACP permission requests in invocation

### DIFF
--- a/src/agent-runtime/invocation.ts
+++ b/src/agent-runtime/invocation.ts
@@ -8,7 +8,7 @@
  * CLI one-shot mode. Each invocation creates an isolated session with
  * its own event log and metadata.
  *
- * AC: @agent-invocation-lifecycle ac-1 through ac-9
+ * AC: @agent-invocation-lifecycle ac-1 through ac-11
  */
 
 import * as path from "node:path";
@@ -19,7 +19,7 @@ import { buildPromptWithSkills } from "./prompts.js";
 import { resolveAdapter } from "../agents/adapters.js";
 import { spawnAndInitialize } from "../agents/spawner.js";
 import type { SpawnedAgent } from "../agents/spawner.js";
-import type { SessionUpdate } from "../acp/index.js";
+import type { RequestPermissionRequest, SessionUpdate } from "../acp/index.js";
 import {
   createSession,
   closeSession,
@@ -180,7 +180,7 @@ function disposeAgent(agent: SpawnedAgent | null): null {
  * Creates a session, spawns the agent, injects KSPEC_SESSION_ID,
  * sends the prompt, streams events, and closes the session on completion.
  *
- * AC: @agent-invocation-lifecycle ac-1 through ac-9
+ * AC: @agent-invocation-lifecycle ac-1 through ac-11
  */
 export async function runInvocation(options: InvocationOptions): Promise<InvocationResult> {
   const {
@@ -307,6 +307,38 @@ export async function runInvocation(options: InvocationOptions): Promise<Invocat
     };
 
     state.agent.client.on("update", updateHandler);
+
+    // ─── Register permission request handler ──────────────────────────────
+    // AC: @agent-invocation-lifecycle ac-11
+    const requestHandler = (id: string | number, method: string, params: unknown) => {
+      if (method === "session/request_permission") {
+        if (autoApprove) {
+          // Auto-approve: prefer allow_always, fall back to allow_once
+          const permParams = params as RequestPermissionRequest;
+          const allowOption =
+            permParams.options?.find((o) => o.kind === "allow_always") ??
+            permParams.options?.find((o) => o.kind === "allow_once");
+
+          if (allowOption) {
+            state.agent!.client.respondPermission(id, {
+              outcome: { outcome: "selected", optionId: allowOption.optionId },
+            });
+          } else {
+            state.agent!.client.respondPermission(id, {
+              outcome: { outcome: "cancelled" },
+            });
+          }
+        } else {
+          // Non-auto-approve: deny the request
+          state.agent!.client.respondPermission(id, {
+            outcome: { outcome: "cancelled" },
+          });
+        }
+      }
+      // Other request types (ReadTextFile, WriteTextFile, etc.) are not handled here
+    };
+
+    state.agent.client.on("request", requestHandler);
 
     // ─── Send prompt with timeout ─────────────────────────────────────────
     // AC: @agent-invocation-lifecycle ac-3

--- a/tests/agent-invocation-lifecycle.test.ts
+++ b/tests/agent-invocation-lifecycle.test.ts
@@ -1063,6 +1063,77 @@ process.exit(0);
   });
 });
 
+// ─── AC-11: ACP permission request auto-approval ─────────────────────────────
+
+// AC: @agent-invocation-lifecycle ac-11
+describe("ACP permission request handling", () => {
+  let testDir: string;
+
+  beforeEach(async () => {
+    testDir = await createTempDir("kspec-invoc-ac11-");
+  });
+
+  afterEach(async () => {
+    await cleanupTempDir(testDir);
+  });
+
+  it("should auto-approve permission requests in auto-approve mode", async () => {
+    // Register adapter that sends a permission request during the prompt
+    registerAdapter("permission-mock-acp", {
+      command: "node",
+      args: [MOCK_ACP],
+      env: {
+        MOCK_ACP_SEND_PERMISSION_REQUEST: "true",
+        MOCK_ACP_PROJECT_DIR: process.cwd(),
+      },
+      description: "Mock ACP that sends permission requests",
+    });
+
+    const agent = makeTestAgent({ adapter: "permission-mock-acp", auto_approve: true });
+
+    const result = await runInvocation({
+      agent,
+      specDir: testDir,
+      cwd: process.cwd(),
+      taskRef: "@" + testUlid("TASK"),
+      prompt: "Test permission auto-approval",
+      trigger: "task.ready",
+      autoApprove: true,
+    });
+
+    // Invocation should complete successfully — not hang waiting for permission
+    expect(result.outcome).toBe("success");
+    expect(result.stopReason).toBe("end_turn");
+  });
+
+  it("should deny permission requests in non-auto-approve mode and still complete", async () => {
+    registerAdapter("permission-deny-acp", {
+      command: "node",
+      args: [MOCK_ACP],
+      env: {
+        MOCK_ACP_SEND_PERMISSION_REQUEST: "true",
+        MOCK_ACP_PROJECT_DIR: process.cwd(),
+      },
+      description: "Mock ACP for permission deny test",
+    });
+
+    const agent = makeTestAgent({ adapter: "permission-deny-acp", auto_approve: false });
+
+    const result = await runInvocation({
+      agent,
+      specDir: testDir,
+      cwd: process.cwd(),
+      taskRef: "@" + testUlid("TASK"),
+      prompt: "Test permission denial",
+      trigger: "task.ready",
+      autoApprove: false,
+    });
+
+    // Invocation should complete (not hang) — mock proceeds after receiving any response
+    expect(result.outcome).toBe("success");
+  });
+});
+
 // ─── Trait: error-guidance ────────────────────────────────────────────────────
 
 // AC: @trait-error-guidance ac-1 — N/A: This is a library module (not a CLI command).

--- a/tests/mocks/acp-mock.js
+++ b/tests/mocks/acp-mock.js
@@ -30,6 +30,8 @@ import { execSync } from 'node:child_process';
 
 let sessionId = null;
 let initialized = false;
+/** Map of pending outgoing requests: id → { resolve, reject } */
+const pendingRequests = new Map();
 
 // ─── Environment Config ──────────────────────────────────────────────────────
 
@@ -48,12 +50,27 @@ const verifyEnvFile = process.env.MOCK_ACP_VERIFY_ENV_FILE;
 const verifyEnvVars = process.env.MOCK_ACP_VERIFY_ENV_VARS; // comma-separated var names
 // Write process.argv to a file for verifying command-line args
 const verifyArgsFile = process.env.MOCK_ACP_VERIFY_ARGS_FILE;
+const sendPermissionRequest = process.env.MOCK_ACP_SEND_PERMISSION_REQUEST === 'true';
 
 // ─── JSON-RPC Helpers ────────────────────────────────────────────────────────
 
 function sendResponse(id, result) {
   const response = { jsonrpc: '2.0', id, result };
   console.log(JSON.stringify(response));
+}
+
+let nextRequestId = 1;
+/**
+ * Send a JSON-RPC request FROM the agent TO the client and await the response.
+ * Used for permission requests where the agent asks the client to approve a tool call.
+ */
+function sendOutgoingRequest(method, params) {
+  return new Promise((resolve, reject) => {
+    const id = `mock-req-${nextRequestId++}`;
+    pendingRequests.set(id, { resolve, reject });
+    const request = { jsonrpc: '2.0', id, method, params };
+    console.log(JSON.stringify(request));
+  });
 }
 
 function sendError(id, code, message) {
@@ -155,6 +172,23 @@ async function handlePrompt(id, params) {
     return;
   }
 
+  // Optionally send a permission request before responding (for ac-11 tests)
+  if (sendPermissionRequest) {
+    await sendOutgoingRequest("session/request_permission", {
+      sessionId: params.sessionId,
+      toolCall: {
+        toolCallUpdate: "tool_use",
+        toolCallId: "mock-tool-1",
+        toolName: "Edit",
+        input: { path: "/some/file.ts", content: "new content" },
+      },
+      options: [
+        { optionId: "allow-once-id", kind: "allow_once", name: "Allow once" },
+        { optionId: "allow-always-id", kind: "allow_always", name: "Allow always" },
+      ],
+    });
+  }
+
   // Send streaming update notification (ACP SessionUpdate format)
   // SessionUpdate is a discriminated union with sessionUpdate as the discriminator
   sendNotification("session/update", {
@@ -238,7 +272,26 @@ async function handleMessage(line) {
   try {
     const msg = JSON.parse(line);
 
-    if (msg.jsonrpc !== "2.0" || !msg.method) {
+    if (msg.jsonrpc !== "2.0") {
+      sendError(msg.id || null, -32600, "Invalid Request");
+      return;
+    }
+
+    // Handle responses to outgoing requests (no 'method' field, has 'result' or 'error')
+    if (!msg.method && msg.id !== undefined) {
+      const pending = pendingRequests.get(msg.id);
+      if (pending) {
+        pendingRequests.delete(msg.id);
+        if (msg.error) {
+          pending.reject(new Error(msg.error.message || 'Request failed'));
+        } else {
+          pending.resolve(msg.result);
+        }
+      }
+      return;
+    }
+
+    if (!msg.method) {
       sendError(msg.id || null, -32600, "Invalid Request");
       return;
     }


### PR DESCRIPTION
## Summary

- Register a `request` event handler on the ACP client in `invocation.ts` alongside the existing `update` handler
- In auto-approve mode: finds `allow_always` or `allow_once` option and responds with the selected optionId
- In non-auto-approve mode: denies with `outcome: cancelled`
- Extended `acp-mock.js` to support bidirectional agent→client JSON-RPC requests via `MOCK_ACP_SEND_PERMISSION_REQUEST=true`

**Root cause**: The ACP agent sends `session/request_permission` as a JSON-RPC request (expecting a response) when it needs tool call authorization. Without a handler, the request sat unanswered and the agent hung indefinitely waiting for human confirmation — even in autonomous dispatch mode.

## Test plan

- [x] `tests/agent-invocation-lifecycle.test.ts` — 2 new ac-11 tests
  - Auto-approve mode: permission request auto-approved, invocation completes successfully
  - Non-auto-approve mode: permission denied, invocation still completes (mock proceeds after any response)
- [x] All 32 existing invocation tests pass
- [x] Shard 1 test suite passes cleanly
- [x] Shard 2 pre-existing failure in `enhanced-setup.test.ts` confirmed unrelated (reproduced on main)

Task: @01KJSA2T
Spec: @agent-invocation-lifecycle
AC: @agent-invocation-lifecycle ac-11

Generated with [Claude Code](https://claude.ai/code)