### PR TITLE
Fix agent dispatch watch subscription handling for Node clients

### DIFF
--- a/packages/daemon/src/websocket/handler.ts
+++ b/packages/daemon/src/websocket/handler.ts
@@ -12,6 +12,49 @@ import type { ServerWebSocket } from 'bun';
 import type { WebSocketCommand, CommandAck, ConnectionData } from './types';
 import type { PubSubManager } from './pubsub';
 
+type WebSocketRawMessage =
+  | string
+  | Buffer
+  | ArrayBuffer
+  | ArrayBufferView
+  | Blob
+  | Record<string, unknown>;
+
+/**
+ * Decode inbound WebSocket payloads into UTF-8 text.
+ *
+ * Node/WebSocket clients may deliver command frames as Uint8Array/ArrayBuffer
+ * or Blob instead of plain strings.
+ */
+async function decodeWebSocketMessage(rawMessage: WebSocketRawMessage): Promise<string> {
+  if (typeof rawMessage === 'string') {
+    return rawMessage;
+  }
+
+  if (typeof rawMessage === 'object' && rawMessage !== null && !ArrayBuffer.isView(rawMessage)) {
+    if (rawMessage instanceof ArrayBuffer) {
+      return Buffer.from(rawMessage).toString('utf-8');
+    }
+
+    if (rawMessage instanceof Blob) {
+      return await rawMessage.text();
+    }
+
+    // Some runtimes already JSON-decode inbound websocket command payloads.
+    return JSON.stringify(rawMessage);
+  }
+
+  if (ArrayBuffer.isView(rawMessage)) {
+    return Buffer.from(
+      rawMessage.buffer,
+      rawMessage.byteOffset,
+      rawMessage.byteLength,
+    ).toString('utf-8');
+  }
+
+  return String(rawMessage);
+}
+
 export class WebSocketHandler {
   constructor(private pubsub: PubSubManager) {}
 
@@ -19,12 +62,22 @@ export class WebSocketHandler {
    * Handle incoming WebSocket command
    * AC: @api-contract ac-26, ac-27, ac-28, ac-30
    */
-  handleMessage(ws: ServerWebSocket<ConnectionData>, rawMessage: string | Buffer) {
+  handleMessage(
+    ws: ServerWebSocket<ConnectionData>,
+    rawMessage: WebSocketRawMessage,
+  ): Promise<void> {
+    return this.handleMessageInternal(ws, rawMessage);
+  }
+
+  private async handleMessageInternal(
+    ws: ServerWebSocket<ConnectionData>,
+    rawMessage: WebSocketRawMessage,
+  ): Promise<void> {
     let command: WebSocketCommand;
 
     try {
       // Parse command
-      const messageStr = typeof rawMessage === 'string' ? rawMessage : rawMessage.toString();
+      const messageStr = await decodeWebSocketMessage(rawMessage);
       command = JSON.parse(messageStr);
 
       // Validate command structure
@@ -76,11 +129,12 @@ export class WebSocketHandler {
       return;
     }
 
-    const success = this.pubsub.subscribe(ws.data.sessionId, topics);
+    const sessionId = this.resolveSessionId(ws);
+    const success = sessionId ? this.pubsub.subscribe(sessionId, topics) : false;
 
     if (success) {
       this.sendAck(ws, command.request_id, true);
-      console.log(`[ws] ${ws.data.sessionId} subscribed to: ${topics.join(', ')}`);
+      console.log(`[ws] ${sessionId} subscribed to: ${topics.join(', ')}`);
     } else {
       this.sendAck(ws, command.request_id, false, 'not_found', 'Session not found');
     }
@@ -97,11 +151,12 @@ export class WebSocketHandler {
       return;
     }
 
-    const success = this.pubsub.unsubscribe(ws.data.sessionId, topics);
+    const sessionId = this.resolveSessionId(ws);
+    const success = sessionId ? this.pubsub.unsubscribe(sessionId, topics) : false;
 
     if (success) {
       this.sendAck(ws, command.request_id, true);
-      console.log(`[ws] ${ws.data.sessionId} unsubscribed from: ${topics.join(', ')}`);
+      console.log(`[ws] ${sessionId} unsubscribed from: ${topics.join(', ')}`);
     } else {
       this.sendAck(ws, command.request_id, false, 'not_found', 'Session not found');
     }
@@ -112,6 +167,12 @@ export class WebSocketHandler {
    */
   private handlePing(ws: ServerWebSocket<ConnectionData>, command: WebSocketCommand) {
     this.sendAck(ws, command.request_id, true);
+  }
+
+  private resolveSessionId(ws: ServerWebSocket<ConnectionData>): string | undefined {
+    const data = ws.data as { id?: unknown } | undefined;
+    const contextId = typeof data?.id === 'string' ? data.id : undefined;
+    return this.pubsub.getSessionIdBySocket(ws, contextId);
   }
 
   /**

--- a/tests/daemon-websocket-handler.test.ts
+++ b/tests/daemon-websocket-handler.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { ServerWebSocket } from 'bun';
+import { PubSubManager } from '../packages/daemon/src/websocket/pubsub';
+import { WebSocketHandler } from '../packages/daemon/src/websocket/handler';
+import type { ConnectionData, CommandAck } from '../packages/daemon/src/websocket/types';
+
+function createMockWebSocket(sessionId: string): ServerWebSocket<ConnectionData> {
+  const data: ConnectionData = {
+    sessionId,
+    topics: new Set<string>(),
+    seq: 0,
+    lastPing: undefined,
+    lastPong: Date.now(),
+    projectPath: '/tmp/ws-handler-test',
+  };
+
+  return {
+    data,
+    send: vi.fn(),
+    close: vi.fn(),
+    ping: vi.fn(),
+    subscribe: vi.fn(),
+    unsubscribe: vi.fn(),
+    getBufferedAmount: vi.fn(() => 0),
+  } as unknown as ServerWebSocket<ConnectionData>;
+}
+
+describe('WebSocketHandler', () => {
+  // AC: @trait-websocket-protocol ac-2
+  it('accepts subscribe commands sent as Uint8Array payloads', async () => {
+    const pubsub = new PubSubManager();
+    const handler = new WebSocketHandler(pubsub);
+    const ws = createMockWebSocket('session-uint8');
+    pubsub.addConnection('session-uint8', ws);
+
+    const commandBytes = new TextEncoder().encode(JSON.stringify({
+      action: 'subscribe',
+      request_id: 'sub-uint8',
+      payload: { topics: ['agents'] },
+    }));
+
+    await handler.handleMessage(ws, commandBytes);
+
+    const sent = (ws.send as unknown as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[0];
+    const ack = JSON.parse(String(sent)) as CommandAck;
+
+    expect(ack.ack).toBe(true);
+    expect(ack.success).toBe(true);
+    expect(ack.request_id).toBe('sub-uint8');
+    expect(ws.data.topics.has('agents')).toBe(true);
+  });
+
+  // AC: @trait-websocket-protocol ac-2
+  it('accepts subscribe commands sent as ArrayBuffer payloads', async () => {
+    const pubsub = new PubSubManager();
+    const handler = new WebSocketHandler(pubsub);
+    const ws = createMockWebSocket('session-arraybuffer');
+    pubsub.addConnection('session-arraybuffer', ws);
+
+    const encoded = new TextEncoder().encode(JSON.stringify({
+      action: 'subscribe',
+      request_id: 'sub-arraybuffer',
+      payload: { topics: ['tasks:updates'] },
+    }));
+    const arrayBuffer = encoded.buffer.slice(
+      encoded.byteOffset,
+      encoded.byteOffset + encoded.byteLength,
+    );
+
+    await handler.handleMessage(ws, arrayBuffer);
+
+    const sent = (ws.send as unknown as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[0];
+    const ack = JSON.parse(String(sent)) as CommandAck;
+
+    expect(ack.ack).toBe(true);
+    expect(ack.success).toBe(true);
+    expect(ack.request_id).toBe('sub-arraybuffer');
+    expect(ws.data.topics.has('tasks:updates')).toBe(true);
+  });
+
+  // AC: @trait-websocket-protocol ac-2
+  it('accepts subscribe commands sent as Blob payloads', async () => {
+    const pubsub = new PubSubManager();
+    const handler = new WebSocketHandler(pubsub);
+    const ws = createMockWebSocket('session-blob');
+    pubsub.addConnection('session-blob', ws);
+
+    const blob = new Blob([JSON.stringify({
+      action: 'subscribe',
+      request_id: 'sub-blob',
+      payload: { topics: ['agents'] },
+    })], { type: 'application/json' });
+
+    await handler.handleMessage(ws, blob);
+
+    const sent = (ws.send as unknown as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[0];
+    const ack = JSON.parse(String(sent)) as CommandAck;
+
+    expect(ack.ack).toBe(true);
+    expect(ack.success).toBe(true);
+    expect(ack.request_id).toBe('sub-blob');
+    expect(ws.data.topics.has('agents')).toBe(true);
+  });
+
+  // AC: @trait-websocket-protocol ac-2
+  it('accepts subscribe commands when runtime already parsed JSON into an object', async () => {
+    const pubsub = new PubSubManager();
+    const handler = new WebSocketHandler(pubsub);
+    const ws = createMockWebSocket('session-object');
+    pubsub.addConnection('session-object', ws);
+
+    await handler.handleMessage(ws, {
+      action: 'subscribe',
+      request_id: 'sub-object',
+      payload: { topics: ['agents'] },
+    });
+
+    const sent = (ws.send as unknown as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[0];
+    const ack = JSON.parse(String(sent)) as CommandAck;
+
+    expect(ack.ack).toBe(true);
+    expect(ack.success).toBe(true);
+    expect(ack.request_id).toBe('sub-object');
+    expect(ws.data.topics.has('agents')).toBe(true);
+  });
+
+  // AC: @trait-websocket-protocol ac-2
+  it('subscribes successfully when message callback socket wrapper lacks sessionId', async () => {
+    const pubsub = new PubSubManager();
+    const handler = new WebSocketHandler(pubsub);
+    const registeredWs = createMockWebSocket('session-context');
+    pubsub.addConnection('session-context', registeredWs, 'ctx-subscribe');
+
+    const wrapperWs = {
+      data: {
+        id: 'ctx-subscribe',
+        topics: new Set<string>(),
+        seq: 0,
+        projectPath: '/tmp/ws-handler-test',
+      },
+      send: vi.fn(),
+      close: vi.fn(),
+      ping: vi.fn(),
+      subscriptions: [],
+    } as unknown as ServerWebSocket<ConnectionData>;
+
+    await handler.handleMessage(wrapperWs, {
+      action: 'subscribe',
+      request_id: 'sub-context',
+      payload: { topics: ['agents'] },
+    });
+
+    const sent = (wrapperWs.send as unknown as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[0];
+    const ack = JSON.parse(String(sent)) as CommandAck;
+
+    expect(ack.ack).toBe(true);
+    expect(ack.success).toBe(true);
+    expect(ack.request_id).toBe('sub-context');
+    expect(registeredWs.data.topics.has('agents')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- fix daemon websocket command decoding so subscribe/unsubscribe works for Node client payload variants (`Uint8Array`, `ArrayBuffer`, `Blob`, and pre-parsed object payloads)
- resolve websocket session IDs via pubsub socket/context mapping instead of relying on `ws.data.sessionId` in message callbacks
- add regression tests covering payload variants and wrapper-socket session resolution in `tests/daemon-websocket-handler.test.ts`

## Test plan
- [x] `npx vitest run tests/daemon-websocket-handler.test.ts`
- [x] `npx vitest run tests/cli-agent-commands.test.ts -t "AC-13: dispatch watch"`
- [x] `npm test`
- [x] manual repro: verified `kspec agent dispatch watch` streams `[agent-id session-id]` text chunks after subscription ack succeeds

Task: @01KJVCWC
Spec: @cli-agent-commands
