### PR TITLE
Harden spec item save/update path against stale full-object writes

### DIFF
--- a/src/parser/yaml.ts
+++ b/src/parser/yaml.ts
@@ -1430,6 +1430,18 @@ function stripSpecItemMetadata(item: LoadedSpecItem): SpecItem {
   return cleanItem as SpecItem;
 }
 
+function assertSpecItemPatch(
+  updates: Partial<SpecItemInput>,
+  operation: "updateSpecItem" | "saveSpecItem",
+): void {
+  const patch = updates as Record<string, unknown>;
+  if ("_sourceFile" in patch || "_path" in patch) {
+    throw new Error(
+      `${operation} expects a patch object, not a full LoadedSpecItem. Pass only intended fields to update.`,
+    );
+  }
+}
+
 /**
  * Parse a path string into segments.
  * e.g., "features[0].requirements[2]" -> [["features", 0], ["requirements", 2]]
@@ -1629,6 +1641,7 @@ export async function updateSpecItem(
   if (!item._sourceFile) {
     throw new Error("Item has no source file");
   }
+  assertSpecItemPatch(updates, "updateSpecItem");
 
   // Lock the file to prevent concurrent read-modify-write races
   return withFileLock(item._sourceFile, async () => {
@@ -1640,10 +1653,22 @@ export async function updateSpecItem(
 
     if (item._path) {
       const nav = navigateToPath(raw, item._path);
-      if (!nav) {
-        throw new Error(`Could not navigate to path: ${item._path}`);
+      const candidate = nav?.array[nav.index];
+      if (
+        candidate &&
+        typeof candidate === "object" &&
+        (candidate as Record<string, unknown>)._ulid === item._ulid
+      ) {
+        targetObj = candidate as Record<string, unknown>;
+      } else {
+        const found = findItemInStructure(raw, item._ulid);
+        if (!found) {
+          throw new Error(
+            `Could not find item ${item._ulid} in structure (path: ${item._path})`,
+          );
+        }
+        targetObj = found.item;
       }
-      targetObj = nav.array[nav.index] as Record<string, unknown>;
     } else {
       // Item might be the root, or we need to find it
       const found = findItemInStructure(raw, item._ulid);
@@ -1760,10 +1785,17 @@ export async function deleteSpecItem(
 export async function saveSpecItem(
   ctx: KspecContext,
   item: LoadedSpecItem,
+  updates: Partial<SpecItemInput>,
 ): Promise<void> {
+  assertSpecItemPatch(updates, "saveSpecItem");
+
+  if (Object.keys(updates).length === 0) {
+    throw new Error("Cannot save spec item without updates. Pass a patch.");
+  }
+
   // If item has a source file and path, it's an update
   if (item._sourceFile && item._path) {
-    await updateSpecItem(ctx, item, item);
+    await updateSpecItem(ctx, item, updates);
     return;
   }
 

--- a/tests/spec-item-mutation-serialization.test.ts
+++ b/tests/spec-item-mutation-serialization.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  initContext,
+  loadAllItems,
+  readYamlFile,
+  saveSpecItem,
+  updateSpecItem,
+  writeYamlFilePreserveFormat,
+  type LoadedSpecItem,
+} from "../src/parser/index.js";
+import {
+  cleanupTempDir,
+  setupTempFixtures,
+  testUlid,
+} from "./helpers/cli.js";
+
+function findItemBySlug(items: LoadedSpecItem[], slug: string): LoadedSpecItem {
+  const found = items.find((item) => item.slugs.includes(slug));
+  if (!found) {
+    throw new Error(`Missing fixture item: ${slug}`);
+  }
+  return found;
+}
+
+describe("Spec Item Mutation Serialization", () => {
+  let tempDir: string;
+
+  afterEach(async () => {
+    if (tempDir) {
+      await cleanupTempDir(tempDir);
+    }
+  });
+
+  it("falls back to ULID lookup when the stored _path is stale", async () => {
+    tempDir = await setupTempFixtures();
+    const ctx = await initContext(tempDir);
+    const target = findItemBySlug(await loadAllItems(ctx), "test-feature");
+
+    expect(target._path).toBe("features[0]");
+    expect(target._sourceFile).toBeDefined();
+
+    const raw = await readYamlFile<unknown>(target._sourceFile!);
+    const document = raw as { features?: unknown[] };
+    expect(Array.isArray(document.features)).toBe(true);
+
+    document.features!.unshift({
+      _ulid: testUlid("NEWFEAT", 1),
+      slugs: ["inserted-feature"],
+      title: "Inserted Feature",
+      type: "feature",
+      description: "inserted concurrently",
+      tags: [],
+      depends_on: [],
+      implements: [],
+      relates_to: [],
+      tests: [],
+      traits: [],
+      notes: [],
+    });
+    await writeYamlFilePreserveFormat(target._sourceFile!, raw);
+
+    await updateSpecItem(ctx, target, {
+      description: "updated through stale path safely",
+    });
+
+    const refreshedItems = await loadAllItems(ctx);
+    const refreshedTarget = findItemBySlug(refreshedItems, "test-feature");
+    const inserted = findItemBySlug(refreshedItems, "inserted-feature");
+
+    expect(refreshedTarget.description).toBe("updated through stale path safely");
+    expect(inserted.description).toBe("inserted concurrently");
+  });
+
+  it("saveSpecItem applies only patch fields and preserves concurrent edits", async () => {
+    tempDir = await setupTempFixtures();
+    const ctx = await initContext(tempDir);
+    const target = findItemBySlug(await loadAllItems(ctx), "test-feature");
+
+    const staleSnapshot: LoadedSpecItem = {
+      ...target,
+      tags: ["stale-tag"],
+      description: "stale description",
+    };
+
+    await updateSpecItem(ctx, target, {
+      tags: [...(target.tags || []), "concurrent-tag"],
+      description: "fresh concurrent description",
+    });
+
+    await saveSpecItem(ctx, staleSnapshot, {
+      title: "Patched Feature Title",
+    });
+
+    const refreshedTarget = findItemBySlug(await loadAllItems(ctx), "test-feature");
+    expect(refreshedTarget.title).toBe("Patched Feature Title");
+    expect(refreshedTarget.description).toBe("fresh concurrent description");
+    expect(refreshedTarget.tags).toContain("concurrent-tag");
+    expect(refreshedTarget.tags).not.toContain("stale-tag");
+  });
+
+  it("rejects full LoadedSpecItem payloads for updateSpecItem", async () => {
+    tempDir = await setupTempFixtures();
+    const ctx = await initContext(tempDir);
+    const target = findItemBySlug(await loadAllItems(ctx), "test-feature");
+
+    await expect(
+      updateSpecItem(ctx, target, {
+        ...(target as unknown as Record<string, unknown>),
+      }),
+    ).rejects.toThrow("patch object");
+  });
+
+  it("rejects empty saveSpecItem patches", async () => {
+    tempDir = await setupTempFixtures();
+    const ctx = await initContext(tempDir);
+    const target = findItemBySlug(await loadAllItems(ctx), "test-feature");
+
+    await expect(saveSpecItem(ctx, target, {})).rejects.toThrow(
+      "Cannot save spec item without updates",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- harden `updateSpecItem` so stale `_path` targets cannot update the wrong node; it now verifies ULID match and falls back to ULID lookup
- make `saveSpecItem` patch-only by requiring explicit updates and rejecting empty or LoadedSpecItem-style payloads
- add regression tests for stale path updates, stale snapshot overwrite prevention, and patch guardrails

## Test plan
- [x] `npm test`
- [x] `npm test -- tests/spec-item-mutation-serialization.test.ts`
- [x] `kspec validate` *(fails due pre-existing project-level schema/reference/alignment issues unrelated to this change)*

Task: @task-harden-spec-item-save-concurrency
