### PR TITLE
fix: suppress non-actionable rate_limit_event noise in agent run output

### DIFF
--- a/src/agents/spawner.ts
+++ b/src/agents/spawner.ts
@@ -35,6 +35,55 @@ export interface SpawnedAgent {
   kill: (signal?: NodeJS.Signals) => void;
 }
 
+const UNEXPECTED_CASE_PREFIX = "Unexpected case:";
+const RATE_LIMIT_EVENT_TYPE = "rate_limit_event";
+
+function isNonActionableAdapterStderrLine(line: string): boolean {
+  const trimmed = line.trim();
+  if (!trimmed.startsWith(UNEXPECTED_CASE_PREFIX)) return false;
+
+  const payload = trimmed.slice(UNEXPECTED_CASE_PREFIX.length).trim();
+  if (!payload) return false;
+
+  try {
+    const parsed = JSON.parse(payload) as { type?: string };
+    return parsed.type === RATE_LIMIT_EVENT_TYPE;
+  } catch {
+    // Keep a narrow fallback pattern in case adapter logs malformed JSON.
+    return /"type"\s*:\s*"rate_limit_event"/.test(payload);
+  }
+}
+
+function forwardFilteredAdapterStderr(child: ChildProcess): void {
+  if (!child.stderr) return;
+
+  child.stderr.setEncoding("utf-8");
+  let pending = "";
+
+  const forward = (line: string, withNewline: boolean): void => {
+    if (isNonActionableAdapterStderrLine(line)) return;
+    process.stderr.write(withNewline ? `${line}\n` : line);
+  };
+
+  child.stderr.on("data", (chunk: string | Buffer) => {
+    pending += chunk.toString();
+    let newlineIndex = pending.indexOf("\n");
+
+    while (newlineIndex !== -1) {
+      const line = pending.slice(0, newlineIndex);
+      pending = pending.slice(newlineIndex + 1);
+      forward(line, true);
+      newlineIndex = pending.indexOf("\n");
+    }
+  });
+
+  child.stderr.on("end", () => {
+    if (pending.length > 0) {
+      forward(pending, false);
+    }
+  });
+}
+
 /**
  * Spawn an ACP agent using the specified adapter.
  *
@@ -66,8 +115,11 @@ export function spawnAgent(
     cwd,
     env: processEnv,
     shell: adapter.shell,
-    stdio: ["pipe", "pipe", "inherit"], // pipe stdin/stdout, inherit stderr
+    stdio: ["pipe", "pipe", "pipe"], // pipe all stdio so stderr can be filtered
   });
+
+  // Keep actionable adapter stderr visible while dropping known non-actionable noise.
+  forwardFilteredAdapterStderr(child);
 
   // Ensure stdin/stdout are available
   if (!child.stdin || !child.stdout) {

--- a/tests/cli-agent-commands.test.ts
+++ b/tests/cli-agent-commands.test.ts
@@ -1286,6 +1286,50 @@ describe("AC-12: Interactive mode streams text as it arrives", () => {
   });
 });
 
+// AC: @cli-agent-commands ac-12
+describe("AC-12: suppress adapter rate_limit_event noise on stderr", () => {
+  let testDir: string;
+
+  beforeEach(() => {
+    testDir = require("node:fs").mkdtempSync(require("node:path").join(require("node:os").tmpdir(), "kspec-agent-stderr-filter-"));
+    registerMockAdapter();
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await cleanupTempDir(testDir);
+  });
+
+  it("suppresses non-actionable rate_limit_event lines while preserving actionable adapter stderr", async () => {
+    const agent = makeTestAgent({ id: "stderr-filter-agent", adapter: "mock-acp" });
+    const stderrLines: string[] = [];
+
+    vi.spyOn(process.stderr, "write").mockImplementation((chunk) => {
+      stderrLines.push(String(chunk));
+      return true;
+    });
+
+    const result = await runInvocation({
+      agent,
+      specDir: testDir,
+      cwd: process.cwd(),
+      prompt: "test prompt",
+      trigger: "manual",
+      env: {
+        MOCK_ACP_RESPONSE_TEXT: "streaming text from agent",
+        MOCK_ACP_EMIT_RATE_LIMIT_EVENT: "true",
+        MOCK_ACP_EMIT_ACTIONABLE_STDERR: "Actionable adapter error: auth expired",
+      },
+    });
+
+    expect(result.outcome).toBe("success");
+
+    const stderrOutput = stderrLines.join("");
+    expect(stderrOutput).not.toContain("rate_limit_event");
+    expect(stderrOutput).toContain("Actionable adapter error: auth expired");
+  });
+});
+
 // ─── AC-13 through AC-16: kspec agent dispatch watch ─────────────────────────
 
 // Helper: create a fake WebSocket instance for testing

--- a/tests/mocks/acp-mock.js
+++ b/tests/mocks/acp-mock.js
@@ -20,6 +20,8 @@
  * - MOCK_ACP_PROJECT_DIR: Working directory for kspec commands
  * - MOCK_ACP_CLI_PATH: Path to kspec CLI entry point (required in CI where kspec isn't global)
  * - MOCK_ACP_VERIFY_ARGS_FILE: Write process.argv to this file for verifying command-line args
+ * - MOCK_ACP_EMIT_RATE_LIMIT_EVENT: If true, emit a simulated non-actionable rate_limit_event stderr line
+ * - MOCK_ACP_EMIT_ACTIONABLE_STDERR: Emit this stderr line during prompt handling
  */
 
 import * as fs from 'node:fs';
@@ -51,6 +53,8 @@ const verifyEnvVars = process.env.MOCK_ACP_VERIFY_ENV_VARS; // comma-separated v
 // Write process.argv to a file for verifying command-line args
 const verifyArgsFile = process.env.MOCK_ACP_VERIFY_ARGS_FILE;
 const sendPermissionRequest = process.env.MOCK_ACP_SEND_PERMISSION_REQUEST === 'true';
+const emitRateLimitEvent = process.env.MOCK_ACP_EMIT_RATE_LIMIT_EVENT === 'true';
+const actionableStderr = process.env.MOCK_ACP_EMIT_ACTIONABLE_STDERR;
 
 // ─── JSON-RPC Helpers ────────────────────────────────────────────────────────
 
@@ -170,6 +174,14 @@ async function handlePrompt(id, params) {
   if (shouldFail()) {
     sendError(id, -32000, "Mock failure");
     return;
+  }
+
+  if (emitRateLimitEvent) {
+    console.error('Unexpected case: {"type":"rate_limit_event","detail":"mock rate limit info"}');
+  }
+
+  if (actionableStderr) {
+    console.error(actionableStderr);
   }
 
   // Optionally send a permission request before responding (for ac-11 tests)


### PR DESCRIPTION
## Summary
- pipe adapter stderr in the agent spawner instead of inheriting it directly
- suppress only known non-actionable stderr lines matching `Unexpected case: {..."type":"rate_limit_event"...}`
- preserve all other adapter stderr output so actionable failures remain visible
- add mock ACP stderr toggles and a regression test that verifies suppression + actionable passthrough

## Test plan
- [x] npx vitest run tests/cli-agent-commands.test.ts
- [x] npm test
- [x] env -u KSPEC_SESSION_ID kspec validate (fails due pre-existing repository meta/spec issues unrelated to this change)

Task: @01KJTQBR
Spec: @cli-agent-commands