### PR TITLE
fix(task-work): require per-task branch isolation before edits

### DIFF
--- a/templates/agents-sections/06-ralph-loop.md
+++ b/templates/agents-sections/06-ralph-loop.md
@@ -8,6 +8,7 @@ When running as an automated agent via the dispatch engine:
 for each dispatched invocation:
   1. Agent runtime checks eligible tasks — if none, invocation ends
   2. Agent works on tasks, may create PR(s)
+     - Before editing files on a selected task, create/switch to a dedicated task branch
   3. Agent stops responding (turn complete)
   4. pr-reviewer agent handles pending_review tasks via separate dispatch
   5. Continue

--- a/templates/skills/task-work/SKILL.md
+++ b/templates/skills/task-work/SKILL.md
@@ -97,6 +97,20 @@ kspec plan get @plan-ref
 kspec task start @ref
 ```
 
+### 3.5 Branch Isolation (Required Before Edits)
+
+Immediately after `kspec task start` and before any file edits, create or switch to a dedicated branch for that task. Do not keep implementing on a branch that is tied to another pending-review task.
+
+```bash
+# Example naming from task intent/slug
+TASK_BRANCH="fix/<task-slug>"
+
+# Create the branch if missing, otherwise switch to it
+git checkout -b "$TASK_BRANCH" 2>/dev/null || git checkout "$TASK_BRANCH"
+```
+
+This keeps each task's commits scoped to its own PR and prevents cross-task contamination.
+
 ### 4. Work and Note
 
 Read all ACs (own + trait) before implementing:
@@ -267,6 +281,7 @@ kspec tasks ready --eligible  # Only automation-eligible tasks
 ### Key Behaviors
 
 - Verify work is needed before starting (prevent duplicates)
+- Create/switch to a dedicated task branch before making code edits
 - Decisions auto-resolve without prompts
 - PR review handled externally (not this workflow)
 - All actions are logged and auditable


### PR DESCRIPTION
## Summary
- add explicit branch-isolation guidance to the task-work skill template: immediately after `kspec task start`, create/switch to a dedicated task branch before editing files
- add the same branch-isolation expectation to dispatch-loop agent guidance so loop workers avoid cross-task branch contamination
- intentionally keep Playwright install guidance out of this skill update (handled in agent-specific instructions)

## Validation
- [x] `npm --prefix /home/chapel/Projects/kynetic-spec run test -- tests/agents-instruction-gen.test.ts`
