### PR TITLE
fix(batch): fail fast when batch stdin input is missing

### DIFF
--- a/src/cli/batch-exec.ts
+++ b/src/cli/batch-exec.ts
@@ -46,6 +46,8 @@ export type BatchInputSource =
   | { type: "file"; path: string }
   | { type: "inline"; json: string };
 
+const BATCH_STDIN_IDLE_TIMEOUT_MS = 1000;
+
 // ── Error Types ─────────────────────────────────────────────────────
 
 export class BatchParseError extends Error {
@@ -98,6 +100,59 @@ export interface ValidateBatchOptions {
 // ── Parsing ─────────────────────────────────────────────────────────
 
 /**
+ * Read stdin with an idle timeout so non-interactive callers that keep
+ * stdin open without writing do not block forever.
+ */
+async function readStdinWithIdleTimeout(timeoutMs: number): Promise<string> {
+  return new Promise((resolve) => {
+    let data = "";
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+
+    const cleanup = () => {
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+      process.stdin.removeListener("data", onData);
+      process.stdin.removeListener("end", onEnd);
+      process.stdin.removeListener("error", onError);
+    };
+
+    const armTimeout = () => {
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+      timeout = setTimeout(() => {
+        cleanup();
+        resolve(data);
+      }, timeoutMs);
+      timeout.unref?.();
+    };
+
+    const onData = (chunk: string) => {
+      data += chunk;
+      armTimeout();
+    };
+
+    const onEnd = () => {
+      cleanup();
+      resolve(data);
+    };
+
+    const onError = () => {
+      cleanup();
+      resolve(data);
+    };
+
+    process.stdin.setEncoding("utf8");
+    process.stdin.on("data", onData);
+    process.stdin.on("end", onEnd);
+    process.stdin.on("error", onError);
+    process.stdin.resume();
+    armTimeout();
+  });
+}
+
+/**
  * Read raw text from a batch input source.
  */
 async function readSource(source: BatchInputSource): Promise<string> {
@@ -115,13 +170,20 @@ async function readSource(source: BatchInputSource): Promise<string> {
       }
 
     case "stdin": {
-      const chunks: Buffer[] = [];
-      for await (const chunk of process.stdin) {
-        chunks.push(chunk as Buffer);
-      }
-      const text = Buffer.concat(chunks).toString("utf-8");
+      const text = process.stdin.isTTY
+        ? await (async () => {
+            const chunks: Buffer[] = [];
+            for await (const chunk of process.stdin) {
+              chunks.push(chunk as Buffer);
+            }
+            return Buffer.concat(chunks).toString("utf-8");
+          })()
+        : await readStdinWithIdleTimeout(BATCH_STDIN_IDLE_TIMEOUT_MS);
+
       if (!text.trim()) {
-        throw new BatchParseError("No input received on stdin");
+        throw new BatchParseError(
+          `No input received on stdin. Provide --commands <json>, --file <path>, or pipe JSON via stdin.`,
+        );
       }
       return text;
     }

--- a/tests/batch-exec-engine.test.ts
+++ b/tests/batch-exec-engine.test.ts
@@ -7,6 +7,7 @@
 
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { Command } from "commander";
+import { spawn } from "node:child_process";
 import {
   buildCommandArgv,
   resetCommandTree,
@@ -28,6 +29,7 @@ import {
   setupTempFixtures,
   cleanupTempDir,
   initGitRepo,
+  CLI_PATH,
 } from "./helpers/cli.js";
 import type { BatchExecResult, BatchCommandResult } from "../src/schema/batch.js";
 
@@ -496,6 +498,40 @@ describe("batch command integration", () => {
     expect(result.exitCode).toBe(1);
     expect(result.stderr).toContain("Invalid JSON");
     expect(result.stderr).not.toContain("No input received on stdin");
+  });
+
+  // AC: @batch-exec ac-stdin — fail fast when stdin pipe is open but empty
+  // AC: @trait-semantic-exit-codes ac-2 — missing input exits non-zero
+  it("fails fast when stdin is open but no input ever arrives", async () => {
+    const child = spawn(process.execPath, [CLI_PATH, "batch"], {
+      cwd: tempDir,
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, KSPEC_AUTHOR: "@test" },
+    });
+
+    let stderr = "";
+    child.stderr.on("data", (chunk: Buffer | string) => {
+      stderr += chunk.toString();
+    });
+
+    const exitResult = await Promise.race([
+      new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((resolve) => {
+        child.on("exit", (code, signal) => resolve({ code, signal }));
+      }),
+      new Promise<"timeout">((resolve) => {
+        setTimeout(() => resolve("timeout"), 3_000);
+      }),
+    ]);
+
+    if (exitResult === "timeout") {
+      child.kill("SIGKILL");
+      throw new Error("batch command hung waiting on stdin");
+    }
+
+    expect(exitResult.signal).toBeNull();
+    expect(exitResult.code).toBe(1);
+    expect(stderr).toContain("No input received on stdin");
+    expect(stderr).toContain("--commands <json>");
   });
 
   // AC: @batch-exec ac-invalid-json — JSON mode returns structured error


### PR DESCRIPTION
## Summary
- add bounded stdin idle-timeout handling for `kspec batch` non-TTY stdin reads
- return clear guidance when no batch input arrives (`--commands`, `--file`, or piped stdin)
- add regression test proving `batch` exits quickly when stdin pipe is open but empty

## Verification
- `npx tsc`
- `npx vitest run tests/batch-exec-engine.test.ts`
- `npx vitest run tests/batch-schema.test.ts tests/batch-commands.test.ts`

Task: @01KJS6ZW51AVVEKHSP2J0AWXHY
