### PR TITLE
feat(task): add --description support to task set

### DIFF
--- a/src/cli/commands/task.ts
+++ b/src/cli/commands/task.ts
@@ -375,6 +375,16 @@ async function setTaskFields(
         mutationChanges.push("title");
       }
 
+      if (options.description !== undefined) {
+        if (options.description === "null" || options.description.trim() === "") {
+          delete nextTask.description;
+          mutationChanges.push("description: cleared");
+        } else {
+          nextTask.description = options.description;
+          mutationChanges.push("description");
+        }
+      }
+
       if (options.specRef !== undefined) {
         if (options.specRef === "null") {
           nextTask.spec_ref = null;
@@ -890,6 +900,10 @@ Examples:
       "Update multiple tasks (AC: @spec-task-set-batch ac-1)",
     )
     .option("--title <title>", "Update task title")
+    .option(
+      "--description <description>",
+      "Update task description (use 'null' to clear)",
+    )
     .option("--spec-ref <ref>", "Link to spec item (use 'null' to clear)")
     .option(
       "--meta-ref <ref>",
@@ -919,6 +933,7 @@ Examples:
       `
 Examples:
   $ kspec task set @task-slug --priority 2
+  $ kspec task set @task-slug --description "Updated context"
   $ kspec task set @task-slug --depends-on @dep1 @dep2
   $ kspec task set @task-slug --tag cli urgent
   $ kspec task set --refs @task1 @task2 --priority 3`,

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -341,6 +341,36 @@ describe('Integration: task set', () => {
     expect(task.title).toBe('Updated Title');
   });
 
+  it('should update task description', () => {
+    const output = kspec('task set @test-task-pending --description "Updated description"', tempDir);
+    expect(output).toContain('Updated task');
+    expect(output).toContain('(description)');
+
+    const task = kspecJson<{ description?: string }>('task get @test-task-pending', tempDir);
+    expect(task.description).toBe('Updated description');
+  });
+
+  it('should clear description with null', () => {
+    kspec('task set @test-task-pending --description "Needs clearing"', tempDir);
+    const before = kspecJson<{ description?: string }>('task get @test-task-pending', tempDir);
+    expect(before.description).toBe('Needs clearing');
+
+    const output = kspec('task set @test-task-pending --description null', tempDir);
+    expect(output).toContain('description: cleared');
+
+    const after = kspecJson<{ description?: string }>('task get @test-task-pending', tempDir);
+    expect(after.description).toBeUndefined();
+  });
+
+  it('should clear description when whitespace-only value is provided', () => {
+    kspec('task set @test-task-pending --description "Needs clearing"', tempDir);
+    const output = kspec('task set @test-task-pending --description "   "', tempDir);
+    expect(output).toContain('description: cleared');
+
+    const task = kspecJson<{ description?: string }>('task get @test-task-pending', tempDir);
+    expect(task.description).toBeUndefined();
+  });
+
   // AC: @task-set ac-task-set-2
   it('should set spec_ref on task', () => {
     const output = kspec('task set @test-task-pending --spec-ref @test-feature', tempDir);

--- a/tests/task-set-batch.test.ts
+++ b/tests/task-set-batch.test.ts
@@ -50,6 +50,20 @@ describe('Integration: task set batch support', () => {
     expect(taskE.tags).toContain('urgent');
   });
 
+  it('should update descriptions in batch mode', () => {
+    kspec('task add --title "Batch Desc A" --slug batch-desc-a', tempDir);
+    kspec('task add --title "Batch Desc B" --slug batch-desc-b', tempDir);
+
+    const result = kspec('task set --refs @batch-desc-a @batch-desc-b --description "Shared description"', tempDir);
+    expect(result.stdout).toContain('Setd 2 of 2');
+
+    const taskA = kspecJson<{ description?: string }>('task get @batch-desc-a', tempDir);
+    const taskB = kspecJson<{ description?: string }>('task get @batch-desc-b', tempDir);
+
+    expect(taskA.description).toBe('Shared description');
+    expect(taskB.description).toBe('Shared description');
+  });
+
   // AC: @spec-task-set-batch ac-3
   it('should reject --status flag with error message', () => {
     kspec('task add --title "Status Test" --slug status-test', tempDir);


### PR DESCRIPTION
## Summary
- add `--description <description>` to `kspec task set` for single-ref and `--refs` batch mode
- support clearing via `--description null` and whitespace-only values
- add integration coverage for description update/clear behavior in both single and batch task-set flows

## Verification
- `npx vitest run tests/integration.test.ts tests/task-set-batch.test.ts`
- `npx vitest run tests/help-examples.test.ts`
- `kspec validate` *(fails due pre-existing repo-level meta/reference/alignment issues unrelated to this change)*

Task: @01KJS6ZXW9ADK2PQPQXEX43MF4
