### PR TITLE
feat: add --text replay mode to session log show

### DIFF
--- a/src/cli/commands/session/commands.ts
+++ b/src/cli/commands/session/commands.ts
@@ -275,6 +275,7 @@ export function registerSessionCommands(program: Command): void {
     .command("show <session-id>")
     .description("Show detailed view of a single session")
     .option("-e, --events", "Include chronological event timeline")
+    .option("--text", "Replay assistant text output from session.update events")
     .option("-t, --type <type>", "Filter events by type (e.g., tool.call)")
     .option("-n, --limit <n>", "Show only the last N events")
     .option("-c, --context <n>", "Show context snapshot for iteration N")

--- a/src/cli/commands/session/log.ts
+++ b/src/cli/commands/session/log.ts
@@ -35,7 +35,7 @@ import {
 } from "../../../utils/index.js";
 import { isObject } from "../../../acp/types.js";
 import { EXIT_CODES } from "../../exit-codes.js";
-import { error, output, warn } from "../../output.js";
+import { error, isStructuredMode, output, warn } from "../../output.js";
 
 // ─── Shared Helpers ─────────────────────────────────────────────────────────
 
@@ -273,10 +273,47 @@ export async function sessionLogListAction(
 
 interface SessionLogShowOptions {
   events?: boolean;
+  text?: boolean;
   type?: string;
   limit?: string;
   context?: string;
   resolveBlobs?: boolean;
+}
+
+/**
+ * Extract replayable assistant text from a top-level content block.
+ * Text payloads may be plain strings or resolved blob pointers.
+ */
+function extractContentBlockText(block: unknown): string {
+  if (!isObject(block) || block.type !== "text") {
+    return "";
+  }
+  const textValue = block.text;
+  if (typeof textValue === "string") {
+    return textValue;
+  }
+  if (isObject(textValue) && typeof textValue.content === "string") {
+    return textValue.content;
+  }
+  return "";
+}
+
+/**
+ * Extract assistant text from a session.update payload.
+ *
+ * `session.update` payloads can carry content as:
+ * - `data.content: ContentBlock[]` (full message events)
+ * - `data.content: ContentBlock`   (chunk events)
+ */
+function extractReplayTextFromSessionUpdate(data: unknown): string {
+  if (!isObject(data)) {
+    return "";
+  }
+  const content = data.content;
+  if (Array.isArray(content)) {
+    return content.map((block) => extractContentBlockText(block)).join("");
+  }
+  return extractContentBlockText(content);
 }
 
 /**
@@ -513,7 +550,7 @@ export async function sessionLogShowAction(
       process.exit(EXIT_CODES.NOT_FOUND);
     }
 
-    if (options.resolveBlobs && !options.events) {
+    if (options.resolveBlobs && !options.events && !options.text) {
       warn("--resolve-blobs has no effect without --events; showing metadata only.");
     }
 
@@ -554,6 +591,28 @@ export async function sessionLogShowAction(
       events = allEvents;
     }
 
+    // AC: @session-log-show ac-11 - Replay assistant text from session.update content blocks
+    let replayText: string | null = null;
+    if (options.text) {
+      const allEvents = await readEvents(ctx.specDir, sessionId);
+      const chunks: string[] = [];
+      for (const event of allEvents) {
+        if (event.type !== "session.update") {
+          continue;
+        }
+        const resolvedData = await resolveSessionBlobPointers(
+          ctx.specDir,
+          sessionId,
+          event.data,
+        );
+        const textChunk = extractReplayTextFromSessionUpdate(resolvedData);
+        if (textChunk.length > 0) {
+          chunks.push(textChunk);
+        }
+      }
+      replayText = chunks.join("");
+    }
+
     // AC: @session-log-show ac-6 - Context snapshot
     let contextSnapshot: unknown = null;
     if (options.context) {
@@ -580,12 +639,29 @@ export async function sessionLogShowAction(
     const jsonOutput = {
       ...detail,
       ...(events !== null ? { events } : {}),
+      ...(replayText !== null ? { text: replayText } : {}),
       ...(contextSnapshot !== null ? { context: contextSnapshot } : {}),
     };
 
-    output(jsonOutput, () =>
-      formatSessionLogShow(detail, events, contextSnapshot, sessionStartTs),
-    );
+    output(jsonOutput, () => {
+      // In text mode, `--text` alone behaves like a raw replay stream.
+      if (options.text && !options.events && !options.context && !isStructuredMode()) {
+        process.stdout.write(replayText ?? "");
+        return;
+      }
+
+      formatSessionLogShow(detail, events, contextSnapshot, sessionStartTs);
+
+      // Keep --events/--context independent from --text in text mode.
+      if (
+        options.text &&
+        !isStructuredMode() &&
+        (options.events || options.context) &&
+        (replayText?.length ?? 0) > 0
+      ) {
+        process.stdout.write(`\n${replayText}`);
+      }
+    });
   } catch (err) {
     error("Failed to show session log", err);
     process.exit(EXIT_CODES.ERROR);

--- a/tests/session-log-show.test.ts
+++ b/tests/session-log-show.test.ts
@@ -655,6 +655,97 @@ describe('kspec session log show (CLI)', () => {
     expect(result.stderr).toContain('Session not found');
   });
 
+  // AC: @session-log-show ac-11
+  it('should replay assistant text from session.update events with --text', async () => {
+    const s1Dir = path.join(tempDir, 'sessions', sessionId1);
+    const textBlobRelPath = 'blobs/session-show-text.blob';
+    await fs.writeFile(path.join(s1Dir, textBlobRelPath), 'world', 'utf-8');
+
+    await fs.writeFile(path.join(s1Dir, 'events.jsonl'), [
+      JSON.stringify({
+        ts: 1000,
+        seq: 0,
+        type: 'session.update',
+        session_id: sessionId1,
+        data: {
+          content: [
+            { type: 'text', text: 'Hello ' },
+            {
+              type: 'text',
+              text: {
+                path: textBlobRelPath,
+                bytes: 5,
+                sha256: 'text-blob-hash',
+                truncated: true,
+                preview: 'wor',
+              },
+            },
+          ],
+        },
+      }),
+      JSON.stringify({
+        ts: 2000,
+        seq: 1,
+        type: 'session.update',
+        session_id: sessionId1,
+        data: {
+          content: { type: 'text', text: '!' },
+        },
+      }),
+      JSON.stringify({
+        ts: 3000,
+        seq: 2,
+        type: 'session.update',
+        session_id: sessionId1,
+        data: {
+          sessionUpdate: 'tool_call_update',
+          content: [{ type: 'content', content: { type: 'text', text: 'TOOL_NOISE' } }],
+        },
+      }),
+    ].join('\n') + '\n');
+
+    const result = kspec(`session log show ${sessionId1} --text`, tempDir);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe('Hello world!');
+    expect(result.stdout).not.toContain('TOOL_NOISE');
+    expect(result.stdout).not.toContain('Session');
+  });
+
+  // AC: @session-log-show ac-11
+  // AC: @trait-json-output ac-6
+  it('should support --text and --events together in JSON output', async () => {
+    const s1Dir = path.join(tempDir, 'sessions', sessionId1);
+    await fs.writeFile(path.join(s1Dir, 'events.jsonl'), [
+      JSON.stringify({
+        ts: 1000,
+        seq: 0,
+        type: 'session.update',
+        session_id: sessionId1,
+        data: { content: [{ type: 'text', text: 'alpha' }] },
+      }),
+      JSON.stringify({
+        ts: 2000,
+        seq: 1,
+        type: 'session.update',
+        session_id: sessionId1,
+        data: { content: [{ type: 'text', text: 'beta' }] },
+      }),
+    ].join('\n') + '\n');
+
+    const detail = kspecJson<SessionLogDetail & {
+      text?: string;
+      events?: Array<{ type: string }>;
+    }>(
+      `session log show ${sessionId1} --json --text --events`,
+      tempDir,
+    );
+    expect(detail.text).toBe('alphabeta');
+    expect(detail.events).toBeDefined();
+    expect(detail.events!.length).toBe(2);
+    expect(detail.events![0].type).toBe('session.update');
+    expect(detail.events![1].type).toBe('session.update');
+  });
+
   // AC: @trait-json-output ac-1
   it('should have no ANSI codes in JSON output', () => {
     const result = kspec(`session log show ${sessionId1} --json`, tempDir);


### PR DESCRIPTION
## Summary
- add a --text flag to kspec session log show
- replay assistant output by reading session.update content blocks in event order
- resolve externalized blob pointers before extracting replay text
- keep --events and --text independent (combined JSON mode supported)
- add integration tests for @session-log-show ac-11 and --json --text --events behavior

## Validation
- npx vitest run tests/session-log-show.test.ts
- npm run test:shard1
- npm run test:shard2
- npm run test:shard3
- npm run typecheck

## Notes
- kspec validate reports pre-existing repo-wide meta/reference/alignment issues unrelated to this task.

Task: @01KJS7PDW5GQQX9WQ2C7C1JNRX
Spec: @session-log-show
