### PR TITLE
fix(acp): handle EPIPE in JSON-RPC framing output path

### DIFF
--- a/src/acp/framing.ts
+++ b/src/acp/framing.ts
@@ -107,6 +107,7 @@ export class JsonRpcFraming extends EventEmitter {
     );
     this.stdin.on("end", () => this.handleEnd());
     this.stdin.on("error", (err) => this.handleError(err));
+    this.stdout.on("error", (err) => this.handleOutputError(err));
   }
 
   /**
@@ -269,11 +270,12 @@ export class JsonRpcFraming extends EventEmitter {
    * Send a JSON-RPC message
    */
   private send(message: JsonRpcMessage): void {
+    const json = JSON.stringify(message);
+
     try {
-      const json = JSON.stringify(message);
       this.stdout.write(`${json}\n`);
     } catch (err) {
-      console.error(`Error sending message: ${err}`);
+      this.handleOutputError(err);
     }
   }
 
@@ -412,6 +414,26 @@ export class JsonRpcFraming extends EventEmitter {
   private handleError(err: Error): void {
     console.error(`Stdin error: ${err.message}`);
     this.emit("error", err);
+    this.close();
+  }
+
+  /**
+   * Handle stdout write/pipe errors.
+   *
+   * EPIPE (or destroyed stream) means the peer is gone. Treat this as a
+   * closed connection instead of surfacing an uncaught exception.
+   */
+  private handleOutputError(err: unknown): void {
+    const error = err instanceof Error ? err : new Error(String(err));
+    const code = (error as NodeJS.ErrnoException).code;
+
+    if (code === "EPIPE" || code === "ERR_STREAM_DESTROYED") {
+      this.close();
+      return;
+    }
+
+    console.error(`Stdout error: ${error.message}`);
+    this.emit("error", error);
     this.close();
   }
 }

--- a/tests/acp.test.ts
+++ b/tests/acp.test.ts
@@ -340,6 +340,42 @@ describe('JsonRpcFraming', () => {
     await expect(requestPromise).rejects.toThrow('Subagent process exited with signal SIGKILL');
   });
 
+  it('should treat EPIPE write failures as connection closed', async () => {
+    const epipeError = new Error('broken pipe') as NodeJS.ErrnoException;
+    epipeError.code = 'EPIPE';
+
+    const brokenStdout = new PassThrough();
+    brokenStdout.write = (() => {
+      throw epipeError;
+    }) as typeof brokenStdout.write;
+
+    const epipeFraming = new JsonRpcFraming({
+      stdin,
+      stdout: brokenStdout,
+      timeout: 1000,
+    });
+
+    const requestPromise = epipeFraming.sendRequest('test/method');
+    await expect(requestPromise).rejects.toThrow('JsonRpcFraming closed');
+    expect(epipeFraming.isClosed()).toBe(true);
+  });
+
+  it('should suppress emitted EPIPE output errors as connection close', async () => {
+    const onError = vi.fn();
+    framing.on('error', onError);
+
+    const requestPromise = framing.sendRequest('test/method');
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    const epipeError = new Error('broken pipe') as NodeJS.ErrnoException;
+    epipeError.code = 'EPIPE';
+    stdout.emit('error', epipeError);
+
+    await expect(requestPromise).rejects.toThrow('JsonRpcFraming closed');
+    expect(framing.isClosed()).toBe(true);
+    expect(onError).not.toHaveBeenCalled();
+  });
+
   // AC: @acp-client ac-6
   it('should reset pending timers on incoming activity', async () => {
     // Create framing with short timeout

--- a/tests/ralph/adapter-auto-approve.test.ts
+++ b/tests/ralph/adapter-auto-approve.test.ts
@@ -6,7 +6,7 @@
  *
  * AC: @ralph-adapter-auto-approve
  */
-import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import * as path from "node:path";
 import * as fs from "node:fs/promises";
 import {
@@ -18,20 +18,6 @@ import { spawnAgent, type SpawnedAgent } from "../../src/agents/spawner.js";
 import { setupTempFixtures, cleanupTempDir } from "../helpers/cli";
 
 const MOCK_ACP = path.join(__dirname, "..", "mocks", "acp-mock.js");
-
-// Suppress EPIPE errors from ACP framing during test cleanup
-// The framing layer may try to write to a dead child process pipe during shutdown
-const originalListeners = process.listeners("uncaughtException");
-function epipeHandler(err: Error & { code?: string }) {
-  if (err.code === "EPIPE") return; // Suppress EPIPE during cleanup
-  throw err;
-}
-beforeAll(() => {
-  process.on("uncaughtException", epipeHandler);
-});
-afterAll(() => {
-  process.removeListener("uncaughtException", epipeHandler);
-});
 
 /**
  * Helper to cleanly shut down a spawned agent, waiting for process exit.


### PR DESCRIPTION
## Summary
- route JsonRpcFraming stdout failures through a dedicated output-error handler
- treat `EPIPE` and `ERR_STREAM_DESTROYED` as clean connection closure instead of uncaught errors
- add framing regression tests for both thrown and emitted EPIPE paths, and remove process-level EPIPE uncaughtException workaround from adapter tests

## Verification
- npx vitest run tests/acp.test.ts tests/ralph/adapter-auto-approve.test.ts
- npm test
- kspec validate *(currently fails due existing repo-wide meta/reference/alignment issues unrelated to this change)*

Task: @01KJS6ZP
