### PR TITLE
Prevent lost task state from concurrent task mutations in agent invocations

### DIFF
--- a/src/cli/commands/task.ts
+++ b/src/cli/commands/task.ts
@@ -14,6 +14,7 @@ import {
   type LoadedTask,
   loadAllItems,
   loadAllTasks,
+  mutateTaskAtomically,
   ReferenceIndex,
   saveTask,
   scanTestCoverage,
@@ -1195,14 +1196,17 @@ Examples:
 
         // Update status
         // AC: @session-scoped-task-claiming ac-stamp, ac-no-env
-        const updatedTask: Task = {
-          ...foundTask,
-          status: "in_progress",
-          started_at: new Date().toISOString(),
-          ...(sessionId ? { session_id: sessionId } : {}),
-        };
+        let transitionFromStatus: Task["status"] = foundTask.status;
+        const updatedTask = await mutateTaskAtomically(ctx, foundTask, (latestTask) => {
+          transitionFromStatus = latestTask.status;
+          return {
+            ...latestTask,
+            status: "in_progress",
+            started_at: new Date().toISOString(),
+            ...(sessionId ? { session_id: sessionId } : {}),
+          };
+        });
 
-        await saveTask(ctx, updatedTask);
         await commitIfShadow(
           ctx.shadow,
           "task-start",
@@ -1214,7 +1218,7 @@ Examples:
         // genuine pending→in_progress transitions. Resume case returns early
         // above. needs_work→in_progress is a fix cycle (task already consumed
         // a budget slot when originally started) — don't double-count it.
-        if (sessionId && foundTask.status === "pending") {
+        if (sessionId && transitionFromStatus === "pending") {
           await incrementBudget(ctx.specDir, sessionId);
         }
 
@@ -1222,7 +1226,7 @@ Examples:
         postDispatchEvent({
           taskId: updatedTask._ulid,
           taskRef: `@${updatedTask.slugs[0] || updatedTask._ulid}`,
-          fromStatus: foundTask.status,
+          fromStatus: transitionFromStatus,
           toStatus: updatedTask.status,
           projectPath: ctx.rootDir,
         });
@@ -2071,12 +2075,10 @@ Examples:
 
         const note = createNote(message, options.author, options.supersedes);
 
-        const updatedTask: Task = {
-          ...foundTask,
-          notes: [...foundTask.notes, note],
-        };
-
-        await saveTask(ctx, updatedTask);
+        const updatedTask = await mutateTaskAtomically(ctx, foundTask, (latestTask) => ({
+          ...latestTask,
+          notes: [...latestTask.notes, note],
+        }));
         await commitIfShadow(
           ctx.shadow,
           "task-note",

--- a/src/parser/yaml.ts
+++ b/src/parser/yaml.ts
@@ -747,6 +747,74 @@ export async function saveTask(
 }
 
 /**
+ * Atomically mutate a task using the latest on-disk state.
+ *
+ * The callback receives the current task value while holding the task file lock,
+ * so concurrent writers cannot clobber unrelated fields (for example status vs notes).
+ */
+export async function mutateTaskAtomically(
+  ctx: KspecContext,
+  task: LoadedTask,
+  mutate: (latestTask: LoadedTask) => Task | LoadedTask | Promise<Task | LoadedTask>,
+): Promise<LoadedTask> {
+  const taskFilePath = task._sourceFile || getDefaultTaskFilePath(ctx);
+  let updatedTask: LoadedTask | undefined;
+
+  await withFileLock(taskFilePath, async () => {
+    // Ensure directory exists (important for default path in new repos)
+    const dir = path.dirname(taskFilePath);
+    await fs.mkdir(dir, { recursive: true });
+
+    // Preserve existing file format (tasks wrapper vs plain array)
+    let existingRaw: unknown = null;
+    let useTasksWrapper = false;
+    try {
+      existingRaw = await readYamlFile<unknown>(taskFilePath);
+      if (
+        existingRaw &&
+        typeof existingRaw === "object" &&
+        "tasks" in existingRaw
+      ) {
+        useTasksWrapper = true;
+      }
+    } catch {
+      throw new Error(`Task file not found: ${taskFilePath}`);
+    }
+
+    const fileTasks = await loadTasksFromFile(taskFilePath);
+    const taskIndex = fileTasks.findIndex((t) => t._ulid === task._ulid);
+    if (taskIndex === -1) {
+      throw new Error(`Task not found in file: ${task._ulid}`);
+    }
+
+    const latestTask = fileTasks[taskIndex];
+    const mutatedTask = await mutate(latestTask);
+    const cleanMutatedTask = stripRuntimeMetadata(mutatedTask as LoadedTask);
+
+    const serializedTasks = fileTasks.map((fileTask, index) =>
+      index === taskIndex ? cleanMutatedTask : stripRuntimeMetadata(fileTask),
+    );
+
+    if (useTasksWrapper) {
+      await writeYamlFilePreserveFormat(taskFilePath, { tasks: serializedTasks });
+    } else {
+      await writeYamlFilePreserveFormat(taskFilePath, serializedTasks);
+    }
+
+    updatedTask = {
+      ...cleanMutatedTask,
+      _sourceFile: taskFilePath,
+    };
+  });
+
+  if (!updatedTask) {
+    throw new Error(`Failed to mutate task atomically: ${task._ulid}`);
+  }
+
+  return updatedTask;
+}
+
+/**
  * Delete a task from its source file.
  * Requires _sourceFile to know which file to modify.
  */

--- a/tests/task-mutation-serialization.test.ts
+++ b/tests/task-mutation-serialization.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  createNote,
+  initContext,
+  loadAllTasks,
+  mutateTaskAtomically,
+} from '../src/parser/index.js';
+import { cleanupTempDir, setupTempFixtures } from './helpers/cli.js';
+
+describe('Task Mutation Serialization', () => {
+  let tempDir: string;
+
+  afterEach(async () => {
+    if (tempDir) {
+      await cleanupTempDir(tempDir);
+    }
+  });
+
+  it('preserves status transition when concurrent note mutation runs on the same task', async () => {
+    // AC: @agent-invocation-lifecycle ac-5 - runtime failure notes must not clobber concurrent task state transitions.
+    tempDir = await setupTempFixtures();
+    const ctx = await initContext(tempDir);
+    const tasks = await loadAllTasks(ctx);
+    const target = tasks.find((task) => task.slugs.includes('test-task-pending'));
+
+    expect(target).toBeDefined();
+
+    const failNote = createNote('[AGENT-FAIL] simulated failure', '@test');
+
+    await Promise.all([
+      mutateTaskAtomically(ctx, target!, async (latestTask) => {
+        // Delay increases overlap pressure so both mutators race for the same file lock.
+        await new Promise((resolve) => setTimeout(resolve, 25));
+        return {
+          ...latestTask,
+          status: 'in_progress',
+          started_at: '2026-03-03T00:00:00.000Z',
+        };
+      }),
+      mutateTaskAtomically(ctx, target!, (latestTask) => ({
+        ...latestTask,
+        notes: [...latestTask.notes, failNote],
+      })),
+    ]);
+
+    const refreshed = (await loadAllTasks(ctx)).find((task) => task._ulid === target!._ulid);
+    expect(refreshed?.status).toBe('in_progress');
+    expect(refreshed?.notes.some((note) => note.content === failNote.content)).toBe(true);
+  });
+
+  it('keeps both notes when concurrent note appends target the same task', async () => {
+    tempDir = await setupTempFixtures();
+    const ctx = await initContext(tempDir);
+    const tasks = await loadAllTasks(ctx);
+    const target = tasks.find((task) => task.slugs.includes('test-task-pending'));
+
+    expect(target).toBeDefined();
+
+    const noteA = createNote('first concurrent note', '@test');
+    const noteB = createNote('second concurrent note', '@test');
+
+    await Promise.all([
+      mutateTaskAtomically(ctx, target!, async (latestTask) => {
+        await new Promise((resolve) => setTimeout(resolve, 15));
+        return {
+          ...latestTask,
+          notes: [...latestTask.notes, noteA],
+        };
+      }),
+      mutateTaskAtomically(ctx, target!, (latestTask) => ({
+        ...latestTask,
+        notes: [...latestTask.notes, noteB],
+      })),
+    ]);
+
+    const refreshed = (await loadAllTasks(ctx)).find((task) => task._ulid === target!._ulid);
+    const contents = refreshed?.notes.map((note) => note.content) ?? [];
+
+    expect(contents).toContain(noteA.content);
+    expect(contents).toContain(noteB.content);
+  });
+});


### PR DESCRIPTION
## Summary
- add `mutateTaskAtomically()` to run same-task mutations against latest on-disk state under one file lock
- migrate `kspec task start` and `kspec task note` to atomic mutation to prevent status/note lost updates under concurrent writes
- add regression tests for concurrent status+note and note+note mutation races
- investigate broader write-path impact and create follow-up tasks:
  - @task-migrate-task-mutators-atomic
  - @task-atomic-plan-inbox-writes
  - @task-harden-spec-item-save-concurrency
  - @task-concurrent-mutation-regression-suite

## Test plan
- [x] `npx vitest run tests/task-mutation-serialization.test.ts tests/agent-invocation-lifecycle.test.ts`
- [x] `npx vitest run tests/task-budget-enforcement.test.ts tests/session-scoped-task-claiming.test.ts tests/note-supersession-filter.test.ts tests/task-needs-work.test.ts`
- [x] `npm test`
- [ ] `kspec validate` *(currently fails due pre-existing repo validation issues unrelated to this change)*

Task: @task-agent-task-mutation-serialization
Spec: @agent-invocation-lifecycle
