### PR TITLE
fix(agent): harden dispatch autonomy and prompt timeout handling

### DIFF
--- a/src/agent-runtime/dispatch.ts
+++ b/src/agent-runtime/dispatch.ts
@@ -604,6 +604,44 @@ export class DispatchEngine {
   }
 
   /**
+   * Build dispatch-mode prompt guardrails to keep autonomous agents from
+   * stopping with handoff text instead of performing required actions.
+   */
+  private _buildDispatchPrompt(agent: LoadedAgent, change: TaskStateChange): string {
+    const trigger = (STATUS_TO_EVENT[change.toStatus] ?? "task.ready") as SessionTrigger;
+    const basePrompt = agent.prompt_template ?? `Work on task ${change.taskRef}`;
+    const taskRef = change.taskRef;
+
+    const autonomousPreamble = [
+      "AUTONOMOUS DISPATCH MODE (no interactive user is available).",
+      "- Do not ask for confirmation, approval, or next-step handoff.",
+      "- Execute required commands directly in this invocation.",
+      "- Do not end your turn with a recommendations-only summary. Perform the next required action yourself.",
+      "- Do not end your turn until the expected task transition is complete, or you have explicitly blocked the task with `kspec task block <task> --reason \"...\"`.",
+      "- If you find an open PR/branch from a different task, create or switch to a dedicated branch for this task before committing to avoid PR conflation.",
+    ];
+
+    const triggerSpecific =
+      trigger === "task.pending_review"
+        ? [
+            `Trigger context: ${trigger} for ${taskRef}.`,
+            `Review flow completion criteria for ${taskRef}:`,
+            "- Execute your configured review workflow directly (no handoff).",
+            `- If blocking issues are found, transition ${taskRef} out of pending_review appropriately (for example needs_work).`,
+            `- If review gates are clean, perform your workflow's completion actions directly in this invocation.`,
+          ]
+        : [
+            `Trigger context: ${trigger} for ${taskRef}.`,
+            `Work flow completion criteria for ${taskRef}:`,
+            "- Execute your configured work workflow directly (no handoff).",
+            `- Perform the required commands to move ${taskRef} to the next appropriate state in this same invocation.`,
+            "- If your workflow includes git or PR steps, execute them directly instead of deferring to a human.",
+          ];
+
+    return `${basePrompt}\n\n${autonomousPreamble.join("\n")}\n\n${triggerSpecific.join("\n")}`;
+  }
+
+  /**
    * Spawn a single invocation for a queue entry.
    * Returns true if an invocation was actually started, false if skipped.
    * AC: @agent-dispatch-engine ac-9, ac-10, ac-11, ac-12
@@ -685,7 +723,7 @@ export class DispatchEngine {
       specDir: this.specDir,
       cwd: this.cwd,
       taskRef: entry.change.taskRef,
-      prompt: agent.prompt_template ?? `Work on task ${entry.change.taskRef}`,
+      prompt: this._buildDispatchPrompt(agent, entry.change),
       trigger: (STATUS_TO_EVENT[entry.change.toStatus] ?? "task.ready") as SessionTrigger,
       kspecCliPath: this.kspecCliPath,
       abortSignal: abortController.signal,

--- a/src/agent-runtime/invocation.ts
+++ b/src/agent-runtime/invocation.ts
@@ -212,6 +212,9 @@ export async function runInvocation(options: InvocationOptions): Promise<Invocat
     agent.budget?.timeout_minutes ??
     30;
   const timeoutMs = timeoutMinutes * 60 * 1000;
+  // Keep ACP request timeout slightly above invocation timeout so the outer
+  // lifecycle controls timeout behavior (cancel + timeout note), not framing.
+  const promptRequestTimeoutMs = Math.max(1, Math.ceil(timeoutMs + 5_000));
 
   // Resolve skill content for prompt
   // AC: @agent-invocation-lifecycle ac-7
@@ -299,6 +302,11 @@ export async function runInvocation(options: InvocationOptions): Promise<Invocat
         KSPEC_SESSION_ID: sessionId,
       },
       extraArgs,
+      clientOptions: {
+        methodTimeouts: {
+          "session/prompt": promptRequestTimeoutMs,
+        },
+      },
     });
 
     // ─── Create ACP session ───────────────────────────────────────────────

--- a/tests/agent-dispatch-engine.test.ts
+++ b/tests/agent-dispatch-engine.test.ts
@@ -954,6 +954,101 @@ describe("Text chunk boundary signaling", () => {
   });
 });
 
+describe("Autonomous dispatch prompt guardrails", () => {
+  let testDir: string;
+
+  beforeEach(async () => {
+    testDir = await createTempDir("kspec-dispatch-prompt-");
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await cleanupTempDir(testDir);
+  });
+
+  it("should include worker completion guardrails for task.ready triggers", async () => {
+    const agent = makeTestAgent({ id: "worker", dispatch: [{ on: "task.ready" }] });
+    await setupProjectWithAgents(testDir, [agent]);
+
+    const runSpy = vi.spyOn(invocationModule, "runInvocation").mockResolvedValue({
+      session: {} as any,
+      outcome: "success",
+      durationMs: 1,
+    });
+
+    const engine = new DispatchEngine({
+      projectDir: testDir,
+      specDir: testDir,
+      kspecCliPath: MOCK_KSPEC_CLI,
+    });
+
+    await engine.start();
+    const taskId = testUlid("TASK");
+    await engine.handleStateChange({
+      taskId,
+      taskRef: `@${taskId}`,
+      fromStatus: "in_progress",
+      toStatus: "pending",
+      timestamp: Date.now(),
+    });
+
+    for (let i = 0; i < 20 && runSpy.mock.calls.length === 0; i++) {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+
+    expect(runSpy).toHaveBeenCalled();
+    const invocationOpts = runSpy.mock.calls[0][0];
+    expect(invocationOpts.prompt).toContain("AUTONOMOUS DISPATCH MODE");
+    expect(invocationOpts.prompt).toContain("Do not ask for confirmation");
+    expect(invocationOpts.prompt).toContain("Perform the required commands");
+    expect(invocationOpts.prompt).toContain("avoid PR conflation");
+
+    await engine.stop();
+  });
+
+  it("should include reviewer completion guardrails for task.pending_review triggers", async () => {
+    const reviewer = makeTestAgent({
+      id: "reviewer",
+      dispatch: [{ on: "task.pending_review" }],
+    });
+    await setupProjectWithAgents(testDir, [reviewer]);
+
+    const runSpy = vi.spyOn(invocationModule, "runInvocation").mockResolvedValue({
+      session: {} as any,
+      outcome: "success",
+      durationMs: 1,
+    });
+
+    const engine = new DispatchEngine({
+      projectDir: testDir,
+      specDir: testDir,
+      kspecCliPath: MOCK_KSPEC_CLI,
+    });
+
+    await engine.start();
+    const taskId = testUlid("TASK");
+    await engine.handleStateChange({
+      taskId,
+      taskRef: `@${taskId}`,
+      fromStatus: "in_progress",
+      toStatus: "pending_review",
+      timestamp: Date.now(),
+    });
+
+    for (let i = 0; i < 20 && runSpy.mock.calls.length === 0; i++) {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+
+    expect(runSpy).toHaveBeenCalled();
+    const invocationOpts = runSpy.mock.calls[0][0];
+    expect(invocationOpts.prompt).toContain("AUTONOMOUS DISPATCH MODE");
+    expect(invocationOpts.prompt).toContain("Review flow completion criteria");
+    expect(invocationOpts.prompt).toContain("configured review workflow");
+
+    await engine.stop();
+  });
+});
+
 // ─── AC-9: Retry with exponential backoff ─────────────────────────────────────
 
 // AC: @agent-dispatch-engine ac-9

--- a/tests/agent-invocation-lifecycle.test.ts
+++ b/tests/agent-invocation-lifecycle.test.ts
@@ -336,6 +336,52 @@ describe("Timeout handling", () => {
     // Verify cancel was called with the ACP session ID — cancel request dispatched on timeout
     expect(cancelCalledWith).toBeDefined();
   });
+
+  it("should set ACP session/prompt timeout above invocation timeout budget", async () => {
+    const agent = makeTestAgent({ adapter: "slow-mock-acp" });
+    const mockSessionId = "mock-acp-session";
+    const emitter = new EventEmitter();
+    const timeoutMinutes = 12;
+
+    const spawnedAgent = {
+      client: {
+        on: (event: string, handler: (...args: unknown[]) => void) => {
+          emitter.on(event, handler);
+        },
+        newSession: vi.fn(async () => mockSessionId),
+        prompt: vi.fn(async () => ({ stopReason: "end_turn" })),
+        cancel: vi.fn(async () => undefined),
+        endSession: vi.fn(async () => undefined),
+        respondPermission: vi.fn(async () => undefined),
+      },
+      kill: vi.fn(() => undefined),
+    };
+
+    const spawnSpy = vi.spyOn(spawnerModule, "spawnAndInitialize").mockResolvedValue(
+      spawnedAgent as unknown as Awaited<ReturnType<typeof spawnerModule.spawnAndInitialize>>,
+    );
+    let spawnOptions: Parameters<typeof spawnerModule.spawnAndInitialize>[1] | undefined;
+
+    try {
+      await runInvocation({
+        agent,
+        specDir: testDir,
+        cwd: process.cwd(),
+        taskRef: "@" + testUlid("TASK"),
+        prompt: "Test ACP prompt timeout alignment",
+        trigger: "task.ready",
+        timeoutMinutes,
+      });
+      spawnOptions = spawnSpy.mock.calls[0]?.[1];
+    } finally {
+      spawnSpy.mockRestore();
+    }
+
+    expect(spawnOptions).toBeDefined();
+    expect(spawnOptions.clientOptions?.methodTimeouts?.["session/prompt"]).toBe(
+      timeoutMinutes * 60 * 1000 + 5_000,
+    );
+  });
 });
 
 // ─── AC-4: Successful completion ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- align ACP `session/prompt` timeout to invocation timeout budget (+5s buffer) so invocation lifecycle controls cancellation/timeout behavior
- add workflow-agnostic autonomous dispatch guardrails to prevent recommendation-only handoffs in queued worker/reviewer runs
- retain explicit branch-isolation guidance to avoid cross-task branch/PR conflation
- add regression tests for timeout wiring and dispatch prompt guardrails

## Test plan
- [x] `npx vitest run tests/agent-dispatch-engine.test.ts tests/agent-invocation-lifecycle.test.ts`

## Context
This addresses dispatch regressions observed in recent sessions where:
- reviewer invocations timed out after 300000ms while waiting on CI
- worker invocations ended with “next steps” handoff text instead of executing required workflow actions
