### PR TITLE
test: add reusable startup wait helper for daemon/process tests

### DIFF
--- a/tests/cli-agent-commands.test.ts
+++ b/tests/cli-agent-commands.test.ts
@@ -17,6 +17,7 @@ import {
   createIsolatedKspecHome,
   cleanupTempDir,
   kspec,
+  waitForStartup,
   testUlid,
   initGitRepo,
 } from "./helpers/cli.js";
@@ -1360,12 +1361,17 @@ function makeFakeWsClass(): { FakeWs: new (url: string) => FakeWsInstance; getLa
  * Used to handle async initContext() completing before WebSocket is created.
  */
 async function waitFor(condition: () => boolean, maxWaitMs = 500): Promise<void> {
-  const interval = 10;
-  let elapsed = 0;
-  while (!condition() && elapsed < maxWaitMs) {
-    await new Promise((r) => setTimeout(r, interval));
-    elapsed += interval;
-  }
+  await waitForStartup(
+    "dispatch watch test readiness",
+    async () => {
+      const ok = condition();
+      return {
+        ok,
+        details: ok ? "condition met" : "condition still false",
+      };
+    },
+    { timeoutMs: maxWaitMs, intervalMs: 10 },
+  );
 }
 
 // AC: @cli-agent-commands ac-15
@@ -2055,7 +2061,19 @@ describe("AC-14: dispatch watch — reconnect on disconnect", () => {
     });
     // Trigger close before coalesced timer flushes naturally.
     instances[0].onclose?.();
-    await new Promise((r) => setTimeout(r, 10));
+    await waitForStartup(
+      "dispatch watch reconnect output flush",
+      async () => {
+        const stdout = stdoutWrites.join("");
+        const reconnectLogged = stderrWrites.some((l) => l.includes("[watch] Connection lost"));
+        const flushed = stdout.includes("[worker sess-abc]\nline without newline\n");
+        return {
+          ok: reconnectLogged && flushed,
+          details: `stdout_len=${stdout.length} stderr_lines=${stderrWrites.length}`,
+        };
+      },
+      { timeoutMs: 1_000, intervalMs: 10 },
+    );
 
     const stdout = stdoutWrites.join("");
     expect(stdout).toContain("[worker sess-abc]\nline without newline\n");

--- a/tests/cli-serve.test.ts
+++ b/tests/cli-serve.test.ts
@@ -10,6 +10,7 @@ import {
   createIsolatedKspecHome,
   initGitRepo,
   kspec,
+  waitForStartup,
   type KspecOptions,
 } from './helpers/cli';
 import { spawn, execSync } from 'child_process';
@@ -62,31 +63,8 @@ describe('kspec serve commands', () => {
     });
   }
 
-  async function waitForCondition(
-    description: string,
-    check: () => Promise<{ ok: boolean; details: string }>,
-    timeoutMs = 5_000,
-    intervalMs = 100
-  ): Promise<void> {
-    const startedAt = Date.now();
-    let lastDetails = 'no observation collected';
-
-    while (Date.now() - startedAt < timeoutMs) {
-      const result = await check();
-      lastDetails = result.details;
-      if (result.ok) {
-        return;
-      }
-      await new Promise((resolve) => setTimeout(resolve, intervalMs));
-    }
-
-    throw new Error(
-      `Timed out waiting for ${description} after ${timeoutMs}ms. Last observation: ${lastDetails}`
-    );
-  }
-
   async function waitForDaemonHealth(port: number): Promise<void> {
-    await waitForCondition(`daemon health endpoint on port ${port}`, async () => {
+    await waitForStartup(`daemon health endpoint on port ${port}`, async () => {
       const url = `http://localhost:${port}/api/health`;
       try {
         const response = await fetch(url);
@@ -100,11 +78,11 @@ describe('kspec serve commands', () => {
         const message = error instanceof Error ? error.message : String(error);
         return { ok: false, details: `fetch error=${message}` };
       }
-    }, 10_000);
+    }, { timeoutMs: 10_000 });
   }
 
   async function waitForDaemonUptime(minUptimeSeconds: number): Promise<void> {
-    await waitForCondition(
+    await waitForStartup(
       `daemon uptime >= ${minUptimeSeconds}s`,
       async () => {
         const result = runKspec(`serve status --json --kspec-dir ${join(tempDir, '.kspec')}`, tempDir, {
@@ -129,7 +107,7 @@ describe('kspec serve commands', () => {
           return { ok: false, details: `invalid-json=${message}` };
         }
       },
-      10_000
+      { timeoutMs: 10_000 }
     );
   }
 
@@ -164,11 +142,10 @@ describe('kspec serve commands', () => {
 
   // AC: @daemon-sensitive-cli-test-determinism ac-1
   it('should include actionable context when readiness wait times out', async () => {
-    await expect(waitForCondition(
+    await expect(waitForStartup(
       'synthetic daemon readiness',
       async () => ({ ok: false, details: 'status=503 body=warming-up' }),
-      120,
-      20
+      { timeoutMs: 120, intervalMs: 20 }
     )).rejects.toThrow(/Last observation: status=503 body=warming-up/);
   });
 

--- a/tests/helpers/cli.ts
+++ b/tests/helpers/cli.ts
@@ -62,6 +62,26 @@ export interface KspecResult {
 }
 
 /**
+ * Result from one startup/readiness probe.
+ */
+export interface StartupProbeResult {
+  /** Whether startup/readiness condition is satisfied */
+  ok: boolean;
+  /** Diagnostic detail for timeout errors */
+  details: string;
+}
+
+/**
+ * Options for startup/readiness wait helper.
+ */
+export interface WaitForStartupOptions {
+  /** Maximum wait duration before failing */
+  timeoutMs?: number;
+  /** Poll interval between probe checks */
+  intervalMs?: number;
+}
+
+/**
  * Run a kspec CLI command
  *
  * @param args - CLI arguments (e.g., "task list --json")
@@ -158,6 +178,37 @@ export function kspecOutput(args: string, cwd: string, options: KspecOptions = {
 export function kspecJson<T>(args: string, cwd: string, options: KspecOptions = {}): T {
   const result = kspec(`${args} --json`, cwd, options);
   return JSON.parse(result.stdout);
+}
+
+/**
+ * Bounded polling helper for startup/readiness checks in daemon/process tests.
+ *
+ * Throws with the most recent probe details to make timeout failures actionable.
+ */
+export async function waitForStartup(
+  description: string,
+  probe: () => StartupProbeResult | Promise<StartupProbeResult>,
+  options: WaitForStartupOptions = {}
+): Promise<void> {
+  const timeoutMs = options.timeoutMs ?? 5_000;
+  const intervalMs = options.intervalMs ?? 100;
+  const startedAt = Date.now();
+  let lastDetails = 'no observation collected';
+
+  while (Date.now() - startedAt < timeoutMs) {
+    const result = await probe();
+    lastDetails = result.details;
+
+    if (result.ok) {
+      return;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+
+  throw new Error(
+    `Timed out waiting for ${description} after ${timeoutMs}ms. Last observation: ${lastDetails}`
+  );
 }
 
 // Legacy aliases for backwards compatibility


### PR DESCRIPTION
## Summary
- add shared `waitForStartup` helper in `tests/helpers/cli.ts` for bounded polling with timeout diagnostics
- migrate `tests/cli-serve.test.ts` startup/readiness waits to the shared helper
- replace dispatch-watch fixed-delay assertion wait in `tests/cli-agent-commands.test.ts` with condition-based polling via shared helper

## Verification
- `npm run test -- tests/cli-serve.test.ts tests/cli-agent-commands.test.ts`
- `npm run test:shard1`
- `npm run test:shard2`
- `npm run test:shard3`
- `kspec validate` *(fails due pre-existing repository-level meta/reference/alignment issues unrelated to this change)*

Task: @01KJTP69W21Z3GQE8J2HAXC4WV
Spec: @daemon-sensitive-cli-test-determinism
