### PR TITLE
Rewrite skill reference tokens to adapter syntax in agent prompts

### DIFF
--- a/src/agent-runtime/invocation.ts
+++ b/src/agent-runtime/invocation.ts
@@ -219,6 +219,7 @@ export async function runInvocation(options: InvocationOptions): Promise<Invocat
     basePrompt: options.prompt,
     skillIds: agent.skills ?? [],
     specDir,
+    adapterId,
   });
 
   // Capture the pre-existing KSPEC_SESSION_ID so we can restore it in finally.

--- a/src/agent-runtime/prompts.ts
+++ b/src/agent-runtime/prompts.ts
@@ -33,6 +33,81 @@ export interface BuildPromptOptions {
   skillIds: string[];
   /** The .kspec directory for resolving skill content */
   specDir: string;
+  /** Adapter identifier used to format cross-skill references */
+  adapterId?: string;
+}
+
+const SKILL_REFERENCE_TOKEN_RE = /\{skill:([a-z0-9][a-z0-9-]*)\}/g;
+
+function getSkillReferenceFormat(adapterId?: string): "claude" | "codex" | "none" {
+  switch (adapterId) {
+    case "claude-agent-acp":
+    case "claude-code-acp":
+      return "claude";
+    case "codex-acp":
+      return "codex";
+    default:
+      return "none";
+  }
+}
+
+function getProjectRootFromSpecDir(specDir: string): string {
+  return path.basename(specDir) === ".kspec" ? path.dirname(specDir) : specDir;
+}
+
+async function loadKspecSkillIds(specDir: string): Promise<Set<string>> {
+  const projectRoot = getProjectRootFromSpecDir(specDir);
+  const skillsDir = path.join(projectRoot, ".agents", "skills");
+
+  try {
+    const entries = await fs.readdir(skillsDir, { withFileTypes: true });
+    const ids = new Set<string>();
+    for (const entry of entries) {
+      if (!entry.isDirectory()) {
+        continue;
+      }
+      if (!entry.name.startsWith("kspec-")) {
+        continue;
+      }
+      ids.add(entry.name.slice("kspec-".length));
+    }
+    return ids;
+  } catch {
+    return new Set<string>();
+  }
+}
+
+function formatSkillReference(
+  refId: string,
+  format: "claude" | "codex" | "none",
+  kspecSkillIds: Set<string>,
+): string {
+  if (format === "none") {
+    return `{skill:${refId}}`;
+  }
+
+  const isKspecSkill = kspecSkillIds.has(refId);
+  if (format === "claude") {
+    return isKspecSkill ? `/kspec:${refId}` : `/${refId}`;
+  }
+
+  return isKspecSkill ? `$kspec-${refId}` : `$${refId}`;
+}
+
+async function rewriteSkillReferences(
+  text: string,
+  specDir: string,
+  adapterId?: string,
+): Promise<string> {
+  const format = getSkillReferenceFormat(adapterId);
+  if (format === "none") {
+    return text;
+  }
+
+  const kspecSkillIds = await loadKspecSkillIds(specDir);
+  return text.replace(SKILL_REFERENCE_TOKEN_RE, (_match, refId: string) =>
+    formatSkillReference(refId, format, kspecSkillIds),
+  );
 }
 
 // ─── Skill Resolution ─────────────────────────────────────────────────────────
@@ -73,7 +148,12 @@ export async function resolveSkills(
  * AC: @agent-invocation-lifecycle ac-7
  */
 export async function buildPromptWithSkills(options: BuildPromptOptions): Promise<string> {
-  const { basePrompt, skillIds, specDir } = options;
+  const {
+    basePrompt,
+    skillIds,
+    specDir,
+    adapterId,
+  } = options;
 
   if (skillIds.length === 0) {
     return basePrompt;
@@ -89,5 +169,9 @@ export async function buildPromptWithSkills(options: BuildPromptOptions): Promis
     .map((skill) => `<!-- Skill: ${skill.id} -->\n${skill.content}`)
     .join("\n\n");
 
-  return `${basePrompt}\n\n## Skills\n\n${skillSections}`;
+  const promptWithSkills = `${basePrompt}\n\n## Skills\n\n${skillSections}`;
+
+  // AC: @agent-invocation-lifecycle ac-10
+  // Rewrite portable {skill:<id>} references to adapter-specific invocation syntax.
+  return rewriteSkillReferences(promptWithSkills, specDir, adapterId);
 }

--- a/src/cli/commands/agent.ts
+++ b/src/cli/commands/agent.ts
@@ -263,6 +263,7 @@ export function registerAgentCommands(program: Command): void {
           basePrompt,
           skillIds: agentDef.skills ?? [],
           specDir: ctx.specDir,
+          adapterId,
         });
 
         // AC: @trait-dry-run ac-1, ac-2, ac-3 - dry run shows prompt, no changes

--- a/tests/agent-invocation-lifecycle.test.ts
+++ b/tests/agent-invocation-lifecycle.test.ts
@@ -796,6 +796,65 @@ describe("Skill resolution for agent invocations", () => {
     expect(result).toContain("skill-a content");
     expect(result).toContain("skill-b content");
   });
+
+  // AC: @agent-invocation-lifecycle ac-10
+  it("buildPromptWithSkills should rewrite skill references for claude adapter", async () => {
+    const skillDir = path.join(testDir, "skills", "task-work");
+    await fs.mkdir(skillDir, { recursive: true });
+    await fs.writeFile(
+      path.join(skillDir, "SKILL.md"),
+      "# Task Work\n\nRun {skill:task-work} then {skill:pr}.",
+    );
+
+    await fs.mkdir(path.join(testDir, ".agents", "skills", "kspec-task-work"), { recursive: true });
+
+    const result = await buildPromptWithSkills({
+      basePrompt: "Base prompt",
+      skillIds: ["task-work"],
+      specDir: testDir,
+      adapterId: "claude-agent-acp",
+    });
+
+    expect(result).toContain("/kspec:task-work");
+    expect(result).toContain("/pr");
+    expect(result).not.toContain("{skill:task-work}");
+    expect(result).not.toContain("{skill:pr}");
+  });
+
+  // AC: @agent-invocation-lifecycle ac-10
+  it("buildPromptWithSkills should rewrite skill references for codex adapter", async () => {
+    const skillDir = path.join(testDir, "skills", "task-work");
+    await fs.mkdir(skillDir, { recursive: true });
+    await fs.writeFile(path.join(skillDir, "SKILL.md"), "# Task Work\n\nRun {skill:task-work}.");
+
+    await fs.mkdir(path.join(testDir, ".agents", "skills", "kspec-task-work"), { recursive: true });
+
+    const result = await buildPromptWithSkills({
+      basePrompt: "Base prompt",
+      skillIds: ["task-work"],
+      specDir: testDir,
+      adapterId: "codex-acp",
+    });
+
+    expect(result).toContain("$kspec-task-work");
+    expect(result).not.toContain("{skill:task-work}");
+  });
+
+  // AC: @agent-invocation-lifecycle ac-10
+  it("buildPromptWithSkills should leave skill references unchanged for unknown adapters", async () => {
+    const skillDir = path.join(testDir, "skills", "task-work");
+    await fs.mkdir(skillDir, { recursive: true });
+    await fs.writeFile(path.join(skillDir, "SKILL.md"), "# Task Work\n\nRun {skill:task-work}.");
+
+    const result = await buildPromptWithSkills({
+      basePrompt: "Base prompt",
+      skillIds: ["task-work"],
+      specDir: testDir,
+      adapterId: "mock-acp",
+    });
+
+    expect(result).toContain("{skill:task-work}");
+  });
 });
 
 // ─── AC-8: Cleanup on completion or failure ───────────────────────────────────


### PR DESCRIPTION
## Summary
- rewrite `{skill:...}` references in injected skill content based on adapter type during prompt construction
- map core `kspec-*` skills using `.agents/skills` naming so Claude emits `/kspec:<id>` and Codex emits `$kspec-<id>`
- pass adapter context through runtime invocation and CLI dry-run prompt preview
- add AC-10 tests for Claude, Codex, and unknown-adapter fallback behavior

## Test plan
- [x] `npm test -- tests/agent-invocation-lifecycle.test.ts`
- [x] `npm test`
- [ ] `kspec validate` (currently failing due pre-existing repo validation issues unrelated to this change)

Task: @01KJS90F
Spec: @agent-invocation-lifecycle
