### PR TITLE
fix(agent): fail fast when dispatch watch subscribe ack is rejected

### DIFF
--- a/src/cli/commands/agent.ts
+++ b/src/cli/commands/agent.ts
@@ -703,7 +703,7 @@ export function registerAgentCommands(program: Command): void {
 
   // ─── kspec agent dispatch watch ───────────────────────────────────────────
 
-  // AC: @cli-agent-commands ac-13 through ac-16
+  // AC: @cli-agent-commands ac-13 through ac-18
   dispatch
     .command("watch")
     .description("Stream agent text output from the dispatch engine in real time")
@@ -834,6 +834,7 @@ export function registerAgentCommands(program: Command): void {
       }
 
       let retryCount = 0;
+      let shouldReconnect = true;
 
       function connect(): void {
         const wsUrl = new URL(`ws://localhost:${daemonConn!.port}/ws`);
@@ -859,6 +860,23 @@ export function registerAgentCommands(program: Command): void {
           try {
             msg = JSON.parse(event.data as string);
           } catch {
+            return;
+          }
+
+          // AC: @cli-agent-commands ac-18 — fail fast on subscribe handshake rejection.
+          if (msg.ack === true && msg.request_id === "watch-subscribe") {
+            if (msg.success === false) {
+              shouldReconnect = false;
+              const reasonParts = [msg.error, msg.details]
+                .filter((value): value is string => typeof value === "string" && value.length > 0);
+              const reason = reasonParts.length > 0 ? ` (${reasonParts.join(": ")})` : "";
+              if (activeStreamKey) {
+                ensureLineBreak();
+              }
+              error(`Failed to subscribe to daemon agent output stream${reason}.`);
+              info("Suggestion: Verify daemon logs for subscribe errors, then restart with: kspec serve");
+              process.exit(EXIT_CODES.NOT_FOUND);
+            }
             return;
           }
 
@@ -894,6 +912,8 @@ export function registerAgentCommands(program: Command): void {
         };
 
         ws.onclose = () => {
+          if (!shouldReconnect) return;
+
           if (activeStreamKey) {
             ensureLineBreak();
           }

--- a/tests/cli-agent-commands.test.ts
+++ b/tests/cli-agent-commands.test.ts
@@ -1330,7 +1330,7 @@ describe("AC-12: suppress adapter rate_limit_event noise on stderr", () => {
   });
 });
 
-// ─── AC-13 through AC-17: kspec agent dispatch watch ─────────────────────────
+// ─── AC-13 through AC-18: kspec agent dispatch watch ─────────────────────────
 
 // Helper: create a fake WebSocket instance for testing
 interface FakeWsInstance {
@@ -1409,6 +1409,74 @@ describe("AC-15: dispatch watch — daemon not running", () => {
     // Error should mention daemon
     const allOutput = errors.join(" ");
     expect(allOutput.toLowerCase()).toMatch(/daemon/);
+  });
+});
+
+// AC: @cli-agent-commands ac-18
+describe("AC-18: dispatch watch — subscribe handshake failure", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("should exit code 3 with actionable guidance when subscribe ack fails", async () => {
+    const { PidFileManager } = await import("../src/cli/pid-utils.js");
+    vi.spyOn(PidFileManager.prototype, "isDaemonRunning").mockReturnValue(true);
+    vi.spyOn(PidFileManager.prototype, "readPort").mockReturnValue(9999);
+
+    const { FakeWs, getLastInstance } = makeFakeWsClass();
+    vi.stubGlobal("WebSocket", FakeWs);
+
+    const errors: string[] = [];
+    const infos: string[] = [];
+    vi.spyOn(console, "error").mockImplementation((...args) => {
+      errors.push(args.join(" "));
+    });
+    vi.spyOn(console, "log").mockImplementation((...args) => {
+      infos.push(args.join(" "));
+    });
+
+    let exitCode: number | undefined;
+    vi.spyOn(process, "exit").mockImplementation((code?: number) => {
+      exitCode = code as number;
+      throw new Error(`process.exit(${code})`);
+    });
+
+    const program = createTestProgram();
+    const runPromise = program
+      .parseAsync(["agent", "dispatch", "watch"], { from: "user" })
+      .catch(() => {/* mocked process.exit throws */});
+
+    await waitFor(() => getLastInstance() !== null);
+    const ws = getLastInstance()!;
+    ws.onopen?.({});
+
+    try {
+      ws.onmessage?.({
+        data: JSON.stringify({
+          ack: true,
+          request_id: "watch-subscribe",
+          success: false,
+          error: "validation_error",
+          details: "Missing or invalid topics array",
+        }),
+      });
+    } catch {
+      // expected: mocked process.exit throws
+    }
+
+    await Promise.resolve();
+
+    expect(exitCode).toBe(3);
+    const allErrors = errors.join(" ");
+    const allInfo = infos.join(" ");
+    expect(allErrors).toContain("Failed to subscribe to daemon agent output stream");
+    expect(allErrors).toContain("Missing or invalid topics array");
+    expect(allInfo).toContain("Suggestion:");
+    expect(allInfo).toContain("kspec serve");
+    expect(allInfo).toContain("daemon logs");
+
+    runPromise.catch(() => {/* ignore */});
   });
 });
 


### PR DESCRIPTION
## Summary
- add spec AC-18 for dispatch watch subscribe-handshake failure semantics
- fail fast in kspec agent dispatch watch when subscribe ack returns success=false
- emit actionable guidance and exit with runtime error code instead of silently waiting
- add AC-18 test coverage in tests/cli-agent-commands.test.ts

## Verification
- npx vitest run tests/cli-agent-commands.test.ts
- npx vitest run .

## Context
- Task: @01KJVD7HDS5HVJ4JAE6M7SPV9R
- Spec: @cli-agent-commands
