### PR TITLE
fix(ralph): point run migration to dispatch start

### DIFF
--- a/src/cli/commands/ralph.ts
+++ b/src/cli/commands/ralph.ts
@@ -60,6 +60,7 @@ function showRalphDeprecationError(): void {
     "",
     chalk.bold("Equivalent commands:"),
     `  ${chalk.yellow("kspec ralph run")}      → ${chalk.cyan("kspec agent dispatch start")}`,
+    `  ${chalk.yellow("kspec ralph --dry-run")} → ${chalk.cyan("kspec agent dispatch start --dry-run")}`,
     `  ${chalk.yellow("kspec ralph end-loop")} → ${chalk.cyan("kspec agent end-loop")}`,
     "",
     chalk.bold("Getting started:"),

--- a/tests/ralph-replacement.test.ts
+++ b/tests/ralph-replacement.test.ts
@@ -87,6 +87,8 @@ describe("kspec ralph deprecation", () => {
     expect(result.stderr).toMatch(
       /kspec ralph run\s+→\s+kspec agent dispatch start/,
     );
+    expect(result.stderr).toContain("kspec ralph --dry-run");
+    expect(result.stderr).toContain("kspec agent dispatch start --dry-run");
   });
 
   it("shows migration error when kspec ralph end-loop is invoked", () => {


### PR DESCRIPTION
## Summary
- update deprecated `kspec ralph` guidance so `ralph run` points to `kspec agent dispatch start`
- keep `ralph end-loop` migration guidance to `kspec agent end-loop`
- tighten ralph replacement tests to assert exit code `1` and mapping text

## Verification
- `npx vitest run tests/ralph-replacement.test.ts`
- `npx vitest run`

Task: @01KJS8BAWP2WNCD003DQX75GKY
Spec: @ralph-replacement
