### PR TITLE
test: add shared HOME isolation helper for daemon-sensitive CLI tests

### DIFF
--- a/tests/cli-agent-commands.test.ts
+++ b/tests/cli-agent-commands.test.ts
@@ -14,6 +14,7 @@ import * as fsSync from "node:fs";
 import * as YAML from "yaml";
 import {
   createTempDir,
+  createIsolatedKspecHome,
   cleanupTempDir,
   kspec,
   testUlid,
@@ -1082,6 +1083,7 @@ describe("AC-2/3: kspec agent run error handling", () => {
 // AC: @trait-error-guidance ac-1, ac-2
 describe("AC-10: kspec agent dispatch start without daemon", () => {
   let testDir: string;
+  let isolatedDaemonEnv: Record<string, string>;
   const fs_sync = require("node:fs");
   const path_sync = require("node:path");
 
@@ -1108,6 +1110,7 @@ describe("AC-10: kspec agent dispatch start without daemon", () => {
 
   beforeEach(async () => {
     testDir = await createTempDir("kspec-agent-dispatch-");
+    isolatedDaemonEnv = (await createIsolatedKspecHome(testDir)).env;
   });
 
   afterEach(async () => {
@@ -1122,7 +1125,7 @@ describe("AC-10: kspec agent dispatch start without daemon", () => {
     // AC: @trait-error-guidance ac-2 - suggests action (kspec serve)
     const result = kspec("agent dispatch start", testDir, {
       expectFail: true,
-      env: { HOME: testDir, USERPROFILE: testDir },
+      env: isolatedDaemonEnv,
     });
 
     expect(result.exitCode).not.toBe(0);
@@ -1137,7 +1140,7 @@ describe("AC-10: kspec agent dispatch start without daemon", () => {
 
     // AC: @cli-agent-commands ac-9 - dispatch status shows info
     const result = kspec("agent dispatch status", testDir, {
-      env: { HOME: testDir, USERPROFILE: testDir },
+      env: isolatedDaemonEnv,
     });
 
     expect(result.exitCode).toBe(0);

--- a/tests/cli-serve.test.ts
+++ b/tests/cli-serve.test.ts
@@ -4,7 +4,14 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { createTempDir, cleanupTempDir, initGitRepo, kspec, type KspecOptions } from './helpers/cli';
+import {
+  createTempDir,
+  cleanupTempDir,
+  createIsolatedKspecHome,
+  initGitRepo,
+  kspec,
+  type KspecOptions,
+} from './helpers/cli';
 import { spawn, execSync } from 'child_process';
 import { join } from 'path';
 import { readFileSync, existsSync, mkdirSync } from 'fs';
@@ -130,14 +137,11 @@ describe('kspec serve commands', () => {
     tempDir = await createTempDir();
     await initGitRepo(tempDir);
     mkdirSync(join(tempDir, '.kspec'), { recursive: true });
-    isolatedHome = join(tempDir, '.home');
-    mkdirSync(isolatedHome, { recursive: true });
-    testEnv = { HOME: isolatedHome };
-
-    // Isolated PID/port files are under test HOME/.config/kspec.
-    const configDir = join(isolatedHome, '.config', 'kspec');
-    globalPidFilePath = join(configDir, 'daemon.pid');
-    globalPortFilePath = join(configDir, 'daemon.port');
+    const isolated = await createIsolatedKspecHome(tempDir);
+    isolatedHome = isolated.homeDir;
+    testEnv = isolated.env;
+    globalPidFilePath = isolated.daemonPidFilePath;
+    globalPortFilePath = isolated.daemonPortFilePath;
 
     // Ensure this test HOME starts from clean daemon state.
     try {
@@ -470,9 +474,8 @@ describe('kspec serve commands', () => {
     // Create temp directory WITHOUT .kspec/ to avoid auto-registration
     const emptyTempDir = await createTempDir();
     await initGitRepo(emptyTempDir);
-    const isolatedHomeForEmptyProject = join(emptyTempDir, '.home');
-    mkdirSync(isolatedHomeForEmptyProject, { recursive: true });
-    const env = { HOME: isolatedHomeForEmptyProject };
+    const isolated = await createIsolatedKspecHome(emptyTempDir);
+    const env = isolated.env;
 
     const port = await getAvailablePort();
 

--- a/tests/helpers/cli.ts
+++ b/tests/helpers/cli.ts
@@ -240,6 +240,50 @@ export async function createTempDir(prefix = 'kspec-test-'): Promise<string> {
 }
 
 /**
+ * Isolated HOME/config paths for daemon-sensitive CLI tests.
+ */
+export interface IsolatedKspecHome {
+  /** Home directory used for HOME/USERPROFILE overrides */
+  homeDir: string;
+  /** kspec config directory under the isolated home */
+  configDir: string;
+  /** Global daemon PID file path under isolated HOME */
+  daemonPidFilePath: string;
+  /** Global daemon port file path under isolated HOME */
+  daemonPortFilePath: string;
+  /** Environment overrides for running commands in isolated HOME */
+  env: Record<string, string>;
+}
+
+/**
+ * Create isolated HOME/config paths for daemon-sensitive CLI tests.
+ *
+ * This avoids ambient ~/.config/kspec PID/port state leaking into tests.
+ *
+ * @param rootDir - Root directory where isolated home will be created
+ * @param homeDirName - Optional isolated home subdirectory name
+ */
+export async function createIsolatedKspecHome(
+  rootDir: string,
+  homeDirName = '.home'
+): Promise<IsolatedKspecHome> {
+  const homeDir = path.join(rootDir, homeDirName);
+  const configDir = path.join(homeDir, '.config', 'kspec');
+  await fs.mkdir(configDir, { recursive: true });
+
+  return {
+    homeDir,
+    configDir,
+    daemonPidFilePath: path.join(configDir, 'daemon.pid'),
+    daemonPortFilePath: path.join(configDir, 'daemon.port'),
+    env: {
+      HOME: homeDir,
+      USERPROFILE: homeDir,
+    },
+  };
+}
+
+/**
  * Initialize a git repo in a directory (useful for tests that need git)
  *
  * @param dir - Directory to initialize


### PR DESCRIPTION
## Summary
- add `createIsolatedKspecHome()` to `tests/helpers/cli.ts` for shared HOME/.config/kspec isolation in daemon-sensitive CLI tests
- migrate `tests/cli-serve.test.ts` to use the helper in suite setup and empty-project daemon scenario
- migrate daemon-not-running cases in `tests/cli-agent-commands.test.ts` to use isolated helper env instead of ad-hoc HOME/USERPROFILE assignment

## Verification
- `npx vitest run tests/cli-serve.test.ts tests/cli-agent-commands.test.ts`
- `kspec validate` *(fails due pre-existing workspace meta/reference issues unrelated to this change)*

Task: @01KJTP68SV9VZ37KXF6TCEEKWB
Spec: @daemon-sensitive-cli-test-determinism
