### PR TITLE
Add atomic update helpers for plan and inbox writes

### DIFF
--- a/src/cli/commands/inbox.ts
+++ b/src/cli/commands/inbox.ts
@@ -13,6 +13,7 @@ import {
   loadAllItems,
   loadAllTasks,
   loadInboxItems,
+  mutateInboxItemAtomically,
   ReferenceIndex,
   saveInboxItem,
   saveTask,
@@ -388,29 +389,21 @@ Examples:
         const items = await loadInboxItems(ctx);
         const item = resolveInboxRef(ref, items);
         const itemRef = shortInboxRef(item, items);
+        const newTags = options.tag ? parseTagsArray(options.tag) : [];
 
         // Track what was updated
         const updates: string[] = [];
 
         // AC: @inbox-set ac-1 - Update content if provided
         if (options.content !== undefined) {
-          item.text = options.content;
           updates.push("content");
         }
 
         // AC: @inbox-set ac-2 - Update tags if provided
         if (options.clearTags) {
-          item.tags = [];
           updates.push("cleared tags");
         }
-        if (options.tag) {
-          const newTags = parseTagsArray(options.tag);
-          // Append new tags, avoiding duplicates
-          for (const tag of newTags) {
-            if (!item.tags.includes(tag)) {
-              item.tags.push(tag);
-            }
-          }
+        if (newTags.length > 0) {
           updates.push("tags");
         }
 
@@ -419,15 +412,42 @@ Examples:
           return;
         }
 
-        await saveInboxItem(ctx, item);
+        const updatedItem = await mutateInboxItemAtomically(
+          ctx,
+          item,
+          (latestItem) => {
+            const nextItem: LoadedInboxItem = {
+              ...latestItem,
+              tags: [...latestItem.tags],
+            };
+
+            if (options.content !== undefined) {
+              nextItem.text = options.content;
+            }
+
+            if (options.clearTags) {
+              nextItem.tags = [];
+            }
+
+            // Append new tags, avoiding duplicates
+            for (const tag of newTags) {
+              if (!nextItem.tags.includes(tag)) {
+                nextItem.tags.push(tag);
+              }
+            }
+
+            return nextItem;
+          },
+        );
+
         await commitIfShadow(
           ctx.shadow,
           "inbox-set",
-          item._ulid.slice(0, 8),
+          updatedItem._ulid.slice(0, 8),
           updates.join(", "),
         );
 
-        success(`Updated inbox item: ${itemRef}`, { item });
+        success(`Updated inbox item: ${itemRef}`, { item: updatedItem });
       } catch (err) {
         error(errors.failures.updateInboxItem, err);
         process.exit(EXIT_CODES.ERROR);
@@ -454,12 +474,22 @@ Examples:
 
         // Append note with separator
         const separator = "\n\n---\n\n";
-        item.text = item.text + separator + text;
+        const updatedItem = await mutateInboxItemAtomically(
+          ctx,
+          item,
+          (latestItem) => ({
+            ...latestItem,
+            text: latestItem.text + separator + text,
+          }),
+        );
 
-        await saveInboxItem(ctx, item);
-        await commitIfShadow(ctx.shadow, "inbox-note", item._ulid.slice(0, 8));
+        await commitIfShadow(
+          ctx.shadow,
+          "inbox-note",
+          updatedItem._ulid.slice(0, 8),
+        );
 
-        success(`Added note to inbox item: ${itemRef}`, { item });
+        success(`Added note to inbox item: ${itemRef}`, { item: updatedItem });
       } catch (err) {
         error(errors.failures.addInboxNote, err);
         process.exit(EXIT_CODES.ERROR);

--- a/src/cli/commands/plan.ts
+++ b/src/cli/commands/plan.ts
@@ -18,6 +18,7 @@ import {
   type LoadedPlan,
   loadAllTasks,
   loadPlans,
+  mutatePlanAtomically,
   savePlan,
   saveTask,
   shortestUniqueUlid,
@@ -275,33 +276,9 @@ Examples:
         const plans = await loadPlans(ctx);
         const foundPlan = resolvePlanRef(ref, plans);
         const foundPlanRef = shortPlanRef(foundPlan, plans);
-
-        // AC: @plan-crud ac-4 - prevent transitions from terminal states
-        if (
-          options.status &&
-          (foundPlan.status === "completed" || foundPlan.status === "rejected")
-        ) {
-          error("Cannot transition from terminal status");
-          process.exit(EXIT_CODES.CONFLICT);
-        }
+        const terminalTransitionError = "__PLAN_TERMINAL_STATUS_TRANSITION__";
 
         const changes: string[] = [];
-
-        if (options.title) {
-          foundPlan.title = options.title;
-          changes.push("title");
-        }
-
-        if (options.status) {
-          const oldStatus = foundPlan.status;
-          foundPlan.status = options.status;
-          changes.push(`status: ${oldStatus} → ${options.status}`);
-
-          // AC: @plan-crud ac-3 - set approved_at timestamp when transitioning to approved
-          if (options.status === "approved" && !foundPlan.approved_at) {
-            foundPlan.approved_at = new Date().toISOString();
-          }
-        }
 
         if (options.slug) {
           if (!foundPlan.slugs.includes(options.slug)) {
@@ -311,9 +288,66 @@ Examples:
               error(`Slug "${options.slug}" collides with existing item. Use a different slug.`);
               process.exit(EXIT_CODES.CONFLICT);
             }
-            foundPlan.slugs.push(options.slug);
-            changes.push(`slug: +${options.slug}`);
           }
+        }
+
+        if (!options.title && !options.status && !options.slug) {
+          info("No changes specified");
+          return;
+        }
+
+        let updatedPlan: LoadedPlan;
+        try {
+          updatedPlan = await mutatePlanAtomically(ctx, foundPlan, (latestPlan) => {
+            // AC: @plan-crud ac-4 - prevent transitions from terminal states
+            if (
+              options.status &&
+              (latestPlan.status === "completed" ||
+                latestPlan.status === "rejected")
+            ) {
+              throw new Error(terminalTransitionError);
+            }
+
+            const nextPlan: LoadedPlan = {
+              ...latestPlan,
+              slugs: [...latestPlan.slugs],
+              derived_tasks: [...latestPlan.derived_tasks],
+              derived_specs: [...latestPlan.derived_specs],
+              notes: [...latestPlan.notes],
+            };
+
+            if (options.title) {
+              nextPlan.title = options.title;
+              changes.push("title");
+            }
+
+            if (options.status) {
+              const oldStatus = latestPlan.status;
+              nextPlan.status = options.status;
+              changes.push(`status: ${oldStatus} → ${options.status}`);
+
+              // AC: @plan-crud ac-3 - set approved_at timestamp when transitioning to approved
+              if (options.status === "approved" && !nextPlan.approved_at) {
+                nextPlan.approved_at = new Date().toISOString();
+              }
+            }
+
+            if (options.slug && !nextPlan.slugs.includes(options.slug)) {
+              nextPlan.slugs.push(options.slug);
+              changes.push(`slug: +${options.slug}`);
+            }
+
+            return nextPlan;
+          });
+        } catch (err) {
+          if (
+            err instanceof Error &&
+            err.message === terminalTransitionError
+          ) {
+            error("Cannot transition from terminal status");
+            process.exit(EXIT_CODES.CONFLICT);
+          }
+          throw err;
         }
 
         if (changes.length === 0) {
@@ -321,17 +355,16 @@ Examples:
           return;
         }
 
-        await savePlan(ctx, foundPlan);
         await commitIfShadow(
           ctx.shadow,
           "plan-set",
-          foundPlan.slugs[0] || foundPlan._ulid.slice(0, 8),
+          updatedPlan.slugs[0] || updatedPlan._ulid.slice(0, 8),
           changes.join(", "),
         );
 
         success(`Updated plan: ${foundPlanRef}`, {
           changes,
-          plan: foundPlan,
+          plan: updatedPlan,
         });
       } catch (err) {
         error(errors.failures.updatePlan, err);
@@ -418,12 +451,19 @@ Examples:
           content: text,
         };
 
-        foundPlan.notes.push(note);
-        await savePlan(ctx, foundPlan);
+        const updatedPlan = await mutatePlanAtomically(
+          ctx,
+          foundPlan,
+          (latestPlan) => ({
+            ...latestPlan,
+            notes: [...latestPlan.notes, note],
+          }),
+        );
+
         await commitIfShadow(
           ctx.shadow,
           "plan-note",
-          foundPlan.slugs[0] || foundPlan._ulid.slice(0, 8),
+          updatedPlan.slugs[0] || updatedPlan._ulid.slice(0, 8),
         );
 
         success(`Added note to plan: ${foundPlanRef}`, {
@@ -521,27 +561,41 @@ Examples:
 
         // AC: @plan-derive ac-5 - update plan's derived_tasks array
         const taskRef = `@${taskSlug}`;
-        if (!foundPlan.derived_tasks.includes(taskRef)) {
-          foundPlan.derived_tasks.push(taskRef);
-        }
+        const updatedPlan = await mutatePlanAtomically(
+          ctx,
+          foundPlan,
+          (latestPlan) => {
+            const nextPlan: LoadedPlan = {
+              ...latestPlan,
+              slugs: [...latestPlan.slugs],
+              derived_tasks: [...latestPlan.derived_tasks],
+              derived_specs: [...latestPlan.derived_specs],
+              notes: [...latestPlan.notes],
+            };
 
-        // AC: @plan-derive ac-5 - transition plan to active if not already
-        if (foundPlan.status === "approved") {
-          foundPlan.status = "active";
-        }
+            if (!nextPlan.derived_tasks.includes(taskRef)) {
+              nextPlan.derived_tasks.push(taskRef);
+            }
 
-        await savePlan(ctx, foundPlan);
+            // AC: @plan-derive ac-5 - transition plan to active if not already
+            if (nextPlan.status === "approved") {
+              nextPlan.status = "active";
+            }
+
+            return nextPlan;
+          },
+        );
 
         await commitIfShadow(
           ctx.shadow,
           "plan-derive",
-          foundPlan.slugs[0] || foundPlan._ulid.slice(0, 8),
+          updatedPlan.slugs[0] || updatedPlan._ulid.slice(0, 8),
           taskTitle,
         );
 
         success(`Created task from plan: ${taskRef}`, {
           task: newTask,
-          plan: foundPlan,
+          plan: updatedPlan,
         });
       } catch (err) {
         error("Failed to derive task from plan", err);

--- a/src/parser/plans.ts
+++ b/src/parser/plans.ts
@@ -41,6 +41,51 @@ export function getPlansFilePath(ctx: KspecContext): string {
 }
 
 /**
+ * Parse plans from raw YAML payload.
+ *
+ * Supports the canonical { kynetic_plans, plans } shape and a fallback
+ * { plans } shape for older files without version metadata.
+ */
+function parsePlansFromRaw(raw: unknown): Plan[] {
+  const parsed = PlansFileSchema.safeParse(raw);
+  if (parsed.success) {
+    return parsed.data.plans;
+  }
+
+  if (raw && typeof raw === "object" && "plans" in raw) {
+    const fallbackPlans = (raw as { plans?: unknown }).plans;
+    if (Array.isArray(fallbackPlans)) {
+      const plans: Plan[] = [];
+      for (const plan of fallbackPlans) {
+        const planResult = PlanSchema.safeParse(plan);
+        if (planResult.success) {
+          plans.push(planResult.data);
+        }
+      }
+      return plans;
+    }
+  }
+
+  return [];
+}
+
+/**
+ * Load plans from an explicit file path.
+ */
+async function loadPlansFromFile(plansPath: string): Promise<Plan[]> {
+  const raw = await readYamlFile<unknown>(plansPath);
+  return parsePlansFromRaw(raw);
+}
+
+/**
+ * Strip runtime metadata before serialization.
+ */
+function stripPlanMetadata(plan: Plan | LoadedPlan): Plan {
+  const { _sourceFile, ...cleanPlan } = plan as LoadedPlan;
+  return cleanPlan as Plan;
+}
+
+/**
  * Load all plans from the project.
  * AC: @plan-crud ac-7, ac-31 - listing plans
  */
@@ -48,16 +93,8 @@ export async function loadPlans(ctx: KspecContext): Promise<LoadedPlan[]> {
   const plansPath = getPlansFilePath(ctx);
 
   try {
-    const raw = await readYamlFile<unknown>(plansPath);
-
-    // Validate and parse plans file
-    const parsed = PlansFileSchema.safeParse(raw);
-    if (!parsed.success) {
-      return [];
-    }
-
-    // Add source file metadata to each plan
-    return parsed.data.plans.map((plan) => ({
+    const plans = await loadPlansFromFile(plansPath);
+    return plans.map((plan) => ({
       ...plan,
       _sourceFile: plansPath,
     }));
@@ -130,27 +167,90 @@ export async function savePlan(
     await fs.mkdir(dir, { recursive: true });
 
     // Load existing plans (inside lock to prevent TOCTOU)
-    const plans = await loadPlans(ctx);
+    let plans: Plan[] = [];
+    try {
+      plans = await loadPlansFromFile(plansPath);
+    } catch {
+      // File doesn't exist yet, start fresh
+    }
 
-    // Strip runtime metadata before saving
-    const { _sourceFile, ...cleanPlan } = plan;
+    const cleanPlan = stripPlanMetadata(plan);
 
     // Update or add
     const existingIndex = plans.findIndex((p) => p._ulid === plan._ulid);
     if (existingIndex >= 0) {
-      plans[existingIndex] = cleanPlan as Plan;
+      plans[existingIndex] = cleanPlan;
     } else {
-      plans.push(cleanPlan as Plan);
+      plans.push(cleanPlan);
     }
 
     // Save back to file
     const plansFile: PlansFile = {
       kynetic_plans: "1.0",
-      plans: plans.map(({ _sourceFile, ...p }) => p as Plan),
+      plans,
     };
 
     await writeYamlFilePreserveFormat(plansPath, plansFile);
   });
+}
+
+/**
+ * Atomically mutate a plan using the latest on-disk state.
+ *
+ * The callback receives the current plan value while holding the plan file lock,
+ * so concurrent writers do not clobber unrelated fields (for example status vs notes).
+ */
+export async function mutatePlanAtomically(
+  ctx: KspecContext,
+  plan: LoadedPlan,
+  mutate: (latestPlan: LoadedPlan) => Plan | LoadedPlan | Promise<Plan | LoadedPlan>,
+): Promise<LoadedPlan> {
+  const plansPath = plan._sourceFile || getPlansFilePath(ctx);
+  let updatedPlan: LoadedPlan | undefined;
+
+  await withFileLock(plansPath, async () => {
+    // Ensure directory exists (important for default path in new repos)
+    const dir = path.dirname(plansPath);
+    await fs.mkdir(dir, { recursive: true });
+
+    let plans: Plan[] = [];
+    try {
+      plans = await loadPlansFromFile(plansPath);
+    } catch {
+      throw new Error(`Plans file not found: ${plansPath}`);
+    }
+
+    const planIndex = plans.findIndex((candidate) => candidate._ulid === plan._ulid);
+    if (planIndex === -1) {
+      throw new Error(`Plan not found in file: ${plan._ulid}`);
+    }
+
+    const latestPlan: LoadedPlan = {
+      ...plans[planIndex],
+      _sourceFile: plansPath,
+    };
+
+    const mutatedPlan = await mutate(latestPlan);
+    const cleanMutatedPlan = stripPlanMetadata(mutatedPlan);
+    plans[planIndex] = cleanMutatedPlan;
+
+    const plansFile: PlansFile = {
+      kynetic_plans: "1.0",
+      plans,
+    };
+    await writeYamlFilePreserveFormat(plansPath, plansFile);
+
+    updatedPlan = {
+      ...cleanMutatedPlan,
+      _sourceFile: plansPath,
+    };
+  });
+
+  if (!updatedPlan) {
+    throw new Error(`Failed to mutate plan atomically: ${plan._ulid}`);
+  }
+
+  return updatedPlan;
 }
 
 /**
@@ -165,7 +265,7 @@ export async function deletePlan(
   // Lock the file to prevent concurrent read-modify-write races
   return withFileLock(plansPath, async () => {
     try {
-      const plans = await loadPlans(ctx);
+      const plans = await loadPlansFromFile(plansPath);
 
       // Find plan to delete
       const index = plans.findIndex((p) => p._ulid === planUlid);
@@ -179,7 +279,7 @@ export async function deletePlan(
       // Save back
       const plansFile: PlansFile = {
         kynetic_plans: "1.0",
-        plans: plans.map(({ _sourceFile, ...p }) => p as Plan),
+        plans,
       };
 
       await writeYamlFilePreserveFormat(plansPath, plansFile);

--- a/src/parser/yaml.ts
+++ b/src/parser/yaml.ts
@@ -1795,6 +1795,55 @@ export function getInboxFilePath(ctx: KspecContext): string {
 }
 
 /**
+ * Parse inbox items from raw YAML payload.
+ *
+ * Supports canonical { inbox: [...] } shape and legacy plain-array shape.
+ */
+function parseInboxItemsFromRaw(raw: unknown): InboxItem[] {
+  // Handle { inbox: [...] } format
+  if (raw && typeof raw === "object" && "inbox" in raw) {
+    const parsed = InboxFileSchema.safeParse(raw);
+    if (parsed.success) {
+      return parsed.data.inbox;
+    }
+
+    const fallbackItems = (raw as { inbox?: unknown }).inbox;
+    if (Array.isArray(fallbackItems)) {
+      const items: InboxItem[] = [];
+      for (const item of fallbackItems) {
+        const result = InboxItemSchema.safeParse(item);
+        if (result.success) {
+          items.push(result.data);
+        }
+      }
+      return items;
+    }
+  }
+
+  // Handle plain array format
+  if (Array.isArray(raw)) {
+    const items: InboxItem[] = [];
+    for (const item of raw) {
+      const result = InboxItemSchema.safeParse(item);
+      if (result.success) {
+        items.push(result.data);
+      }
+    }
+    return items;
+  }
+
+  return [];
+}
+
+/**
+ * Load inbox items from an explicit file path.
+ */
+async function loadInboxItemsFromFile(inboxPath: string): Promise<InboxItem[]> {
+  const raw = await readYamlFile<unknown>(inboxPath);
+  return parseInboxItemsFromRaw(raw);
+}
+
+/**
  * Load all inbox items from the project.
  */
 export async function loadInboxItems(
@@ -1803,32 +1852,11 @@ export async function loadInboxItems(
   const inboxPath = getInboxFilePath(ctx);
 
   try {
-    const raw = await readYamlFile<unknown>(inboxPath);
-
-    // Handle { inbox: [...] } format
-    if (raw && typeof raw === "object" && "inbox" in raw) {
-      const parsed = InboxFileSchema.safeParse(raw);
-      if (parsed.success) {
-        return parsed.data.inbox.map((item) => ({
-          ...item,
-          _sourceFile: inboxPath,
-        }));
-      }
-    }
-
-    // Handle plain array format
-    if (Array.isArray(raw)) {
-      const items: LoadedInboxItem[] = [];
-      for (const item of raw) {
-        const result = InboxItemSchema.safeParse(item);
-        if (result.success) {
-          items.push({ ...result.data, _sourceFile: inboxPath });
-        }
-      }
-      return items;
-    }
-
-    return [];
+    const items = await loadInboxItemsFromFile(inboxPath);
+    return items.map((item) => ({
+      ...item,
+      _sourceFile: inboxPath,
+    }));
   } catch {
     // File doesn't exist or parse error
     return [];
@@ -1859,8 +1887,8 @@ export function createInboxItem(
 /**
  * Strip runtime metadata before serialization.
  */
-function stripInboxMetadata(item: LoadedInboxItem): InboxItem {
-  const { _sourceFile, ...cleanItem } = item;
+function stripInboxMetadata(item: LoadedInboxItem | InboxItem): InboxItem {
+  const { _sourceFile, ...cleanItem } = item as LoadedInboxItem;
   return cleanItem as InboxItem;
 }
 
@@ -1883,20 +1911,7 @@ export async function saveInboxItem(
     let existingItems: InboxItem[] = [];
 
     try {
-      const raw = await readYamlFile<unknown>(inboxPath);
-      if (raw && typeof raw === "object" && "inbox" in raw) {
-        const parsed = InboxFileSchema.safeParse(raw);
-        if (parsed.success) {
-          existingItems = parsed.data.inbox;
-        }
-      } else if (Array.isArray(raw)) {
-        for (const i of raw) {
-          const result = InboxItemSchema.safeParse(i);
-          if (result.success) {
-            existingItems.push(result.data);
-          }
-        }
-      }
+      existingItems = await loadInboxItemsFromFile(inboxPath);
     } catch {
       // File doesn't exist, start fresh
     }
@@ -1919,6 +1934,65 @@ export async function saveInboxItem(
 }
 
 /**
+ * Atomically mutate an inbox item using the latest on-disk state.
+ *
+ * The callback receives the current item value while holding the inbox file lock,
+ * so concurrent writers do not clobber unrelated fields (for example text vs tags).
+ */
+export async function mutateInboxItemAtomically(
+  ctx: KspecContext,
+  item: LoadedInboxItem,
+  mutate: (
+    latestItem: LoadedInboxItem,
+  ) => InboxItem | LoadedInboxItem | Promise<InboxItem | LoadedInboxItem>,
+): Promise<LoadedInboxItem> {
+  const inboxPath = item._sourceFile || getInboxFilePath(ctx);
+  let updatedItem: LoadedInboxItem | undefined;
+
+  await withFileLock(inboxPath, async () => {
+    // Ensure directory exists (important for default path in new repos)
+    const dir = path.dirname(inboxPath);
+    await fs.mkdir(dir, { recursive: true });
+
+    let existingItems: InboxItem[] = [];
+    try {
+      existingItems = await loadInboxItemsFromFile(inboxPath);
+    } catch {
+      throw new Error(`Inbox file not found: ${inboxPath}`);
+    }
+
+    const itemIndex = existingItems.findIndex(
+      (existingItem) => existingItem._ulid === item._ulid,
+    );
+    if (itemIndex === -1) {
+      throw new Error(`Inbox item not found in file: ${item._ulid}`);
+    }
+
+    const latestItem: LoadedInboxItem = {
+      ...existingItems[itemIndex],
+      _sourceFile: inboxPath,
+    };
+
+    const mutatedItem = await mutate(latestItem);
+    const cleanMutatedItem = stripInboxMetadata(mutatedItem);
+    existingItems[itemIndex] = cleanMutatedItem;
+
+    await writeYamlFilePreserveFormat(inboxPath, { inbox: existingItems });
+
+    updatedItem = {
+      ...cleanMutatedItem,
+      _sourceFile: inboxPath,
+    };
+  });
+
+  if (!updatedItem) {
+    throw new Error(`Failed to mutate inbox item atomically: ${item._ulid}`);
+  }
+
+  return updatedItem;
+}
+
+/**
  * Delete an inbox item by ULID.
  */
 export async function deleteInboxItem(
@@ -1930,15 +2004,7 @@ export async function deleteInboxItem(
   // Lock the file to prevent concurrent read-modify-write races
   return withFileLock(inboxPath, async () => {
     try {
-      const raw = await readYamlFile<unknown>(inboxPath);
-      let existingItems: InboxItem[] = [];
-
-      if (raw && typeof raw === "object" && "inbox" in raw) {
-        const parsed = InboxFileSchema.safeParse(raw);
-        if (parsed.success) {
-          existingItems = parsed.data.inbox;
-        }
-      }
+      const existingItems = await loadInboxItemsFromFile(inboxPath);
 
       const index = existingItems.findIndex((i) => i._ulid === ulid);
       if (index < 0) {

--- a/tests/plan-inbox-mutation-serialization.test.ts
+++ b/tests/plan-inbox-mutation-serialization.test.ts
@@ -1,0 +1,127 @@
+import { spawn } from "node:child_process";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  initContext,
+  loadInboxItems,
+  loadPlans,
+  mutateInboxItemAtomically,
+  mutatePlanAtomically,
+} from "../src/parser/index.js";
+import {
+  cleanupTempDir,
+  CLI_PATH,
+  kspec,
+  setupTempFixtures,
+  testUlid,
+} from "./helpers/cli.js";
+
+function runKspecAsync(
+  args: string,
+  cwd: string,
+): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("/bin/sh", ["-c", `node ${CLI_PATH} ${args}`], {
+      cwd,
+      env: { ...process.env, KSPEC_AUTHOR: "@test" },
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.on("data", (data: Buffer) => {
+      stdout += data.toString("utf-8");
+    });
+    child.stderr.on("data", (data: Buffer) => {
+      stderr += data.toString("utf-8");
+    });
+    child.on("error", reject);
+    child.on("close", (exitCode) => {
+      resolve({
+        exitCode: exitCode ?? 1,
+        stdout: stdout.trim(),
+        stderr: stderr.trim(),
+      });
+    });
+  });
+}
+
+describe("Plan/Inbox Mutation Serialization", () => {
+  let tempDir: string;
+
+  afterEach(async () => {
+    if (tempDir) {
+      await cleanupTempDir(tempDir);
+    }
+  });
+
+  it("preserves concurrent plan notes during plan set updates", async () => {
+    // AC: @plan-crud ac-3 - plan set must not clobber concurrently appended notes.
+    tempDir = await setupTempFixtures();
+    kspec('plan add --title "Concurrent Plan" --content "base"', tempDir);
+
+    const ctx = await initContext(tempDir);
+    const plans = await loadPlans(ctx);
+    const target = plans.find((plan) => plan.title === "Concurrent Plan");
+    expect(target).toBeDefined();
+
+    const note = {
+      _ulid: testUlid("NOTE", 1),
+      created_at: "2026-03-03T00:00:00.000Z",
+      author: "@test",
+      content: "concurrent note during plan set",
+    };
+
+    const targetRef = target!.slugs[0] ? `@${target!.slugs[0]}` : `@${target!._ulid}`;
+
+    const [setResult] = await Promise.all([
+      runKspecAsync(`plan set ${targetRef} --status approved`, tempDir),
+      mutatePlanAtomically(ctx, target!, async (latestPlan) => {
+        await new Promise((resolve) => setTimeout(resolve, 15));
+        return {
+          ...latestPlan,
+          notes: [...latestPlan.notes, note],
+        };
+      }),
+    ]);
+
+    expect(setResult.exitCode).toBe(0);
+    const refreshed = (await loadPlans(ctx)).find((plan) => plan._ulid === target!._ulid);
+    expect(refreshed?.status).toBe("approved");
+    expect(refreshed?.notes.some((entry) => entry.content === note.content)).toBe(
+      true,
+    );
+  });
+
+  it("preserves concurrent inbox tag updates during inbox set --content", async () => {
+    // AC: @inbox-set ac-1 - content updates must not clobber concurrent tag changes.
+    tempDir = await setupTempFixtures();
+    kspec('inbox add "Concurrent inbox item"', tempDir);
+
+    const ctx = await initContext(tempDir);
+    const items = await loadInboxItems(ctx);
+    const target = items.find((item) => item.text === "Concurrent inbox item");
+    expect(target).toBeDefined();
+
+    const targetRef = `@${target!._ulid.slice(0, 8)}`;
+    const [setResult] = await Promise.all([
+      runKspecAsync(
+        `inbox set ${targetRef} --content "Updated inbox content"`,
+        tempDir,
+      ),
+      mutateInboxItemAtomically(ctx, target!, async (latestItem) => {
+        await new Promise((resolve) => setTimeout(resolve, 15));
+        return {
+          ...latestItem,
+          tags: [...latestItem.tags, "concurrent"],
+        };
+      }),
+    ]);
+
+    expect(setResult.exitCode).toBe(0);
+    const refreshed = (await loadInboxItems(ctx)).find(
+      (item) => item._ulid === target!._ulid,
+    );
+    expect(refreshed?.text).toBe("Updated inbox content");
+    expect(refreshed?.tags).toContain("concurrent");
+  });
+});


### PR DESCRIPTION
## Summary
- add `mutatePlanAtomically` and `mutateInboxItemAtomically` so writers mutate latest on-disk state under file lock
- migrate `plan set|note|derive` and `inbox set|note` to atomic update callbacks
- add concurrency regression tests for plan/inbox command mutation serialization

## Test plan
- [x] `npx vitest run tests/plan-inbox-mutation-serialization.test.ts tests/parser-plans.test.ts tests/integration.test.ts -t "Integration: inbox set --content|Integration: inbox note|Plan Parser|Plan/Inbox Mutation Serialization"`
- [x] `npm test`
- [x] `kspec validate` *(fails due pre-existing repo validation issues unrelated to this PR)*

Task: @task-atomic-plan-inbox-writes
