### PR TITLE
feat(batch): accept tags alias for tag in batch commands

### DIFF
--- a/src/cli/batch-exec.ts
+++ b/src/cli/batch-exec.ts
@@ -266,6 +266,19 @@ function normalizeArgKey(key: string): string {
 }
 
 /**
+ * Batch-only argument aliases for common plural forms.
+ * Keys and values are canonical kebab-case.
+ */
+const BATCH_ARG_ALIASES: Record<string, string> = {
+  tags: "tag",
+};
+
+function resolveBatchArgAlias(key: string): string {
+  const canonical = normalizeArgKey(key);
+  return BATCH_ARG_ALIASES[canonical] ?? canonical;
+}
+
+/**
  * Get all known argument and option names for a command, returning both
  * kebab-case, camelCase, and underscore variants.
  */
@@ -405,7 +418,7 @@ export function validateBatchCommands(
     const knownNamesArray = Array.from(knownNames);
 
     for (const argKey of Object.keys(cmd.args)) {
-      if (!knownCanonicalNames.has(normalizeArgKey(argKey))) {
+      if (!knownCanonicalNames.has(resolveBatchArgAlias(argKey))) {
         const suggestion = findClosestCommand(argKey, knownNamesArray);
         errors.push({
           index: i,
@@ -423,7 +436,7 @@ export function validateBatchCommands(
       const normalizedReqName = normalizeArgKey(reqName);
       if (
         !Object.keys(cmd.args).some(
-          (k) => normalizeArgKey(k) === normalizedReqName,
+          (k) => resolveBatchArgAlias(k) === normalizedReqName,
         )
       ) {
         errors.push({
@@ -582,7 +595,7 @@ export function buildCommandArgv(cmd: BatchCommand, cmdMeta: CommandMeta): strin
   for (const argDef of positionalDefs) {
     const canonicalName = normalizeArgKey(argDef.name);
     const matchedKey = Object.keys(cmd.args).find(
-      (k) => normalizeArgKey(k) === canonicalName,
+      (k) => resolveBatchArgAlias(k) === canonicalName,
     );
     const value = matchedKey ? cmd.args[matchedKey] : undefined;
     if (value === undefined) continue;
@@ -605,7 +618,7 @@ export function buildCommandArgv(cmd: BatchCommand, cmdMeta: CommandMeta): strin
       continue;
     }
 
-    const canonicalKey = normalizeArgKey(key);
+    const canonicalKey = resolveBatchArgAlias(key);
     // Skip positional args (already emitted)
     if (positionalCanonicalNameSet.has(canonicalKey)) {
       continue;

--- a/tests/batch-exec-engine.test.ts
+++ b/tests/batch-exec-engine.test.ts
@@ -185,6 +185,23 @@ describe("buildCommandArgv", () => {
     expect(argv[tagIndices[1] + 1]).toBe("b");
   });
 
+  it("accepts tags alias for variadic --tag option", () => {
+    const cmdMeta = tree.subcommands
+      .find((c) => c.name === "inbox")!
+      .subcommands.find((c) => c.name === "add")!;
+    const argv = buildCommandArgv(
+      { command: "inbox add", args: { text: "idea", tags: ["cli", "dx"] } },
+      cmdMeta,
+    );
+    const tagIndices = argv
+      .map((v, i) => (v === "--tag" ? i : -1))
+      .filter((i) => i >= 0);
+    expect(tagIndices).toHaveLength(2);
+    expect(argv[tagIndices[0] + 1]).toBe("cli");
+    expect(argv[tagIndices[1] + 1]).toBe("dx");
+    expect(argv).not.toContain("--tags");
+  });
+
   it("handles camelCase args", () => {
     const cmdMeta = tree.subcommands
       .find((c) => c.name === "task")!
@@ -638,6 +655,34 @@ describe("batch command integration", () => {
     expect(prioritiesByTitle.get("batch priority alias 1")).toBe(1);
     expect(prioritiesByTitle.get("batch priority alias 2")).toBe(2);
     expect(prioritiesByTitle.get("batch priority alias 3")).toBe(3);
+  });
+
+  it("accepts tags alias for tag args in batch commands", () => {
+    const commands = JSON.stringify([
+      {
+        command: "inbox add",
+        args: {
+          text: "batch tags alias check",
+          tags: ["cli", "dx"],
+        },
+      },
+    ]);
+    const result = kspecJson<BatchExecResult>(
+      `batch --commands '${commands}'`,
+      tempDir,
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.summary.succeeded).toBe(1);
+
+    const listOutput = kspec("inbox list --json", tempDir);
+    const parsed = JSON.parse(listOutput.stdout);
+    const items = Array.isArray(parsed) ? parsed : parsed.items ?? [];
+    const createdItem = items.find(
+      (item: any) => item?.text === "batch tags alias check",
+    );
+    expect(createdItem).toBeTruthy();
+    expect(createdItem.tags).toEqual(expect.arrayContaining(["cli", "dx"]));
   });
 
   // AC: @plan-import ac-34


### PR DESCRIPTION
## Summary
- add batch argument alias resolution so `tags` maps to canonical `tag`
- apply alias resolution in both batch validation and argv construction paths
- add unit and integration tests covering `tags` alias behavior

## Validation
- npx vitest run tests/batch-schema.test.ts tests/batch-exec-engine.test.ts
- npx vitest run tests/batch-exec-engine.test.ts
- npm run test:shard1
- npm run test:shard2
- npm run test:shard3

Task: @01KJS702WDPKNN01FQ3CEYB822
