### PR TITLE
fix(e2e): isolate daemon per test with ephemeral ports

### DIFF
--- a/packages/web-ui/playwright.config.ts
+++ b/packages/web-ui/playwright.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   fullyParallel: false,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  workers: 1, // Required: daemon uses fixed port 3456
+  workers: 1, // Sequential: each test gets its own ephemeral-port daemon
   reporter: process.env.CI ? 'github' : 'html',
   timeout: 30_000,
 
@@ -14,8 +14,8 @@ export default defineConfig({
   },
 
   use: {
-    // Connect directly to daemon which serves both API and UI
-    baseURL: 'http://localhost:3456',
+    // No baseURL — each test gets a daemon on an ephemeral port via the daemon fixture
+    // Tests use daemon.baseUrl for API calls and page.goto(`${daemon.baseUrl}/...`) for navigation
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
     video: 'retain-on-failure',

--- a/packages/web-ui/tests/e2e/api-agent-dispatch.spec.ts
+++ b/packages/web-ui/tests/e2e/api-agent-dispatch.spec.ts
@@ -47,13 +47,11 @@
 
 import { test, expect } from '../fixtures/test-base';
 
-const DAEMON_URL = 'http://localhost:3456';
-
 test.describe('Agent Dispatch API', () => {
   test.describe('GET /api/agent/status', () => {
     // AC: @daemon-agent-dispatch ac-5
     test('returns dispatch_enabled, active_invocations, queue_depth, agent_definitions', async ({ request, daemon }) => {
-      const response = await request.get(`${DAEMON_URL}/api/agent/status`);
+      const response = await request.get(`${daemon.baseUrl}/api/agent/status`);
 
       expect(response.status()).toBe(200);
 
@@ -74,7 +72,7 @@ test.describe('Agent Dispatch API', () => {
 
     // AC: @daemon-agent-dispatch ac-5
     test('returns dispatch_enabled=false when engine not started', async ({ request, daemon }) => {
-      const response = await request.get(`${DAEMON_URL}/api/agent/status`);
+      const response = await request.get(`${daemon.baseUrl}/api/agent/status`);
 
       expect(response.status()).toBe(200);
 
@@ -88,7 +86,7 @@ test.describe('Agent Dispatch API', () => {
   test.describe('POST /api/agent/dispatch', () => {
     // AC: @daemon-agent-dispatch ac-6
     test('starts dispatch engine with action=start', async ({ request, daemon }) => {
-      const response = await request.post(`${DAEMON_URL}/api/agent/dispatch`, {
+      const response = await request.post(`${daemon.baseUrl}/api/agent/dispatch`, {
         data: { action: 'start' },
         headers: { 'Content-Type': 'application/json' },
       });
@@ -100,7 +98,7 @@ test.describe('Agent Dispatch API', () => {
       expect(body.dispatch_enabled).toBe(true);
 
       // Clean up
-      await request.post(`${DAEMON_URL}/api/agent/dispatch`, {
+      await request.post(`${daemon.baseUrl}/api/agent/dispatch`, {
         data: { action: 'stop' },
         headers: { 'Content-Type': 'application/json' },
       });
@@ -109,12 +107,12 @@ test.describe('Agent Dispatch API', () => {
     // AC: @daemon-agent-dispatch ac-6
     test('stops dispatch engine with action=stop', async ({ request, daemon }) => {
       // Start first
-      await request.post(`${DAEMON_URL}/api/agent/dispatch`, {
+      await request.post(`${daemon.baseUrl}/api/agent/dispatch`, {
         data: { action: 'start' },
         headers: { 'Content-Type': 'application/json' },
       });
 
-      const response = await request.post(`${DAEMON_URL}/api/agent/dispatch`, {
+      const response = await request.post(`${daemon.baseUrl}/api/agent/dispatch`, {
         data: { action: 'stop' },
         headers: { 'Content-Type': 'application/json' },
       });
@@ -128,19 +126,19 @@ test.describe('Agent Dispatch API', () => {
 
     // AC: @daemon-agent-dispatch ac-6
     test('returns dispatch_enabled=true when GET /api/agent/status is called after start', async ({ request, daemon }) => {
-      await request.post(`${DAEMON_URL}/api/agent/dispatch`, {
+      await request.post(`${daemon.baseUrl}/api/agent/dispatch`, {
         data: { action: 'start' },
         headers: { 'Content-Type': 'application/json' },
       });
 
-      const statusResponse = await request.get(`${DAEMON_URL}/api/agent/status`);
+      const statusResponse = await request.get(`${daemon.baseUrl}/api/agent/status`);
       expect(statusResponse.status()).toBe(200);
 
       const body = await statusResponse.json();
       expect(body.dispatch_enabled).toBe(true);
 
       // Clean up
-      await request.post(`${DAEMON_URL}/api/agent/dispatch`, {
+      await request.post(`${daemon.baseUrl}/api/agent/dispatch`, {
         data: { action: 'stop' },
         headers: { 'Content-Type': 'application/json' },
       });
@@ -150,7 +148,7 @@ test.describe('Agent Dispatch API', () => {
   test.describe('POST /api/agent/events', () => {
     // AC: @daemon-agent-dispatch ac-2, ac-7
     test('returns accepted=false when dispatch engine not running', async ({ request, daemon }) => {
-      const response = await request.post(`${DAEMON_URL}/api/agent/events`, {
+      const response = await request.post(`${daemon.baseUrl}/api/agent/events`, {
         data: {
           task_id: '01JXXXXXXXXXXXXXXXXXXXXXXXXX',
           from_status: 'in_progress',
@@ -171,12 +169,12 @@ test.describe('Agent Dispatch API', () => {
     // AC: @daemon-agent-dispatch ac-2
     test('returns accepted=true when dispatch engine is running', async ({ request, daemon }) => {
       // Start the engine first
-      await request.post(`${DAEMON_URL}/api/agent/dispatch`, {
+      await request.post(`${daemon.baseUrl}/api/agent/dispatch`, {
         data: { action: 'start' },
         headers: { 'Content-Type': 'application/json' },
       });
 
-      const response = await request.post(`${DAEMON_URL}/api/agent/events`, {
+      const response = await request.post(`${daemon.baseUrl}/api/agent/events`, {
         data: {
           task_id: '01JXXXXXXXXXXXXXXXXXXXXXXXXX',
           task_ref: '@test-task',
@@ -193,7 +191,7 @@ test.describe('Agent Dispatch API', () => {
       expect(body.accepted).toBe(true);
 
       // Clean up
-      await request.post(`${DAEMON_URL}/api/agent/dispatch`, {
+      await request.post(`${daemon.baseUrl}/api/agent/dispatch`, {
         data: { action: 'stop' },
         headers: { 'Content-Type': 'application/json' },
       });
@@ -201,7 +199,7 @@ test.describe('Agent Dispatch API', () => {
 
     // AC: @daemon-agent-dispatch ac-2
     test('POST /api/agent/event (legacy alias) returns accepted=false when engine not running', async ({ request, daemon }) => {
-      const response = await request.post(`${DAEMON_URL}/api/agent/event`, {
+      const response = await request.post(`${daemon.baseUrl}/api/agent/event`, {
         data: {
           task_id: '01JXXXXXXXXXXXXXXXXXXXXXXXXX',
           from_status: 'pending',
@@ -221,7 +219,7 @@ test.describe('Agent Dispatch API', () => {
   test.describe('GET /api/agent/dispatch/status (internal format)', () => {
     // AC: @daemon-agent-dispatch ac-5 (internal route for backwards compat)
     test('returns running=false when engine not started', async ({ request, daemon }) => {
-      const response = await request.get(`${DAEMON_URL}/api/agent/dispatch/status`);
+      const response = await request.get(`${daemon.baseUrl}/api/agent/dispatch/status`);
 
       expect(response.status()).toBe(200);
 
@@ -233,7 +231,7 @@ test.describe('Agent Dispatch API', () => {
 
   test.describe('Legacy dispatch start/stop routes', () => {
     test('POST /api/agent/dispatch/start starts the engine', async ({ request, daemon }) => {
-      const response = await request.post(`${DAEMON_URL}/api/agent/dispatch/start`);
+      const response = await request.post(`${daemon.baseUrl}/api/agent/dispatch/start`);
 
       expect(response.status()).toBe(200);
 
@@ -241,19 +239,19 @@ test.describe('Agent Dispatch API', () => {
       expect(body.started).toBe(true);
 
       // Verify engine is running
-      const statusResponse = await request.get(`${DAEMON_URL}/api/agent/dispatch/status`);
+      const statusResponse = await request.get(`${daemon.baseUrl}/api/agent/dispatch/status`);
       const status = await statusResponse.json();
       expect(status.running).toBe(true);
 
       // Clean up
-      await request.post(`${DAEMON_URL}/api/agent/dispatch/stop`);
+      await request.post(`${daemon.baseUrl}/api/agent/dispatch/stop`);
     });
 
     test('POST /api/agent/dispatch/stop stops the engine', async ({ request, daemon }) => {
       // Start first
-      await request.post(`${DAEMON_URL}/api/agent/dispatch/start`);
+      await request.post(`${daemon.baseUrl}/api/agent/dispatch/start`);
 
-      const response = await request.post(`${DAEMON_URL}/api/agent/dispatch/stop`);
+      const response = await request.post(`${daemon.baseUrl}/api/agent/dispatch/stop`);
 
       expect(response.status()).toBe(200);
 
@@ -261,7 +259,7 @@ test.describe('Agent Dispatch API', () => {
       expect(body.stopped).toBe(true);
 
       // Verify engine is stopped
-      const statusResponse = await request.get(`${DAEMON_URL}/api/agent/dispatch/status`);
+      const statusResponse = await request.get(`${daemon.baseUrl}/api/agent/dispatch/status`);
       const status = await statusResponse.json();
       expect(status.running).toBe(false);
     });
@@ -270,13 +268,13 @@ test.describe('Agent Dispatch API', () => {
   test.describe('Trait: @trait-api-endpoint', () => {
     // AC: @trait-api-endpoint ac-1 — valid requests return 2xx
     test('all dispatch endpoints return 2xx for valid requests', async ({ request, daemon }) => {
-      const statusResp = await request.get(`${DAEMON_URL}/api/agent/status`);
+      const statusResp = await request.get(`${daemon.baseUrl}/api/agent/status`);
       expect(statusResp.status()).toBe(200);
 
-      const dispatchStatusResp = await request.get(`${DAEMON_URL}/api/agent/dispatch/status`);
+      const dispatchStatusResp = await request.get(`${daemon.baseUrl}/api/agent/dispatch/status`);
       expect(dispatchStatusResp.status()).toBe(200);
 
-      const eventResp = await request.post(`${DAEMON_URL}/api/agent/events`, {
+      const eventResp = await request.post(`${daemon.baseUrl}/api/agent/events`, {
         data: { task_id: '01JXXXXXXXXXXXXXXXXXXXXXXXXX', from_status: 'pending', to_status: 'in_progress' },
         headers: { 'Content-Type': 'application/json' },
       });
@@ -285,7 +283,7 @@ test.describe('Agent Dispatch API', () => {
 
     // AC: @trait-api-endpoint ac-3 — invalid body returns 400
     test('POST /api/agent/dispatch with invalid action returns 400', async ({ request, daemon }) => {
-      const response = await request.post(`${DAEMON_URL}/api/agent/dispatch`, {
+      const response = await request.post(`${daemon.baseUrl}/api/agent/dispatch`, {
         data: { action: 'restart' }, // invalid action
         headers: { 'Content-Type': 'application/json' },
       });

--- a/packages/web-ui/tests/e2e/api-errors.spec.ts
+++ b/packages/web-ui/tests/e2e/api-errors.spec.ts
@@ -30,8 +30,6 @@
 
 import { test, expect } from '../fixtures/test-base';
 
-const DAEMON_URL = 'http://localhost:3456';
-
 test.describe('Error Handling API', () => {
   test.describe('404 Not Found Errors', () => {
     // AC: @api-contract ac-22
@@ -39,7 +37,7 @@ test.describe('Error Handling API', () => {
       request,
       daemon,
     }) => {
-      const response = await request.get(`${DAEMON_URL}/api/tasks/@nonexistent-ref-xyz`);
+      const response = await request.get(`${daemon.baseUrl}/api/tasks/@nonexistent-ref-xyz`);
 
       expect(response.status()).toBe(404);
 
@@ -60,7 +58,7 @@ test.describe('Error Handling API', () => {
       request,
       daemon,
     }) => {
-      const response = await request.get(`${DAEMON_URL}/api/items/@nonexistent-item-xyz`);
+      const response = await request.get(`${daemon.baseUrl}/api/items/@nonexistent-item-xyz`);
 
       expect(response.status()).toBe(404);
 
@@ -78,7 +76,7 @@ test.describe('Error Handling API', () => {
       request,
       daemon,
     }) => {
-      const response = await request.get(`${DAEMON_URL}/api/inbox/@nonexistent-inbox-xyz`);
+      const response = await request.get(`${daemon.baseUrl}/api/inbox/@nonexistent-inbox-xyz`);
 
       expect(response.status()).toBe(404);
 
@@ -93,7 +91,7 @@ test.describe('Error Handling API', () => {
       request,
       daemon,
     }) => {
-      const response = await request.get(`${DAEMON_URL}/api/tasks/@nonexistent-task-xyz`);
+      const response = await request.get(`${daemon.baseUrl}/api/tasks/@nonexistent-task-xyz`);
 
       expect(response.status()).toBe(404);
 
@@ -110,7 +108,7 @@ test.describe('Error Handling API', () => {
       daemon,
     }) => {
       const response = await request.post(
-        `${DAEMON_URL}/api/tasks/@nonexistent-task-xyz/start`,
+        `${daemon.baseUrl}/api/tasks/@nonexistent-task-xyz/start`,
         { data: {} }
       );
 
@@ -129,7 +127,7 @@ test.describe('Error Handling API', () => {
       daemon,
     }) => {
       const response = await request.post(
-        `${DAEMON_URL}/api/tasks/@nonexistent-task-xyz/note`,
+        `${daemon.baseUrl}/api/tasks/@nonexistent-task-xyz/note`,
         { data: { content: 'test note' } }
       );
 
@@ -156,7 +154,7 @@ test.describe('Error Handling API', () => {
     }) => {
       // Elysia validates body schema before handler runs — returns 422 for schema violations
       const response = await request.post(
-        `${DAEMON_URL}/api/tasks/@test-task-in-progress/note`,
+        `${daemon.baseUrl}/api/tasks/@test-task-in-progress/note`,
         { data: {} } // missing required 'content' field
       );
 
@@ -171,7 +169,7 @@ test.describe('Error Handling API', () => {
       daemon,
     }) => {
       // Send request without required 'text' field
-      const response = await request.post(`${DAEMON_URL}/api/inbox`, {
+      const response = await request.post(`${daemon.baseUrl}/api/inbox`, {
         data: {}, // missing required 'text' field
       });
 
@@ -185,7 +183,7 @@ test.describe('Error Handling API', () => {
       request,
       daemon,
     }) => {
-      const response = await request.post(`${DAEMON_URL}/api/inbox`, {
+      const response = await request.post(`${daemon.baseUrl}/api/inbox`, {
         data: { text: '   ' }, // whitespace-only text: passes Elysia schema but fails custom validation
       });
 
@@ -211,13 +209,13 @@ test.describe('Error Handling API', () => {
       daemon,
     }) => {
       // First create an inbox item to triage
-      const inboxResponse = await request.post(`${DAEMON_URL}/api/inbox`, {
+      const inboxResponse = await request.post(`${daemon.baseUrl}/api/inbox`, {
         data: { text: `Error handling test ${Date.now()}` },
       });
       expect(inboxResponse.status()).toBe(200);
       const inbox = await inboxResponse.json();
 
-      const response = await request.post(`${DAEMON_URL}/api/triage`, {
+      const response = await request.post(`${daemon.baseUrl}/api/triage`, {
         data: {
           inbox_ref: `@${inbox.item._ulid}`,
           action: 'invalid-action-xyz',
@@ -249,7 +247,7 @@ test.describe('Error Handling API', () => {
     }) => {
       // test-task-in-progress is already in_progress in the fixture
       const response = await request.post(
-        `${DAEMON_URL}/api/tasks/@test-task-in-progress/start`,
+        `${daemon.baseUrl}/api/tasks/@test-task-in-progress/start`,
         { data: {} }
       );
 
@@ -272,7 +270,7 @@ test.describe('Error Handling API', () => {
     }) => {
       // test-task-completed is in completed state — cannot be started
       const response = await request.post(
-        `${DAEMON_URL}/api/tasks/@test-task-completed/start`,
+        `${daemon.baseUrl}/api/tasks/@test-task-completed/start`,
         { data: {} }
       );
 
@@ -291,7 +289,7 @@ test.describe('Error Handling API', () => {
     test('409 current field reflects the actual task state', async ({ request, daemon }) => {
       // in_progress task — trying to start it again
       const response = await request.post(
-        `${DAEMON_URL}/api/tasks/@test-task-in-progress/start`,
+        `${daemon.baseUrl}/api/tasks/@test-task-in-progress/start`,
         { data: {} }
       );
 
@@ -309,7 +307,7 @@ test.describe('Error Handling API', () => {
     }) => {
       // test-task-in-progress: already in_progress
       const response = await request.post(
-        `${DAEMON_URL}/api/tasks/@test-task-in-progress/start`,
+        `${daemon.baseUrl}/api/tasks/@test-task-in-progress/start`,
         { data: {} }
       );
 
@@ -331,8 +329,8 @@ test.describe('Error Handling API', () => {
       daemon,
     }) => {
       const endpoints = [
-        { method: 'GET', url: `${DAEMON_URL}/api/tasks/@nonexistent-xyz` },
-        { method: 'GET', url: `${DAEMON_URL}/api/items/@nonexistent-xyz` },
+        { method: 'GET', url: `${daemon.baseUrl}/api/tasks/@nonexistent-xyz` },
+        { method: 'GET', url: `${daemon.baseUrl}/api/items/@nonexistent-xyz` },
       ];
 
       for (const endpoint of endpoints) {
@@ -354,7 +352,7 @@ test.describe('Error Handling API', () => {
 
     // AC: @api-contract ac-22 — 404 content type is JSON
     test('404 responses return JSON content type', async ({ request, daemon }) => {
-      const response = await request.get(`${DAEMON_URL}/api/tasks/@nonexistent-ref-xyz`);
+      const response = await request.get(`${daemon.baseUrl}/api/tasks/@nonexistent-ref-xyz`);
 
       expect(response.status()).toBe(404);
 

--- a/packages/web-ui/tests/e2e/api-inbox.spec.ts
+++ b/packages/web-ui/tests/e2e/api-inbox.spec.ts
@@ -13,13 +13,11 @@
 
 import { test, expect } from '../fixtures/test-base';
 
-const DAEMON_URL = 'http://localhost:3456';
-
 test.describe('Inbox API', () => {
   test.describe('GET /api/inbox', () => {
     // AC: @api-contract ac-12
     test('returns inbox items as array with total', async ({ request, daemon }) => {
-      const response = await request.get(`${DAEMON_URL}/api/inbox`);
+      const response = await request.get(`${daemon.baseUrl}/api/inbox`);
 
       expect(response.status()).toBe(200);
 
@@ -37,7 +35,7 @@ test.describe('Inbox API', () => {
       request,
       daemon,
     }) => {
-      const response = await request.get(`${DAEMON_URL}/api/inbox`);
+      const response = await request.get(`${daemon.baseUrl}/api/inbox`);
       expect(response.status()).toBe(200);
 
       const body = await response.json();
@@ -55,7 +53,7 @@ test.describe('Inbox API', () => {
 
     // AC: @api-contract ac-12 - item fields
     test('each inbox item has required fields', async ({ request, daemon }) => {
-      const response = await request.get(`${DAEMON_URL}/api/inbox`);
+      const response = await request.get(`${daemon.baseUrl}/api/inbox`);
       expect(response.status()).toBe(200);
 
       const body = await response.json();
@@ -71,7 +69,7 @@ test.describe('Inbox API', () => {
 
     // AC: @api-contract ac-12 - fixture data integrity
     test('returns the fixture inbox items in correct order', async ({ request, daemon }) => {
-      const response = await request.get(`${DAEMON_URL}/api/inbox`);
+      const response = await request.get(`${daemon.baseUrl}/api/inbox`);
       expect(response.status()).toBe(200);
 
       const body = await response.json();
@@ -87,7 +85,7 @@ test.describe('Inbox API', () => {
 
     // AC: @api-contract ac-12 (response format) - JSON content type
     test('returns JSON content type', async ({ request, daemon }) => {
-      const response = await request.get(`${DAEMON_URL}/api/inbox`);
+      const response = await request.get(`${daemon.baseUrl}/api/inbox`);
       const contentType = response.headers()['content-type'] || '';
       expect(contentType).toContain('application/json');
     });
@@ -97,7 +95,7 @@ test.describe('Inbox API', () => {
     // AC: @api-contract ac-13
     test('creates inbox item and returns it with generated ULID', async ({ request, daemon }) => {
       const itemText = `E2E test inbox item ${Date.now()}`;
-      const response = await request.post(`${DAEMON_URL}/api/inbox`, {
+      const response = await request.post(`${daemon.baseUrl}/api/inbox`, {
         data: { text: itemText },
       });
 
@@ -117,7 +115,7 @@ test.describe('Inbox API', () => {
 
     // AC: @api-contract ac-13 - ULID is auto-generated (not provided by client)
     test('assigns a ULID to the new item', async ({ request, daemon }) => {
-      const response = await request.post(`${DAEMON_URL}/api/inbox`, {
+      const response = await request.post(`${daemon.baseUrl}/api/inbox`, {
         data: { text: 'ULID assignment test' },
       });
 
@@ -134,14 +132,14 @@ test.describe('Inbox API', () => {
       daemon,
     }) => {
       const itemText = `Created item check ${Date.now()}`;
-      const createResponse = await request.post(`${DAEMON_URL}/api/inbox`, {
+      const createResponse = await request.post(`${daemon.baseUrl}/api/inbox`, {
         data: { text: itemText },
       });
       expect(createResponse.status()).toBe(200);
       const created = await createResponse.json();
 
       // Now list inbox items
-      const listResponse = await request.get(`${DAEMON_URL}/api/inbox`);
+      const listResponse = await request.get(`${daemon.baseUrl}/api/inbox`);
       expect(listResponse.status()).toBe(200);
       const list = await listResponse.json();
 
@@ -153,7 +151,7 @@ test.describe('Inbox API', () => {
 
     // AC: @api-contract ac-13 - supports optional tags
     test('creates item with optional tags', async ({ request, daemon }) => {
-      const response = await request.post(`${DAEMON_URL}/api/inbox`, {
+      const response = await request.post(`${daemon.baseUrl}/api/inbox`, {
         data: { text: 'Tagged item', tags: ['feature', 'dx'] },
       });
 
@@ -164,7 +162,7 @@ test.describe('Inbox API', () => {
 
     // AC: @api-contract ac-13 - supports optional added_by
     test('creates item with optional added_by field', async ({ request, daemon }) => {
-      const response = await request.post(`${DAEMON_URL}/api/inbox`, {
+      const response = await request.post(`${daemon.baseUrl}/api/inbox`, {
         data: { text: 'Item by author', added_by: '@testuser' },
       });
 
@@ -176,7 +174,7 @@ test.describe('Inbox API', () => {
     // AC: @api-contract ac-13 - created_at is set
     test('created item has a created_at timestamp', async ({ request, daemon }) => {
       const before = new Date().getTime();
-      const response = await request.post(`${DAEMON_URL}/api/inbox`, {
+      const response = await request.post(`${daemon.baseUrl}/api/inbox`, {
         data: { text: 'Timestamp test item' },
       });
 
@@ -192,7 +190,7 @@ test.describe('Inbox API', () => {
 
     // Error: missing text field — Elysia validates body schema, returns 422
     test('returns 422 when text field is missing', async ({ request, daemon }) => {
-      const response = await request.post(`${DAEMON_URL}/api/inbox`, {
+      const response = await request.post(`${daemon.baseUrl}/api/inbox`, {
         data: {},
       });
 
@@ -201,7 +199,7 @@ test.describe('Inbox API', () => {
 
     // Error: empty text — handler validation returns 400
     test('returns 400 when text is empty string', async ({ request, daemon }) => {
-      const response = await request.post(`${DAEMON_URL}/api/inbox`, {
+      const response = await request.post(`${daemon.baseUrl}/api/inbox`, {
         data: { text: '' },
       });
 
@@ -215,7 +213,7 @@ test.describe('Inbox API', () => {
 
     // Error: whitespace-only text — handler validation returns 400
     test('returns 400 when text is whitespace only', async ({ request, daemon }) => {
-      const response = await request.post(`${DAEMON_URL}/api/inbox`, {
+      const response = await request.post(`${daemon.baseUrl}/api/inbox`, {
         data: { text: '   ' },
       });
 
@@ -229,7 +227,7 @@ test.describe('Inbox API', () => {
     // AC: @api-contract ac-14
     test('deletes an inbox item and returns success confirmation', async ({ request, daemon }) => {
       // First create an item to delete
-      const createResponse = await request.post(`${DAEMON_URL}/api/inbox`, {
+      const createResponse = await request.post(`${daemon.baseUrl}/api/inbox`, {
         data: { text: 'Item to delete' },
       });
       expect(createResponse.status()).toBe(200);
@@ -237,7 +235,7 @@ test.describe('Inbox API', () => {
       const ulid = created.item._ulid;
 
       // Delete it using its ULID ref
-      const deleteResponse = await request.delete(`${DAEMON_URL}/api/inbox/@${ulid}`);
+      const deleteResponse = await request.delete(`${daemon.baseUrl}/api/inbox/@${ulid}`);
       expect(deleteResponse.status()).toBe(200);
 
       const body = await deleteResponse.json();
@@ -250,7 +248,7 @@ test.describe('Inbox API', () => {
     // AC: @api-contract ac-14 - item is actually removed from list
     test('deleted item no longer appears in GET /api/inbox', async ({ request, daemon }) => {
       // Create an item
-      const createResponse = await request.post(`${DAEMON_URL}/api/inbox`, {
+      const createResponse = await request.post(`${daemon.baseUrl}/api/inbox`, {
         data: { text: 'Item to verify deletion' },
       });
       expect(createResponse.status()).toBe(200);
@@ -258,11 +256,11 @@ test.describe('Inbox API', () => {
       const ulid = created.item._ulid;
 
       // Delete it
-      const deleteResponse = await request.delete(`${DAEMON_URL}/api/inbox/@${ulid}`);
+      const deleteResponse = await request.delete(`${daemon.baseUrl}/api/inbox/@${ulid}`);
       expect(deleteResponse.status()).toBe(200);
 
       // Verify it's gone
-      const listResponse = await request.get(`${DAEMON_URL}/api/inbox`);
+      const listResponse = await request.get(`${daemon.baseUrl}/api/inbox`);
       const list = await listResponse.json();
       const found = list.items.find((i: { _ulid: string }) => i._ulid === ulid);
       expect(found).toBeUndefined();
@@ -271,7 +269,7 @@ test.describe('Inbox API', () => {
     // AC: @api-contract ac-14 - can delete using full ULID ref
     test('deletes item using full ULID ref', async ({ request, daemon }) => {
       // Create a new item to delete
-      const createResponse = await request.post(`${DAEMON_URL}/api/inbox`, {
+      const createResponse = await request.post(`${daemon.baseUrl}/api/inbox`, {
         data: { text: 'Full ULID ref deletion test' },
       });
       expect(createResponse.status()).toBe(200);
@@ -279,7 +277,7 @@ test.describe('Inbox API', () => {
       const ulid = created.item._ulid;
 
       // Delete using the full ULID
-      const deleteResponse = await request.delete(`${DAEMON_URL}/api/inbox/@${ulid}`);
+      const deleteResponse = await request.delete(`${daemon.baseUrl}/api/inbox/@${ulid}`);
       expect(deleteResponse.status()).toBe(200);
       const body = await deleteResponse.json();
       expect(body.success).toBe(true);
@@ -293,7 +291,7 @@ test.describe('Inbox API', () => {
       daemon,
     }) => {
       const response = await request.delete(
-        `${DAEMON_URL}/api/inbox/@nonexistent-inbox-ref-xyz`
+        `${daemon.baseUrl}/api/inbox/@nonexistent-inbox-ref-xyz`
       );
       expect(response.status()).toBe(404);
 
@@ -311,7 +309,7 @@ test.describe('Inbox API', () => {
       // Use the third fixture item (oldest) to avoid affecting ordering tests
       const ulid = '01KJNBX2CB8N4YGP991WD7XS9R';
 
-      const deleteResponse = await request.delete(`${DAEMON_URL}/api/inbox/@${ulid}`);
+      const deleteResponse = await request.delete(`${daemon.baseUrl}/api/inbox/@${ulid}`);
       expect(deleteResponse.status()).toBe(200);
 
       const body = await deleteResponse.json();
@@ -319,7 +317,7 @@ test.describe('Inbox API', () => {
       expect(body.deleted).toBe(ulid);
 
       // Verify list now has 2 items
-      const listResponse = await request.get(`${DAEMON_URL}/api/inbox`);
+      const listResponse = await request.get(`${daemon.baseUrl}/api/inbox`);
       const list = await listResponse.json();
       expect(list.items.length).toBe(2);
     });
@@ -334,13 +332,13 @@ test.describe('Inbox API', () => {
       // Wait a moment to ensure new item has a later timestamp
       await new Promise((r) => setTimeout(r, 10));
 
-      const response = await request.post(`${DAEMON_URL}/api/inbox`, {
+      const response = await request.post(`${daemon.baseUrl}/api/inbox`, {
         data: { text: 'Should be at top' },
       });
       expect(response.status()).toBe(200);
       const created = await response.json();
 
-      const listResponse = await request.get(`${DAEMON_URL}/api/inbox`);
+      const listResponse = await request.get(`${daemon.baseUrl}/api/inbox`);
       const list = await listResponse.json();
 
       // Newest item should be first since fixture items are from 2026-01-01

--- a/packages/web-ui/tests/e2e/api-items.spec.ts
+++ b/packages/web-ui/tests/e2e/api-items.spec.ts
@@ -14,13 +14,11 @@
 
 import { test, expect } from '../fixtures/test-base';
 
-const DAEMON_URL = 'http://localhost:3456';
-
 test.describe('Items API', () => {
   test.describe('GET /api/items', () => {
     // AC: @api-contract ac-8
     test('returns spec items with required fields', async ({ request, daemon }) => {
-      const response = await request.get(`${DAEMON_URL}/api/items`);
+      const response = await request.get(`${daemon.baseUrl}/api/items`);
 
       expect(response.status()).toBe(200);
 
@@ -47,7 +45,7 @@ test.describe('Items API', () => {
       request,
       daemon,
     }) => {
-      const response = await request.get(`${DAEMON_URL}/api/items`);
+      const response = await request.get(`${daemon.baseUrl}/api/items`);
       expect(response.status()).toBe(200);
 
       const body = await response.json();
@@ -63,7 +61,7 @@ test.describe('Items API', () => {
 
     // AC: @api-contract ac-8 - slugs field is present
     test('items include slugs array', async ({ request, daemon }) => {
-      const response = await request.get(`${DAEMON_URL}/api/items`);
+      const response = await request.get(`${daemon.baseUrl}/api/items`);
       expect(response.status()).toBe(200);
 
       const body = await response.json();
@@ -76,7 +74,7 @@ test.describe('Items API', () => {
 
     // AC: @api-contract ac-9 - single type filter
     test('filters items by single type value', async ({ request, daemon }) => {
-      const response = await request.get(`${DAEMON_URL}/api/items?type=feature`);
+      const response = await request.get(`${daemon.baseUrl}/api/items?type=feature`);
       expect(response.status()).toBe(200);
 
       const body = await response.json();
@@ -95,7 +93,7 @@ test.describe('Items API', () => {
       request,
       daemon,
     }) => {
-      const response = await request.get(`${DAEMON_URL}/api/items?type=feature&type=requirement`);
+      const response = await request.get(`${daemon.baseUrl}/api/items?type=feature&type=requirement`);
       expect(response.status()).toBe(200);
 
       const body = await response.json();
@@ -116,7 +114,7 @@ test.describe('Items API', () => {
     // AC: @api-contract ac-9 - type filter excludes non-matching types
     test('type filter excludes items of non-matching types', async ({ request, daemon }) => {
       // Filter for only modules — should not return features or requirements
-      const response = await request.get(`${DAEMON_URL}/api/items?type=module`);
+      const response = await request.get(`${daemon.baseUrl}/api/items?type=module`);
       expect(response.status()).toBe(200);
 
       const body = await response.json();
@@ -135,7 +133,7 @@ test.describe('Items API', () => {
       request,
       daemon,
     }) => {
-      const response = await request.get(`${DAEMON_URL}/api/items?offset=0&limit=2`);
+      const response = await request.get(`${daemon.baseUrl}/api/items?offset=0&limit=2`);
       expect(response.status()).toBe(200);
 
       const body = await response.json();
@@ -153,16 +151,16 @@ test.describe('Items API', () => {
     // AC: @api-contract ac-8 (pagination) - pagination offsets work
     test('respects offset parameter for pagination', async ({ request, daemon }) => {
       // Get total count first
-      const allResponse = await request.get(`${DAEMON_URL}/api/items`);
+      const allResponse = await request.get(`${daemon.baseUrl}/api/items`);
       const allBody = await allResponse.json();
       const total = allBody.total;
 
       // Only test pagination if there are more than 2 items
       if (total > 2) {
-        const page1 = await request.get(`${DAEMON_URL}/api/items?offset=0&limit=2`);
+        const page1 = await request.get(`${daemon.baseUrl}/api/items?offset=0&limit=2`);
         const body1 = await page1.json();
 
-        const page2 = await request.get(`${DAEMON_URL}/api/items?offset=2&limit=2`);
+        const page2 = await request.get(`${daemon.baseUrl}/api/items?offset=2&limit=2`);
         const body2 = await page2.json();
 
         // Pages should have different items
@@ -182,7 +180,7 @@ test.describe('Items API', () => {
     // AC: @api-contract ac-10 - resolve item by slug
     test('resolves item by slug and returns full item', async ({ request, daemon }) => {
       // Use known fixture slug
-      const response = await request.get(`${DAEMON_URL}/api/items/@test-feature`);
+      const response = await request.get(`${daemon.baseUrl}/api/items/@test-feature`);
       expect(response.status()).toBe(200);
 
       const item = await response.json();
@@ -196,7 +194,7 @@ test.describe('Items API', () => {
     // AC: @api-contract ac-10 - returns acceptance_criteria
     test('returns item with acceptance_criteria array', async ({ request, daemon }) => {
       // test-feature has 2 ACs in the fixture
-      const response = await request.get(`${DAEMON_URL}/api/items/@test-feature`);
+      const response = await request.get(`${daemon.baseUrl}/api/items/@test-feature`);
       expect(response.status()).toBe(200);
 
       const item = await response.json();
@@ -214,7 +212,7 @@ test.describe('Items API', () => {
     // AC: @api-contract ac-10 - returns traits
     test('returns item with traits array', async ({ request, daemon }) => {
       // test-feature has the @test-trait in its traits
-      const response = await request.get(`${DAEMON_URL}/api/items/@test-feature`);
+      const response = await request.get(`${daemon.baseUrl}/api/items/@test-feature`);
       expect(response.status()).toBe(200);
 
       const item = await response.json();
@@ -227,7 +225,7 @@ test.describe('Items API', () => {
 
     // AC: @api-contract ac-10 - returns description
     test('returns item with description field', async ({ request, daemon }) => {
-      const response = await request.get(`${DAEMON_URL}/api/items/@test-feature`);
+      const response = await request.get(`${daemon.baseUrl}/api/items/@test-feature`);
       expect(response.status()).toBe(200);
 
       const item = await response.json();
@@ -239,7 +237,7 @@ test.describe('Items API', () => {
     // AC: @api-contract ac-10 - resolve by full ULID
     test('resolves item by full ULID', async ({ request, daemon }) => {
       // First, get the item list to find a ULID
-      const listResponse = await request.get(`${DAEMON_URL}/api/items?type=feature`);
+      const listResponse = await request.get(`${daemon.baseUrl}/api/items?type=feature`);
       const listBody = await listResponse.json();
       expect(listBody.items.length).toBeGreaterThan(0);
 
@@ -247,7 +245,7 @@ test.describe('Items API', () => {
       expect(firstItem._ulid).toBeTruthy();
 
       // Get by full ULID
-      const response = await request.get(`${DAEMON_URL}/api/items/@${firstItem._ulid}`);
+      const response = await request.get(`${daemon.baseUrl}/api/items/@${firstItem._ulid}`);
       expect(response.status()).toBe(200);
 
       const item = await response.json();
@@ -257,7 +255,7 @@ test.describe('Items API', () => {
 
     // AC: @api-contract ac-10 (error handling) - 404 for invalid ref
     test('returns 404 for non-existent item ref', async ({ request, daemon }) => {
-      const response = await request.get(`${DAEMON_URL}/api/items/@nonexistent-item-xyz`);
+      const response = await request.get(`${daemon.baseUrl}/api/items/@nonexistent-item-xyz`);
       expect(response.status()).toBe(404);
 
       const body = await response.json();
@@ -269,7 +267,7 @@ test.describe('Items API', () => {
 
     // AC: @api-contract ac-10 - returns JSON content type
     test('returns JSON content type', async ({ request, daemon }) => {
-      const response = await request.get(`${DAEMON_URL}/api/items/@test-feature`);
+      const response = await request.get(`${daemon.baseUrl}/api/items/@test-feature`);
       expect(response.status()).toBe(200);
 
       const contentType = response.headers()['content-type'] || '';
@@ -281,7 +279,7 @@ test.describe('Items API', () => {
     // AC: @api-contract ac-11 - returns tasks linked via AlignmentIndex
     test('returns tasks linked to spec item', async ({ request, daemon }) => {
       // test-feature has tasks with spec_ref: "@test-feature" in the fixture
-      const response = await request.get(`${DAEMON_URL}/api/items/@test-feature/tasks`);
+      const response = await request.get(`${daemon.baseUrl}/api/items/@test-feature/tasks`);
       expect(response.status()).toBe(200);
 
       const body = await response.json();
@@ -294,7 +292,7 @@ test.describe('Items API', () => {
 
     // AC: @api-contract ac-11 - linked tasks have summary fields
     test('linked tasks include required summary fields', async ({ request, daemon }) => {
-      const response = await request.get(`${DAEMON_URL}/api/items/@test-feature/tasks`);
+      const response = await request.get(`${daemon.baseUrl}/api/items/@test-feature/tasks`);
       expect(response.status()).toBe(200);
 
       const body = await response.json();
@@ -310,7 +308,7 @@ test.describe('Items API', () => {
 
     // AC: @api-contract ac-11 - total matches items count
     test('total matches number of linked tasks', async ({ request, daemon }) => {
-      const response = await request.get(`${DAEMON_URL}/api/items/@test-feature/tasks`);
+      const response = await request.get(`${daemon.baseUrl}/api/items/@test-feature/tasks`);
       expect(response.status()).toBe(200);
 
       const body = await response.json();
@@ -322,7 +320,7 @@ test.describe('Items API', () => {
       request,
       daemon,
     }) => {
-      const response = await request.get(`${DAEMON_URL}/api/items/@test-feature/tasks`);
+      const response = await request.get(`${daemon.baseUrl}/api/items/@test-feature/tasks`);
       expect(response.status()).toBe(200);
 
       const body = await response.json();
@@ -336,7 +334,7 @@ test.describe('Items API', () => {
 
     // AC: @api-contract ac-11 (error handling) - 404 for invalid ref
     test('returns 404 for non-existent item ref', async ({ request, daemon }) => {
-      const response = await request.get(`${DAEMON_URL}/api/items/@nonexistent-item-xyz/tasks`);
+      const response = await request.get(`${daemon.baseUrl}/api/items/@nonexistent-item-xyz/tasks`);
       expect(response.status()).toBe(404);
 
       const body = await response.json();
@@ -350,7 +348,7 @@ test.describe('Items API', () => {
       daemon,
     }) => {
       // test-trait is a trait with no tasks linked to it
-      const response = await request.get(`${DAEMON_URL}/api/items/@test-trait/tasks`);
+      const response = await request.get(`${daemon.baseUrl}/api/items/@test-trait/tasks`);
       expect(response.status()).toBe(200);
 
       const body = await response.json();
@@ -365,7 +363,7 @@ test.describe('Items API', () => {
   test.describe('Content-Type and Response Format', () => {
     // AC: @api-contract ac-8 - JSON content type for GET /api/items
     test('returns JSON content type for list endpoint', async ({ request, daemon }) => {
-      const response = await request.get(`${DAEMON_URL}/api/items`);
+      const response = await request.get(`${daemon.baseUrl}/api/items`);
       expect(response.status()).toBe(200);
 
       const contentType = response.headers()['content-type'] || '';
@@ -375,7 +373,7 @@ test.describe('Items API', () => {
     // AC: @api-contract ac-8, ac-10 - list and detail responses consistent
     test('list and detail responses have consistent item fields', async ({ request, daemon }) => {
       // Get list
-      const listResponse = await request.get(`${DAEMON_URL}/api/items?type=feature`);
+      const listResponse = await request.get(`${daemon.baseUrl}/api/items?type=feature`);
       const listBody = await listResponse.json();
       expect(listBody.items.length).toBeGreaterThan(0);
 
@@ -383,7 +381,7 @@ test.describe('Items API', () => {
       expect(listItem._ulid).toBeTruthy();
 
       // Get detail by ULID
-      const detailResponse = await request.get(`${DAEMON_URL}/api/items/@${listItem._ulid}`);
+      const detailResponse = await request.get(`${daemon.baseUrl}/api/items/@${listItem._ulid}`);
       expect(detailResponse.status()).toBe(200);
       const detailItem = await detailResponse.json();
 

--- a/packages/web-ui/tests/e2e/api-meta.spec.ts
+++ b/packages/web-ui/tests/e2e/api-meta.spec.ts
@@ -55,8 +55,6 @@
 
 import { test, expect } from '../fixtures/test-base';
 
-const DAEMON_URL = 'http://localhost:3456';
-
 test.describe('Meta API', () => {
   test.describe('GET /api/meta/session', () => {
     // AC: @api-contract ac-15
@@ -64,7 +62,7 @@ test.describe('Meta API', () => {
       request,
       daemon,
     }) => {
-      const response = await request.get(`${DAEMON_URL}/api/meta/session`);
+      const response = await request.get(`${daemon.baseUrl}/api/meta/session`);
 
       expect(response.status()).toBe(200);
 
@@ -82,7 +80,7 @@ test.describe('Meta API', () => {
 
     // AC: @api-contract ac-15 - fixture data integrity
     test('returns fixture session context values', async ({ request, daemon }) => {
-      const response = await request.get(`${DAEMON_URL}/api/meta/session`);
+      const response = await request.get(`${daemon.baseUrl}/api/meta/session`);
       expect(response.status()).toBe(200);
 
       const body = await response.json();
@@ -94,7 +92,7 @@ test.describe('Meta API', () => {
 
     // AC: @api-contract ac-15 - JSON content type
     test('returns JSON content type', async ({ request, daemon }) => {
-      const response = await request.get(`${DAEMON_URL}/api/meta/session`);
+      const response = await request.get(`${daemon.baseUrl}/api/meta/session`);
       const contentType = response.headers()['content-type'] || '';
       expect(contentType).toContain('application/json');
     });
@@ -103,7 +101,7 @@ test.describe('Meta API', () => {
   test.describe('GET /api/meta/agents', () => {
     // AC: @api-contract ac-16
     test('returns paginated response with items and total', async ({ request, daemon }) => {
-      const response = await request.get(`${DAEMON_URL}/api/meta/agents`);
+      const response = await request.get(`${daemon.baseUrl}/api/meta/agents`);
 
       expect(response.status()).toBe(200);
 
@@ -117,7 +115,7 @@ test.describe('Meta API', () => {
 
     // AC: @api-contract ac-16 - fixture data consistency
     test('items count matches total field', async ({ request, daemon }) => {
-      const response = await request.get(`${DAEMON_URL}/api/meta/agents`);
+      const response = await request.get(`${daemon.baseUrl}/api/meta/agents`);
       expect(response.status()).toBe(200);
 
       const body = await response.json();
@@ -131,7 +129,7 @@ test.describe('Meta API', () => {
   test.describe('GET /api/meta/workflows', () => {
     // AC: @api-contract ac-17
     test('returns paginated response with items and total', async ({ request, daemon }) => {
-      const response = await request.get(`${DAEMON_URL}/api/meta/workflows`);
+      const response = await request.get(`${daemon.baseUrl}/api/meta/workflows`);
 
       expect(response.status()).toBe(200);
 
@@ -145,7 +143,7 @@ test.describe('Meta API', () => {
 
     // AC: @api-contract ac-17 - fixture data consistency
     test('items count matches total field', async ({ request, daemon }) => {
-      const response = await request.get(`${DAEMON_URL}/api/meta/workflows`);
+      const response = await request.get(`${daemon.baseUrl}/api/meta/workflows`);
       expect(response.status()).toBe(200);
 
       const body = await response.json();
@@ -159,7 +157,7 @@ test.describe('Meta API', () => {
   test.describe('GET /api/meta/observations', () => {
     // AC: @api-contract ac-18
     test('returns all observations without filter', async ({ request, daemon }) => {
-      const response = await request.get(`${DAEMON_URL}/api/meta/observations`);
+      const response = await request.get(`${daemon.baseUrl}/api/meta/observations`);
 
       expect(response.status()).toBe(200);
 
@@ -175,7 +173,7 @@ test.describe('Meta API', () => {
 
     // AC: @api-contract ac-18 - each observation has required fields
     test('observations have required fields', async ({ request, daemon }) => {
-      const response = await request.get(`${DAEMON_URL}/api/meta/observations`);
+      const response = await request.get(`${daemon.baseUrl}/api/meta/observations`);
       expect(response.status()).toBe(200);
 
       const body = await response.json();
@@ -193,7 +191,7 @@ test.describe('Meta API', () => {
       request,
       daemon,
     }) => {
-      const response = await request.get(`${DAEMON_URL}/api/meta/observations`);
+      const response = await request.get(`${daemon.baseUrl}/api/meta/observations`);
       expect(response.status()).toBe(200);
 
       const body = await response.json();
@@ -210,7 +208,7 @@ test.describe('Meta API', () => {
 
     // AC: @api-contract ac-18 - filter by resolved=false returns unresolved
     test('filters unresolved observations with ?resolved=false', async ({ request, daemon }) => {
-      const response = await request.get(`${DAEMON_URL}/api/meta/observations?resolved=false`);
+      const response = await request.get(`${daemon.baseUrl}/api/meta/observations?resolved=false`);
 
       expect(response.status()).toBe(200);
 
@@ -227,7 +225,7 @@ test.describe('Meta API', () => {
 
     // AC: @api-contract ac-18 - filter by resolved=true returns no results (fixture has none)
     test('filters resolved observations with ?resolved=true', async ({ request, daemon }) => {
-      const response = await request.get(`${DAEMON_URL}/api/meta/observations?resolved=true`);
+      const response = await request.get(`${daemon.baseUrl}/api/meta/observations?resolved=true`);
 
       expect(response.status()).toBe(200);
 
@@ -240,7 +238,7 @@ test.describe('Meta API', () => {
 
     // AC: @api-contract ac-18 - fixture content check
     test('returns fixture observations with correct content', async ({ request, daemon }) => {
-      const response = await request.get(`${DAEMON_URL}/api/meta/observations`);
+      const response = await request.get(`${daemon.baseUrl}/api/meta/observations`);
       expect(response.status()).toBe(200);
 
       const body = await response.json();
@@ -263,7 +261,7 @@ test.describe('Search API', () => {
   test.describe('GET /api/search', () => {
     // AC: @api-contract ac-19
     test('returns search results with results array and total', async ({ request, daemon }) => {
-      const response = await request.get(`${DAEMON_URL}/api/search?q=test`);
+      const response = await request.get(`${daemon.baseUrl}/api/search?q=test`);
 
       expect(response.status()).toBe(200);
 
@@ -276,7 +274,7 @@ test.describe('Search API', () => {
 
     // AC: @api-contract ac-19 - each result has type, ulid, title, matchedFields
     test('each search result has required fields', async ({ request, daemon }) => {
-      const response = await request.get(`${DAEMON_URL}/api/search?q=test`);
+      const response = await request.get(`${daemon.baseUrl}/api/search?q=test`);
       expect(response.status()).toBe(200);
 
       const body = await response.json();
@@ -293,7 +291,7 @@ test.describe('Search API', () => {
     // AC: @api-contract ac-19 - searches across spec items
     test('finds spec items matching query', async ({ request, daemon }) => {
       // Fixture has "Test Feature", "Test Requirement", etc. matching "Core"
-      const response = await request.get(`${DAEMON_URL}/api/search?q=Core+Module`);
+      const response = await request.get(`${daemon.baseUrl}/api/search?q=Core+Module`);
       expect(response.status()).toBe(200);
 
       const body = await response.json();
@@ -306,7 +304,7 @@ test.describe('Search API', () => {
     // AC: @api-contract ac-19 - searches across tasks
     test('finds tasks matching query', async ({ request, daemon }) => {
       // Fixture has "Ready task", "In progress task", etc.
-      const response = await request.get(`${DAEMON_URL}/api/search?q=Ready+task`);
+      const response = await request.get(`${daemon.baseUrl}/api/search?q=Ready+task`);
       expect(response.status()).toBe(200);
 
       const body = await response.json();
@@ -318,7 +316,7 @@ test.describe('Search API', () => {
     // AC: @api-contract ac-19 - searches inbox items
     test('finds inbox items matching query', async ({ request, daemon }) => {
       // Fixture inbox has "First inbox item for testing"
-      const response = await request.get(`${DAEMON_URL}/api/search?q=First+inbox+item`);
+      const response = await request.get(`${daemon.baseUrl}/api/search?q=First+inbox+item`);
       expect(response.status()).toBe(200);
 
       const body = await response.json();
@@ -329,7 +327,7 @@ test.describe('Search API', () => {
     // AC: @api-contract ac-19 - searches meta entities (observations)
     test('finds observations matching query', async ({ request, daemon }) => {
       // Fixture has "Test friction observation"
-      const response = await request.get(`${DAEMON_URL}/api/search?q=friction+observation`);
+      const response = await request.get(`${daemon.baseUrl}/api/search?q=friction+observation`);
       expect(response.status()).toBe(200);
 
       const body = await response.json();
@@ -342,7 +340,7 @@ test.describe('Search API', () => {
     // AC: @api-contract ac-19 - returns empty results for no match
     test('returns empty results for non-matching query', async ({ request, daemon }) => {
       const response = await request.get(
-        `${DAEMON_URL}/api/search?q=zzznomatch_unique_xyz_99999`
+        `${daemon.baseUrl}/api/search?q=zzznomatch_unique_xyz_99999`
       );
       expect(response.status()).toBe(200);
 
@@ -353,7 +351,7 @@ test.describe('Search API', () => {
 
     // AC: @api-contract ac-19 - returns empty results for empty query
     test('returns empty results when no query provided', async ({ request, daemon }) => {
-      const response = await request.get(`${DAEMON_URL}/api/search`);
+      const response = await request.get(`${daemon.baseUrl}/api/search`);
       expect(response.status()).toBe(200);
 
       const body = await response.json();
@@ -363,7 +361,7 @@ test.describe('Search API', () => {
 
     // AC: @api-contract ac-19 - result types are from known set
     test('result types are from known entity types', async ({ request, daemon }) => {
-      const response = await request.get(`${DAEMON_URL}/api/search?q=test`);
+      const response = await request.get(`${daemon.baseUrl}/api/search?q=test`);
       expect(response.status()).toBe(200);
 
       const body = await response.json();
@@ -376,7 +374,7 @@ test.describe('Search API', () => {
 
     // AC: @api-contract ac-19 - limit parameter restricts results
     test('limits results with ?limit parameter', async ({ request, daemon }) => {
-      const response = await request.get(`${DAEMON_URL}/api/search?q=test&limit=2`);
+      const response = await request.get(`${daemon.baseUrl}/api/search?q=test&limit=2`);
       expect(response.status()).toBe(200);
 
       const body = await response.json();
@@ -388,7 +386,7 @@ test.describe('Search API', () => {
 
     // AC: @api-contract ac-19 - showing field
     test('includes showing field in response', async ({ request, daemon }) => {
-      const response = await request.get(`${DAEMON_URL}/api/search?q=test`);
+      const response = await request.get(`${daemon.baseUrl}/api/search?q=test`);
       expect(response.status()).toBe(200);
 
       const body = await response.json();
@@ -402,7 +400,7 @@ test.describe('Validation API', () => {
   test.describe('GET /api/validate', () => {
     // AC: @api-contract ac-20
     test('returns ValidationResult with required fields', async ({ request, daemon }) => {
-      const response = await request.get(`${DAEMON_URL}/api/validate`);
+      const response = await request.get(`${daemon.baseUrl}/api/validate`);
 
       expect(response.status()).toBe(200);
 
@@ -422,7 +420,7 @@ test.describe('Validation API', () => {
 
     // AC: @api-contract ac-20 - fixture data is valid
     test('fixture data passes validation', async ({ request, daemon }) => {
-      const response = await request.get(`${DAEMON_URL}/api/validate`);
+      const response = await request.get(`${daemon.baseUrl}/api/validate`);
       expect(response.status()).toBe(200);
 
       const body = await response.json();
@@ -433,7 +431,7 @@ test.describe('Validation API', () => {
 
     // AC: @api-contract ac-20 - includes refWarnings and completenessWarnings
     test('includes refWarnings and completenessWarnings fields', async ({ request, daemon }) => {
-      const response = await request.get(`${DAEMON_URL}/api/validate`);
+      const response = await request.get(`${daemon.baseUrl}/api/validate`);
       expect(response.status()).toBe(200);
 
       const body = await response.json();
@@ -446,7 +444,7 @@ test.describe('Validation API', () => {
 
     // AC: @api-contract ac-20 - includes traitCycles field
     test('includes traitCycles field', async ({ request, daemon }) => {
-      const response = await request.get(`${DAEMON_URL}/api/validate`);
+      const response = await request.get(`${daemon.baseUrl}/api/validate`);
       expect(response.status()).toBe(200);
 
       const body = await response.json();
@@ -456,7 +454,7 @@ test.describe('Validation API', () => {
 
     // AC: @api-contract ac-20 - JSON content type
     test('returns JSON content type', async ({ request, daemon }) => {
-      const response = await request.get(`${DAEMON_URL}/api/validate`);
+      const response = await request.get(`${daemon.baseUrl}/api/validate`);
       const contentType = response.headers()['content-type'] || '';
       expect(contentType).toContain('application/json');
     });
@@ -465,7 +463,7 @@ test.describe('Validation API', () => {
   test.describe('GET /api/alignment', () => {
     // AC: @api-contract ac-21
     test('returns alignment stats and warnings', async ({ request, daemon }) => {
-      const response = await request.get(`${DAEMON_URL}/api/alignment`);
+      const response = await request.get(`${daemon.baseUrl}/api/alignment`);
 
       expect(response.status()).toBe(200);
 
@@ -478,7 +476,7 @@ test.describe('Validation API', () => {
 
     // AC: @api-contract ac-21 - stats has required fields
     test('stats contains required alignment fields', async ({ request, daemon }) => {
-      const response = await request.get(`${DAEMON_URL}/api/alignment`);
+      const response = await request.get(`${daemon.baseUrl}/api/alignment`);
       expect(response.status()).toBe(200);
 
       const body = await response.json();
@@ -497,7 +495,7 @@ test.describe('Validation API', () => {
 
     // AC: @api-contract ac-21 - stats values are non-negative
     test('alignment stats values are non-negative integers', async ({ request, daemon }) => {
-      const response = await request.get(`${DAEMON_URL}/api/alignment`);
+      const response = await request.get(`${daemon.baseUrl}/api/alignment`);
       expect(response.status()).toBe(200);
 
       const body = await response.json();
@@ -511,7 +509,7 @@ test.describe('Validation API', () => {
 
     // AC: @api-contract ac-21 - fixture has spec items
     test('fixture has spec items reflected in totalSpecs', async ({ request, daemon }) => {
-      const response = await request.get(`${DAEMON_URL}/api/alignment`);
+      const response = await request.get(`${daemon.baseUrl}/api/alignment`);
       expect(response.status()).toBe(200);
 
       const body = await response.json();
@@ -521,7 +519,7 @@ test.describe('Validation API', () => {
 
     // AC: @api-contract ac-21 - JSON content type
     test('returns JSON content type', async ({ request, daemon }) => {
-      const response = await request.get(`${DAEMON_URL}/api/alignment`);
+      const response = await request.get(`${daemon.baseUrl}/api/alignment`);
       const contentType = response.headers()['content-type'] || '';
       expect(contentType).toContain('application/json');
     });

--- a/packages/web-ui/tests/e2e/api-projects.spec.ts
+++ b/packages/web-ui/tests/e2e/api-projects.spec.ts
@@ -26,8 +26,6 @@
 
 import { test, expect } from '../fixtures/test-base';
 
-const DAEMON_URL = 'http://localhost:3456';
-
 test.describe('Projects API', () => {
   test.describe('GET /api/projects', () => {
     // AC: @multi-directory-daemon ac-28
@@ -35,7 +33,7 @@ test.describe('Projects API', () => {
       request,
       daemon,
     }) => {
-      const response = await request.get(`${DAEMON_URL}/api/projects`);
+      const response = await request.get(`${daemon.baseUrl}/api/projects`);
 
       expect(response.status()).toBe(200);
 
@@ -55,7 +53,7 @@ test.describe('Projects API', () => {
       request,
       daemon,
     }) => {
-      const response = await request.get(`${DAEMON_URL}/api/projects`);
+      const response = await request.get(`${daemon.baseUrl}/api/projects`);
       expect(response.status()).toBe(200);
 
       const body = await response.json();
@@ -79,7 +77,7 @@ test.describe('Projects API', () => {
 
     // AC: @multi-directory-daemon ac-28
     test('returns JSON content type', async ({ request, daemon }) => {
-      const response = await request.get(`${DAEMON_URL}/api/projects`);
+      const response = await request.get(`${daemon.baseUrl}/api/projects`);
       expect(response.status()).toBe(200);
 
       const contentType = response.headers()['content-type'] || '';
@@ -88,7 +86,7 @@ test.describe('Projects API', () => {
 
     // AC: @multi-directory-daemon ac-28 — default project path is absolute
     test('project paths are absolute filesystem paths', async ({ request, daemon }) => {
-      const response = await request.get(`${DAEMON_URL}/api/projects`);
+      const response = await request.get(`${daemon.baseUrl}/api/projects`);
       expect(response.status()).toBe(200);
 
       const body = await response.json();
@@ -103,7 +101,7 @@ test.describe('Projects API', () => {
       // Register a second project
       const secondPath = await daemon.createSecondProject();
 
-      const response = await request.get(`${DAEMON_URL}/api/projects`);
+      const response = await request.get(`${daemon.baseUrl}/api/projects`);
       expect(response.status()).toBe(200);
 
       const body = await response.json();
@@ -132,10 +130,10 @@ test.describe('Projects API', () => {
 
       // Unregister so we can re-register and capture the direct POST response
       const encodedPath = encodeURIComponent(secondPath);
-      await request.delete(`${DAEMON_URL}/api/projects/${encodedPath}`);
+      await request.delete(`${daemon.baseUrl}/api/projects/${encodedPath}`);
 
       // AC: @multi-directory-daemon ac-29 — POST with {path} body, verify response shape
-      const registerResponse = await request.post(`${DAEMON_URL}/api/projects`, {
+      const registerResponse = await request.post(`${daemon.baseUrl}/api/projects`, {
         data: { path: secondPath },
       });
 
@@ -159,7 +157,7 @@ test.describe('Projects API', () => {
     // (Note: ac-6/ac-7/ac-5 are for X-Kspec-Dir header validation; POST /api/projects
     // mirrors those rules for the request body {path} field as part of ac-29 path validation)
     test('returns 400 when path is not absolute', async ({ request, daemon }) => {
-      const response = await request.post(`${DAEMON_URL}/api/projects`, {
+      const response = await request.post(`${daemon.baseUrl}/api/projects`, {
         data: { path: 'relative/path/without/slash' },
       });
 
@@ -172,7 +170,7 @@ test.describe('Projects API', () => {
 
     // AC: @multi-directory-daemon ac-29 — POST /api/projects rejects parent traversal in path
     test('returns 400 when path contains ".." segments', async ({ request, daemon }) => {
-      const response = await request.post(`${DAEMON_URL}/api/projects`, {
+      const response = await request.post(`${daemon.baseUrl}/api/projects`, {
         data: { path: '/tmp/../etc' },
       });
 
@@ -185,7 +183,7 @@ test.describe('Projects API', () => {
 
     // AC: @multi-directory-daemon ac-29 — POST /api/projects rejects paths without .kspec/
     test('returns 400 for path without .kspec/ directory', async ({ request, daemon }) => {
-      const response = await request.post(`${DAEMON_URL}/api/projects`, {
+      const response = await request.post(`${daemon.baseUrl}/api/projects`, {
         data: { path: '/tmp' }, // /tmp exists but has no .kspec/
       });
 
@@ -203,7 +201,7 @@ test.describe('Projects API', () => {
     }) => {
       const secondPath = await daemon.createSecondProject();
 
-      const listResponse = await request.get(`${DAEMON_URL}/api/projects`);
+      const listResponse = await request.get(`${daemon.baseUrl}/api/projects`);
       expect(listResponse.status()).toBe(200);
 
       const listBody = await listResponse.json();
@@ -226,7 +224,7 @@ test.describe('Projects API', () => {
 
       // AC: @multi-directory-daemon ac-30 — DELETE to unregister
       const response = await request.delete(
-        `${DAEMON_URL}/api/projects/${encodedPath}`
+        `${daemon.baseUrl}/api/projects/${encodedPath}`
       );
 
       expect(response.status()).toBe(200);
@@ -245,7 +243,7 @@ test.describe('Projects API', () => {
       const secondPath = await daemon.createSecondProject();
 
       // Verify it's registered
-      const beforeResponse = await request.get(`${DAEMON_URL}/api/projects`);
+      const beforeResponse = await request.get(`${daemon.baseUrl}/api/projects`);
       const beforeBody = await beforeResponse.json();
       const foundBefore = beforeBody.projects.find(
         (p: { path: string }) => p.path === secondPath
@@ -255,12 +253,12 @@ test.describe('Projects API', () => {
       // Unregister it
       const encodedPath = encodeURIComponent(secondPath);
       const deleteResponse = await request.delete(
-        `${DAEMON_URL}/api/projects/${encodedPath}`
+        `${daemon.baseUrl}/api/projects/${encodedPath}`
       );
       expect(deleteResponse.status()).toBe(200);
 
       // Verify it's gone from the list
-      const afterResponse = await request.get(`${DAEMON_URL}/api/projects`);
+      const afterResponse = await request.get(`${daemon.baseUrl}/api/projects`);
       const afterBody = await afterResponse.json();
       const foundAfter = afterBody.projects.find(
         (p: { path: string }) => p.path === secondPath
@@ -277,7 +275,7 @@ test.describe('Projects API', () => {
       const encodedPath = encodeURIComponent(fakePath);
 
       const response = await request.delete(
-        `${DAEMON_URL}/api/projects/${encodedPath}`
+        `${daemon.baseUrl}/api/projects/${encodedPath}`
       );
 
       expect(response.status()).toBe(404);
@@ -298,7 +296,7 @@ test.describe('Projects API', () => {
       expect(encodedPath).not.toContain('/');
 
       const response = await request.delete(
-        `${DAEMON_URL}/api/projects/${encodedPath}`
+        `${daemon.baseUrl}/api/projects/${encodedPath}`
       );
 
       // Should successfully decode and delete
@@ -314,10 +312,10 @@ test.describe('Projects API', () => {
       const encodedPath = encodeURIComponent(secondPath);
 
       // Unregister (stops watcher as part of unregister)
-      await request.delete(`${DAEMON_URL}/api/projects/${encodedPath}`);
+      await request.delete(`${daemon.baseUrl}/api/projects/${encodedPath}`);
 
       // Project should not be in list (verifies cleanup happened)
-      const listResponse = await request.get(`${DAEMON_URL}/api/projects`);
+      const listResponse = await request.get(`${daemon.baseUrl}/api/projects`);
       const listBody = await listResponse.json();
       const found = listBody.projects.find(
         (p: { path: string }) => p.path === secondPath

--- a/packages/web-ui/tests/e2e/api-server.spec.ts
+++ b/packages/web-ui/tests/e2e/api-server.spec.ts
@@ -6,7 +6,7 @@
  * which only read source files and check string patterns.
  *
  * Covered ACs:
- * - @daemon-server ac-1: Elysia HTTP server starts on port 3456 (verified by health check)
+ * - @daemon-server ac-1: Elysia HTTP server starts on configured port (verified by health check)
  * - @daemon-server ac-2: Binds to localhost only (verified by daemon accessibility)
  * - @daemon-server ac-11: GET /api/health returns {status, uptime, connections, version}
  * - @daemon-server ac-15: Plugin pattern middleware (CORS verified via response headers)
@@ -49,9 +49,6 @@
 import { test, expect } from '../fixtures/test-base';
 import * as http from 'http';
 
-const DAEMON_PORT = 3456;
-const DAEMON_URL = `http://localhost:${DAEMON_PORT}`;
-
 /**
  * Make a raw HTTP request with explicit Host header control.
  * Node's built-in http.request allows overriding the Host header,
@@ -61,12 +58,13 @@ const DAEMON_URL = `http://localhost:${DAEMON_PORT}`;
 function rawHttpRequest(options: {
   path: string;
   host: string; // The Host header value to send
+  port: number;
 }): Promise<{ status: number; body: unknown }> {
   return new Promise((resolve, reject) => {
     const req = http.request(
       {
         hostname: 'localhost',
-        port: DAEMON_PORT,
+        port: options.port,
         path: options.path,
         method: 'GET',
         headers: {
@@ -105,7 +103,7 @@ test.describe('Server Core API', () => {
       request,
       daemon,
     }) => {
-      const response = await request.get(`${DAEMON_URL}/api/health`);
+      const response = await request.get(`${daemon.baseUrl}/api/health`);
 
       expect(response.status()).toBe(200);
 
@@ -126,13 +124,13 @@ test.describe('Server Core API', () => {
 
     // AC: @daemon-server ac-11
     test('uptime increases over time', async ({ request, daemon }) => {
-      const first = await request.get(`${DAEMON_URL}/api/health`);
+      const first = await request.get(`${daemon.baseUrl}/api/health`);
       const firstBody = await first.json();
 
       // Wait briefly to ensure uptime ticks
       await new Promise((r) => setTimeout(r, 100));
 
-      const second = await request.get(`${DAEMON_URL}/api/health`);
+      const second = await request.get(`${daemon.baseUrl}/api/health`);
       const secondBody = await second.json();
 
       expect(secondBody.uptime).toBeGreaterThanOrEqual(firstBody.uptime);
@@ -142,7 +140,7 @@ test.describe('Server Core API', () => {
   test.describe('CORS Headers', () => {
     // AC: @daemon-server ac-15, @api-contract ac-1
     test('allows requests from localhost:5173 origin', async ({ request, daemon }) => {
-      const response = await request.get(`${DAEMON_URL}/api/health`, {
+      const response = await request.get(`${daemon.baseUrl}/api/health`, {
         headers: {
           Origin: 'http://localhost:5173',
         },
@@ -158,7 +156,7 @@ test.describe('Server Core API', () => {
 
     // AC: @api-contract ac-1
     test('allows requests from 127.0.0.1:5173 origin', async ({ request, daemon }) => {
-      const response = await request.get(`${DAEMON_URL}/api/health`, {
+      const response = await request.get(`${daemon.baseUrl}/api/health`, {
         headers: {
           Origin: 'http://127.0.0.1:5173',
         },
@@ -173,7 +171,7 @@ test.describe('Server Core API', () => {
 
     // AC: @daemon-server ac-15, @api-contract ac-1
     test('supports credentials (CORS credentials mode)', async ({ request, daemon }) => {
-      const response = await request.fetch(`${DAEMON_URL}/api/health`, {
+      const response = await request.fetch(`${daemon.baseUrl}/api/health`, {
         method: 'OPTIONS',
         headers: {
           Origin: 'http://localhost:5173',
@@ -195,7 +193,7 @@ test.describe('Server Core API', () => {
     // If the daemon is not bound to localhost, none of the other E2E tests would pass.
     test('daemon is accessible from localhost (binding works)', async ({ request, daemon }) => {
       // AC: @daemon-server ac-1
-      const response = await request.get(`${DAEMON_URL}/api/health`);
+      const response = await request.get(`${daemon.baseUrl}/api/health`);
       expect(response.status()).toBe(200);
     });
 
@@ -207,6 +205,7 @@ test.describe('Server Core API', () => {
       const result = await rawHttpRequest({
         path: '/api/health',
         host: 'evil.example.com',
+        port: daemon.port,
       });
 
       expect(result.status).toBe(403);
@@ -222,7 +221,8 @@ test.describe('Server Core API', () => {
     test('rejects requests with external IP Host header with 403', async ({ daemon }) => {
       const result = await rawHttpRequest({
         path: '/api/health',
-        host: '192.168.1.100:3456',
+        host: `192.168.1.100:${daemon.port}`,
+        port: daemon.port,
       });
 
       expect(result.status).toBe(403);

--- a/packages/web-ui/tests/e2e/api-tasks.spec.ts
+++ b/packages/web-ui/tests/e2e/api-tasks.spec.ts
@@ -16,13 +16,11 @@
 
 import { test, expect } from '../fixtures/test-base';
 
-const DAEMON_URL = 'http://localhost:3456';
-
 test.describe('Tasks API', () => {
   test.describe('GET /api/tasks', () => {
     // AC: @api-contract ac-2
     test('returns tasks with required fields', async ({ request, daemon }) => {
-      const response = await request.get(`${DAEMON_URL}/api/tasks`);
+      const response = await request.get(`${daemon.baseUrl}/api/tasks`);
 
       expect(response.status()).toBe(200);
 
@@ -48,7 +46,7 @@ test.describe('Tasks API', () => {
 
     // AC: @api-contract ac-2 - spec_ref field
     test('returns spec_ref on tasks that have it', async ({ request, daemon }) => {
-      const response = await request.get(`${DAEMON_URL}/api/tasks`);
+      const response = await request.get(`${daemon.baseUrl}/api/tasks`);
       expect(response.status()).toBe(200);
 
       const body = await response.json();
@@ -67,7 +65,7 @@ test.describe('Tasks API', () => {
 
     // AC: @api-contract ac-3 - status filter (single value)
     test('filters tasks by single status value', async ({ request, daemon }) => {
-      const response = await request.get(`${DAEMON_URL}/api/tasks?status=pending`);
+      const response = await request.get(`${daemon.baseUrl}/api/tasks?status=pending`);
       expect(response.status()).toBe(200);
 
       const body = await response.json();
@@ -87,7 +85,7 @@ test.describe('Tasks API', () => {
       daemon,
     }) => {
       const response = await request.get(
-        `${DAEMON_URL}/api/tasks?status=pending&status=in_progress`
+        `${daemon.baseUrl}/api/tasks?status=pending&status=in_progress`
       );
       expect(response.status()).toBe(200);
 
@@ -105,7 +103,7 @@ test.describe('Tasks API', () => {
     // AC: @api-contract ac-3 - comma-separated status filter
     test('filters tasks by comma-separated status values', async ({ request, daemon }) => {
       const response = await request.get(
-        `${DAEMON_URL}/api/tasks?status=pending,in_progress`
+        `${daemon.baseUrl}/api/tasks?status=pending,in_progress`
       );
       expect(response.status()).toBe(200);
 
@@ -125,7 +123,7 @@ test.describe('Tasks API', () => {
       request,
       daemon,
     }) => {
-      const response = await request.get(`${DAEMON_URL}/api/tasks?offset=0&limit=2`);
+      const response = await request.get(`${daemon.baseUrl}/api/tasks?offset=0&limit=2`);
       expect(response.status()).toBe(200);
 
       const body = await response.json();
@@ -143,7 +141,7 @@ test.describe('Tasks API', () => {
     // AC: @api-contract ac-4 - pagination offset
     test('respects offset parameter for pagination', async ({ request, daemon }) => {
       // Get first page
-      const page1 = await request.get(`${DAEMON_URL}/api/tasks?offset=0&limit=2`);
+      const page1 = await request.get(`${daemon.baseUrl}/api/tasks?offset=0&limit=2`);
       expect(page1.status()).toBe(200);
       const body1 = await page1.json();
 
@@ -152,7 +150,7 @@ test.describe('Tasks API', () => {
       expect(body1.items.length).toBe(2);
 
       // Get second page
-      const page2 = await request.get(`${DAEMON_URL}/api/tasks?offset=2&limit=2`);
+      const page2 = await request.get(`${daemon.baseUrl}/api/tasks?offset=2&limit=2`);
       expect(page2.status()).toBe(200);
       const body2 = await page2.json();
 
@@ -167,8 +165,8 @@ test.describe('Tasks API', () => {
 
     // AC: @api-contract ac-4 - total count is consistent
     test('total count is consistent across paginated requests', async ({ request, daemon }) => {
-      const response1 = await request.get(`${DAEMON_URL}/api/tasks?offset=0&limit=2`);
-      const response2 = await request.get(`${DAEMON_URL}/api/tasks?offset=2&limit=2`);
+      const response1 = await request.get(`${daemon.baseUrl}/api/tasks?offset=0&limit=2`);
+      const response2 = await request.get(`${daemon.baseUrl}/api/tasks?offset=2&limit=2`);
 
       const body1 = await response1.json();
       const body2 = await response2.json();
@@ -182,7 +180,7 @@ test.describe('Tasks API', () => {
     // AC: @api-contract ac-5 - resolve by slug
     test('resolves task by slug and returns full task', async ({ request, daemon }) => {
       // Use a known task slug from fixtures
-      const response = await request.get(`${DAEMON_URL}/api/tasks/@test-task-ready`);
+      const response = await request.get(`${daemon.baseUrl}/api/tasks/@test-task-ready`);
       expect(response.status()).toBe(200);
 
       const task = await response.json();
@@ -198,7 +196,7 @@ test.describe('Tasks API', () => {
     // AC: @api-contract ac-5 - returns notes array
     test('returns task with notes array', async ({ request, daemon }) => {
       // test-task-in-progress has a note in the fixture
-      const response = await request.get(`${DAEMON_URL}/api/tasks/@test-task-in-progress`);
+      const response = await request.get(`${daemon.baseUrl}/api/tasks/@test-task-in-progress`);
       expect(response.status()).toBe(200);
 
       const task = await response.json();
@@ -214,7 +212,7 @@ test.describe('Tasks API', () => {
     // AC: @api-contract ac-5 - returns dependencies
     test('returns task with depends_on array', async ({ request, daemon }) => {
       // test-task-blocked depends on test-task-ready
-      const response = await request.get(`${DAEMON_URL}/api/tasks/@test-task-blocked`);
+      const response = await request.get(`${daemon.baseUrl}/api/tasks/@test-task-blocked`);
       expect(response.status()).toBe(200);
 
       const task = await response.json();
@@ -225,7 +223,7 @@ test.describe('Tasks API', () => {
     // AC: @api-contract ac-5 - resolve by full ULID
     test('resolves task by full ULID', async ({ request, daemon }) => {
       // First get the task list to find a ULID
-      const listResponse = await request.get(`${DAEMON_URL}/api/tasks`);
+      const listResponse = await request.get(`${daemon.baseUrl}/api/tasks`);
       const body = await listResponse.json();
       expect(body.items.length).toBeGreaterThan(0);
 
@@ -233,7 +231,7 @@ test.describe('Tasks API', () => {
       expect(firstTask._ulid).toBeTruthy();
 
       // Get by full ULID
-      const response = await request.get(`${DAEMON_URL}/api/tasks/@${firstTask._ulid}`);
+      const response = await request.get(`${daemon.baseUrl}/api/tasks/@${firstTask._ulid}`);
       expect(response.status()).toBe(200);
 
       const task = await response.json();
@@ -243,7 +241,7 @@ test.describe('Tasks API', () => {
 
     // AC: @api-contract ac-5 (error handling) - 404 for invalid ref
     test('returns 404 for non-existent task ref', async ({ request, daemon }) => {
-      const response = await request.get(`${DAEMON_URL}/api/tasks/@nonexistent-task-xyz`);
+      const response = await request.get(`${daemon.baseUrl}/api/tasks/@nonexistent-task-xyz`);
       expect(response.status()).toBe(404);
 
       const body = await response.json();
@@ -257,7 +255,7 @@ test.describe('Tasks API', () => {
     test('transitions pending task to in_progress', async ({ request, daemon }) => {
       // Use a fresh fixture — test-task-ready starts as pending (daemon fixture is test-scoped)
       const startResponse = await request.post(
-        `${DAEMON_URL}/api/tasks/@test-task-ready/start`,
+        `${daemon.baseUrl}/api/tasks/@test-task-ready/start`,
         { data: {} }
       );
       expect(startResponse.status()).toBe(200);
@@ -272,7 +270,7 @@ test.describe('Tasks API', () => {
     test('response includes full task shape after start', async ({ request, daemon }) => {
       // Each test gets a fresh daemon fixture (test-scoped), so test-task-ready is pending again
       const startResponse = await request.post(
-        `${DAEMON_URL}/api/tasks/@test-task-ready/start`,
+        `${daemon.baseUrl}/api/tasks/@test-task-ready/start`,
         { data: {} }
       );
       // Fresh fixture — test-task-ready must be pending, so this must return 200
@@ -289,7 +287,7 @@ test.describe('Tasks API', () => {
     // AC: @api-contract ac-6 (error handling) - 404 for invalid ref
     test('returns 404 for non-existent task', async ({ request, daemon }) => {
       const response = await request.post(
-        `${DAEMON_URL}/api/tasks/@nonexistent-task-xyz/start`,
+        `${daemon.baseUrl}/api/tasks/@nonexistent-task-xyz/start`,
         { data: {} }
       );
       expect(response.status()).toBe(404);
@@ -305,7 +303,7 @@ test.describe('Tasks API', () => {
     }) => {
       // test-task-completed is in completed state — cannot be started
       const response = await request.post(
-        `${DAEMON_URL}/api/tasks/@test-task-completed/start`,
+        `${daemon.baseUrl}/api/tasks/@test-task-completed/start`,
         { data: {} }
       );
       expect(response.status()).toBe(409);
@@ -325,7 +323,7 @@ test.describe('Tasks API', () => {
     test('appends note to task and returns {success, note, task}', async ({ request, daemon }) => {
       const noteContent = `E2E test note ${Date.now()}`;
       const response = await request.post(
-        `${DAEMON_URL}/api/tasks/@test-task-in-progress/note`,
+        `${daemon.baseUrl}/api/tasks/@test-task-in-progress/note`,
         {
           data: { content: noteContent, author: '@test' },
         }
@@ -354,7 +352,7 @@ test.describe('Tasks API', () => {
     test('created note has _ulid, content, created_at', async ({ request, daemon }) => {
       const noteContent = `Note field check ${Date.now()}`;
       const response = await request.post(
-        `${DAEMON_URL}/api/tasks/@test-task-in-progress/note`,
+        `${daemon.baseUrl}/api/tasks/@test-task-in-progress/note`,
         {
           data: { content: noteContent },
         }
@@ -376,7 +374,7 @@ test.describe('Tasks API', () => {
     // Elysia validates body schema before handler runs, returning 422 (not 400)
     test('returns 422 validation error when content is missing', async ({ request, daemon }) => {
       const response = await request.post(
-        `${DAEMON_URL}/api/tasks/@test-task-in-progress/note`,
+        `${daemon.baseUrl}/api/tasks/@test-task-in-progress/note`,
         { data: {} }
       );
       expect(response.status()).toBe(422);
@@ -385,7 +383,7 @@ test.describe('Tasks API', () => {
     // AC: @api-contract ac-7 (error handling) - 404 for invalid ref
     test('returns 404 for non-existent task', async ({ request, daemon }) => {
       const response = await request.post(
-        `${DAEMON_URL}/api/tasks/@nonexistent-task-xyz/note`,
+        `${daemon.baseUrl}/api/tasks/@nonexistent-task-xyz/note`,
         { data: { content: 'test note' } }
       );
       expect(response.status()).toBe(404);
@@ -399,8 +397,8 @@ test.describe('Tasks API', () => {
     // AC: @api-contract ac-1 (partial) - JSON content type for GET endpoints
     test('returns JSON content type for GET endpoints', async ({ request, daemon }) => {
       const responses = await Promise.all([
-        request.get(`${DAEMON_URL}/api/tasks`),
-        request.get(`${DAEMON_URL}/api/tasks/@test-task-ready`),
+        request.get(`${daemon.baseUrl}/api/tasks`),
+        request.get(`${daemon.baseUrl}/api/tasks/@test-task-ready`),
       ]);
 
       for (const response of responses) {
@@ -412,7 +410,7 @@ test.describe('Tasks API', () => {
     // AC: @api-contract ac-2 - items have consistent shape across list and detail
     test('list and detail responses have consistent task fields', async ({ request, daemon }) => {
       // Get list
-      const listResponse = await request.get(`${DAEMON_URL}/api/tasks`);
+      const listResponse = await request.get(`${daemon.baseUrl}/api/tasks`);
       const listBody = await listResponse.json();
       expect(listBody.items.length).toBeGreaterThan(0);
 
@@ -420,7 +418,7 @@ test.describe('Tasks API', () => {
       expect(listTask._ulid).toBeTruthy();
 
       // Get detail by ULID
-      const detailResponse = await request.get(`${DAEMON_URL}/api/tasks/@${listTask._ulid}`);
+      const detailResponse = await request.get(`${daemon.baseUrl}/api/tasks/@${listTask._ulid}`);
       expect(detailResponse.status()).toBe(200);
       const detailTask = await detailResponse.json();
 

--- a/packages/web-ui/tests/e2e/api-triage.spec.ts
+++ b/packages/web-ui/tests/e2e/api-triage.spec.ts
@@ -31,9 +31,6 @@
 
 import { test, expect } from '../fixtures/test-base';
 
-const DAEMON_URL = 'http://localhost:3456';
-const DAEMON_WS_URL = 'ws://localhost:3456/ws';
-
 // Fixture ULIDs defined in project.triage.yaml
 // TRIAGED record: inbox_ref = 01KJNBX0CA45ZT43W2T6HJMVA1 ("First inbox item for testing"), status=triaged
 const FIXTURE_TRIAGE_TRIAGED_ULID = '01KJC3NZ8Y268B3KFD2NVS6613';
@@ -47,8 +44,8 @@ const INBOX_ITEM_1_ULID = '01KJNBX0CA45ZT43W2T6HJMVA1'; // First inbox item — 
 const INBOX_ITEM_2_ULID = '01KJNBX1CC9N4YGP991WD7XS8S'; // Second inbox item — already acted_on
 const INBOX_ITEM_3_ULID = '01KJNBX2CB8N4YGP991WD7XS9R'; // Third inbox item — pending triage record
 
-async function subscribeToTriageUpdates(page: import('@playwright/test').Page): Promise<void> {
-  await page.goto(DAEMON_URL + '/api/health');
+async function subscribeToTriageUpdates(page: import('@playwright/test').Page, baseUrl: string, wsUrl: string): Promise<void> {
+  await page.goto(baseUrl + '/api/health');
 
   await page.evaluate((wsUrl: string) => {
     return new Promise<void>((resolve, reject) => {
@@ -92,7 +89,7 @@ async function subscribeToTriageUpdates(page: import('@playwright/test').Page): 
         reject(new Error('WebSocket error while subscribing to triage:updates'));
       };
     });
-  }, DAEMON_WS_URL);
+  }, wsUrl + '/ws');
 }
 
 async function waitForTriageBroadcast(
@@ -163,7 +160,7 @@ test.describe('Triage API', () => {
       request,
       daemon,
     }) => {
-      const response = await request.get(`${DAEMON_URL}/api/triage`);
+      const response = await request.get(`${daemon.baseUrl}/api/triage`);
 
       expect(response.status()).toBe(200);
 
@@ -180,7 +177,7 @@ test.describe('Triage API', () => {
       request,
       daemon,
     }) => {
-      const response = await request.get(`${DAEMON_URL}/api/triage`);
+      const response = await request.get(`${daemon.baseUrl}/api/triage`);
       expect(response.status()).toBe(200);
 
       const body = await response.json();
@@ -196,7 +193,7 @@ test.describe('Triage API', () => {
 
     // AC: @triage-daemon-api ac-1 — fixture records loaded
     test('returns fixture triage records with correct fields', async ({ request, daemon }) => {
-      const response = await request.get(`${DAEMON_URL}/api/triage`);
+      const response = await request.get(`${daemon.baseUrl}/api/triage`);
       expect(response.status()).toBe(200);
 
       const body = await response.json();
@@ -214,14 +211,14 @@ test.describe('Triage API', () => {
     // AC: @triage-daemon-api ac-1 — JSON content type
     // AC: @trait-api-endpoint ac-1
     test('returns JSON content type', async ({ request, daemon }) => {
-      const response = await request.get(`${DAEMON_URL}/api/triage`);
+      const response = await request.get(`${daemon.baseUrl}/api/triage`);
       const contentType = response.headers()['content-type'] || '';
       expect(contentType).toContain('application/json');
     });
 
     // AC: @triage-daemon-api ac-2 — status filter
     test('filters records by status query parameter', async ({ request, daemon }) => {
-      const response = await request.get(`${DAEMON_URL}/api/triage?status=triaged`);
+      const response = await request.get(`${daemon.baseUrl}/api/triage?status=triaged`);
       expect(response.status()).toBe(200);
 
       const body = await response.json();
@@ -235,7 +232,7 @@ test.describe('Triage API', () => {
 
     // AC: @triage-daemon-api ac-2 — filter for acted_on
     test('filters records by acted_on status', async ({ request, daemon }) => {
-      const response = await request.get(`${DAEMON_URL}/api/triage?status=acted_on`);
+      const response = await request.get(`${daemon.baseUrl}/api/triage?status=acted_on`);
       expect(response.status()).toBe(200);
 
       const body = await response.json();
@@ -246,7 +243,7 @@ test.describe('Triage API', () => {
 
     // AC: @triage-daemon-api ac-2 — filter for pending
     test('filters records by pending status', async ({ request, daemon }) => {
-      const response = await request.get(`${DAEMON_URL}/api/triage?status=pending`);
+      const response = await request.get(`${daemon.baseUrl}/api/triage?status=pending`);
       expect(response.status()).toBe(200);
 
       const body = await response.json();
@@ -258,12 +255,12 @@ test.describe('Triage API', () => {
     // AC: @trait-api-endpoint ac-4 — pagination
     test('supports limit and offset pagination', async ({ request, daemon }) => {
       // Get all records first
-      const allResponse = await request.get(`${DAEMON_URL}/api/triage`);
+      const allResponse = await request.get(`${daemon.baseUrl}/api/triage`);
       const allBody = await allResponse.json();
       const totalCount = allBody.total;
 
       // Get first page with limit=1
-      const pagedResponse = await request.get(`${DAEMON_URL}/api/triage?limit=1&offset=0`);
+      const pagedResponse = await request.get(`${daemon.baseUrl}/api/triage?limit=1&offset=0`);
       expect(pagedResponse.status()).toBe(200);
 
       const pagedBody = await pagedResponse.json();
@@ -275,8 +272,8 @@ test.describe('Triage API', () => {
 
     // AC: @trait-api-endpoint ac-4 — pagination offset
     test('pagination offset skips records', async ({ request, daemon }) => {
-      const firstResponse = await request.get(`${DAEMON_URL}/api/triage?limit=1&offset=0`);
-      const secondResponse = await request.get(`${DAEMON_URL}/api/triage?limit=1&offset=1`);
+      const firstResponse = await request.get(`${daemon.baseUrl}/api/triage?limit=1&offset=0`);
+      const secondResponse = await request.get(`${daemon.baseUrl}/api/triage?limit=1&offset=1`);
 
       expect(firstResponse.status()).toBe(200);
       expect(secondResponse.status()).toBe(200);
@@ -292,7 +289,7 @@ test.describe('Triage API', () => {
   test.describe('GET /api/triage/export', () => {
     // AC: @triage-daemon-api ac-6 — JSON export format
     test('exports triage records as JSON by default', async ({ request, daemon }) => {
-      const response = await request.get(`${DAEMON_URL}/api/triage/export`);
+      const response = await request.get(`${daemon.baseUrl}/api/triage/export`);
       expect(response.status()).toBe(200);
 
       const body = await response.json();
@@ -306,7 +303,7 @@ test.describe('Triage API', () => {
 
     // AC: @triage-daemon-api ac-6 — JSON format explicit
     test('exports triage records as JSON when format=json', async ({ request, daemon }) => {
-      const response = await request.get(`${DAEMON_URL}/api/triage/export?format=json`);
+      const response = await request.get(`${daemon.baseUrl}/api/triage/export?format=json`);
       expect(response.status()).toBe(200);
 
       const body = await response.json();
@@ -322,7 +319,7 @@ test.describe('Triage API', () => {
       request,
       daemon,
     }) => {
-      const response = await request.get(`${DAEMON_URL}/api/triage/export?format=context`);
+      const response = await request.get(`${daemon.baseUrl}/api/triage/export?format=context`);
       expect(response.status()).toBe(200);
 
       // Context format: {format: "context", content: "# Triage Decisions\n..."}
@@ -338,7 +335,7 @@ test.describe('Triage API', () => {
     // AC: @triage-daemon-api ac-6 — export with status filter
     test('supports status filter on export', async ({ request, daemon }) => {
       const response = await request.get(
-        `${DAEMON_URL}/api/triage/export?format=json&status=triaged`
+        `${daemon.baseUrl}/api/triage/export?format=json&status=triaged`
       );
       expect(response.status()).toBe(200);
 
@@ -356,7 +353,7 @@ test.describe('Triage API', () => {
     // AC: @trait-api-endpoint ac-1 — single record retrieval
     test('returns single triage record by ULID ref', async ({ request, daemon }) => {
       const response = await request.get(
-        `${DAEMON_URL}/api/triage/@${FIXTURE_TRIAGE_TRIAGED_ULID}`
+        `${daemon.baseUrl}/api/triage/@${FIXTURE_TRIAGE_TRIAGED_ULID}`
       );
       expect(response.status()).toBe(200);
 
@@ -371,7 +368,7 @@ test.describe('Triage API', () => {
       request,
       daemon,
     }) => {
-      const response = await request.get(`${DAEMON_URL}/api/triage/@nonexistent-triage-ref-xyz`);
+      const response = await request.get(`${daemon.baseUrl}/api/triage/@nonexistent-triage-ref-xyz`);
       expect(response.status()).toBe(404);
 
       const body = await response.json();
@@ -391,7 +388,7 @@ test.describe('Triage API', () => {
       daemon,
     }) => {
       // Use inbox item 1 which already has a "triaged" fixture record — upsert case
-      const response = await request.post(`${DAEMON_URL}/api/triage`, {
+      const response = await request.post(`${daemon.baseUrl}/api/triage`, {
         data: {
           inbox_ref: `@${INBOX_ITEM_1_ULID}`,
           action: 'defer',
@@ -421,7 +418,7 @@ test.describe('Triage API', () => {
       daemon,
     }) => {
       // Create a fresh inbox item first
-      const inboxResponse = await request.post(`${DAEMON_URL}/api/inbox`, {
+      const inboxResponse = await request.post(`${daemon.baseUrl}/api/inbox`, {
         data: { text: `Fresh item for triage ${Date.now()}` },
       });
       expect(inboxResponse.status()).toBe(200);
@@ -429,7 +426,7 @@ test.describe('Triage API', () => {
       const newInboxUlid = inbox.item._ulid;
 
       // Create a triage record for it
-      const triageResponse = await request.post(`${DAEMON_URL}/api/triage`, {
+      const triageResponse = await request.post(`${daemon.baseUrl}/api/triage`, {
         data: {
           inbox_ref: `@${newInboxUlid}`,
           action: 'defer',
@@ -451,7 +448,7 @@ test.describe('Triage API', () => {
       daemon,
     }) => {
       // Create a fresh inbox item
-      const inboxResponse = await request.post(`${DAEMON_URL}/api/inbox`, {
+      const inboxResponse = await request.post(`${daemon.baseUrl}/api/inbox`, {
         data: { text: `Triage list check ${Date.now()}` },
       });
       expect(inboxResponse.status()).toBe(200);
@@ -459,7 +456,7 @@ test.describe('Triage API', () => {
       const newInboxUlid = inbox.item._ulid;
 
       // Create triage record
-      const triageResponse = await request.post(`${DAEMON_URL}/api/triage`, {
+      const triageResponse = await request.post(`${daemon.baseUrl}/api/triage`, {
         data: {
           inbox_ref: `@${newInboxUlid}`,
           action: 'spec-gap',
@@ -470,7 +467,7 @@ test.describe('Triage API', () => {
       const created = await triageResponse.json();
 
       // Verify it appears in the list
-      const listResponse = await request.get(`${DAEMON_URL}/api/triage`);
+      const listResponse = await request.get(`${daemon.baseUrl}/api/triage`);
       expect(listResponse.status()).toBe(200);
       const list = await listResponse.json();
 
@@ -482,13 +479,13 @@ test.describe('Triage API', () => {
     // AC: @triage-daemon-api ac-3 — supports optional decided_by
     test('creates record with optional decided_by field', async ({ request, daemon }) => {
       // Create fresh inbox item
-      const inboxResponse = await request.post(`${DAEMON_URL}/api/inbox`, {
+      const inboxResponse = await request.post(`${daemon.baseUrl}/api/inbox`, {
         data: { text: `Decided by test ${Date.now()}` },
       });
       expect(inboxResponse.status()).toBe(200);
       const inbox = await inboxResponse.json();
 
-      const response = await request.post(`${DAEMON_URL}/api/triage`, {
+      const response = await request.post(`${daemon.baseUrl}/api/triage`, {
         data: {
           inbox_ref: `@${inbox.item._ulid}`,
           action: 'delete',
@@ -509,17 +506,17 @@ test.describe('Triage API', () => {
       page,
       daemon,
     }) => {
-      await subscribeToTriageUpdates(page);
+      await subscribeToTriageUpdates(page, daemon.baseUrl, daemon.wsUrl);
 
       // Create a fresh inbox item for deterministic broadcast data
-      const inboxResponse = await request.post(`${DAEMON_URL}/api/inbox`, {
+      const inboxResponse = await request.post(`${daemon.baseUrl}/api/inbox`, {
         data: { text: `Broadcast create test ${Date.now()}` },
       });
       expect(inboxResponse.status()).toBe(200);
       const inbox = await inboxResponse.json();
 
       const broadcastPromise = waitForTriageBroadcast(page, 'triage_record_created');
-      const triageResponse = await request.post(`${DAEMON_URL}/api/triage`, {
+      const triageResponse = await request.post(`${daemon.baseUrl}/api/triage`, {
         data: {
           inbox_ref: `@${inbox.item._ulid}`,
           action: 'defer',
@@ -543,7 +540,7 @@ test.describe('Triage API', () => {
 
     // AC: @triage-daemon-api ac-7 — 404 for nonexistent inbox item
     test('returns 404 for nonexistent inbox item reference', async ({ request, daemon }) => {
-      const response = await request.post(`${DAEMON_URL}/api/triage`, {
+      const response = await request.post(`${daemon.baseUrl}/api/triage`, {
         data: {
           inbox_ref: '@01ZZZZZZZZZZZZZZZZZZZZZZZY',
           action: 'defer',
@@ -564,7 +561,7 @@ test.describe('Triage API', () => {
       request,
       daemon,
     }) => {
-      const response = await request.post(`${DAEMON_URL}/api/triage`, {
+      const response = await request.post(`${daemon.baseUrl}/api/triage`, {
         data: {
           inbox_ref: `@${INBOX_ITEM_1_ULID}`,
           action: 'invalid-action-xyz',
@@ -583,7 +580,7 @@ test.describe('Triage API', () => {
 
     // AC: @trait-api-endpoint ac-3 — missing required fields → Elysia validation
     test('returns 422 when required fields are missing', async ({ request, daemon }) => {
-      const response = await request.post(`${DAEMON_URL}/api/triage`, {
+      const response = await request.post(`${daemon.baseUrl}/api/triage`, {
         data: {
           // Missing inbox_ref, action, reasoning
         },
@@ -600,7 +597,7 @@ test.describe('Triage API', () => {
       daemon,
     }) => {
       const response = await request.post(
-        `${DAEMON_URL}/api/triage/@${FIXTURE_TRIAGE_TRIAGED_ULID}/override`,
+        `${daemon.baseUrl}/api/triage/@${FIXTURE_TRIAGE_TRIAGED_ULID}/override`,
         {
           data: {
             action: 'promote',
@@ -628,7 +625,7 @@ test.describe('Triage API', () => {
       daemon,
     }) => {
       const response = await request.post(
-        `${DAEMON_URL}/api/triage/@${FIXTURE_TRIAGE_ACTED_ULID}/override`,
+        `${daemon.baseUrl}/api/triage/@${FIXTURE_TRIAGE_ACTED_ULID}/override`,
         {
           data: {
             action: 'defer',
@@ -649,7 +646,7 @@ test.describe('Triage API', () => {
     // AC: @triage-daemon-api ac-4 — override with custom override_by
     test('accepts optional override_by field', async ({ request, daemon }) => {
       const response = await request.post(
-        `${DAEMON_URL}/api/triage/@${FIXTURE_TRIAGE_TRIAGED_ULID}/override`,
+        `${daemon.baseUrl}/api/triage/@${FIXTURE_TRIAGE_TRIAGED_ULID}/override`,
         {
           data: {
             action: 'delete',
@@ -673,13 +670,13 @@ test.describe('Triage API', () => {
       daemon,
     }) => {
       // Create a record first so this test is not fixture-dependent.
-      const inboxResponse = await request.post(`${DAEMON_URL}/api/inbox`, {
+      const inboxResponse = await request.post(`${daemon.baseUrl}/api/inbox`, {
         data: { text: `Broadcast override test ${Date.now()}` },
       });
       expect(inboxResponse.status()).toBe(200);
       const inbox = await inboxResponse.json();
 
-      const triageResponse = await request.post(`${DAEMON_URL}/api/triage`, {
+      const triageResponse = await request.post(`${daemon.baseUrl}/api/triage`, {
         data: {
           inbox_ref: `@${inbox.item._ulid}`,
           action: 'defer',
@@ -689,11 +686,11 @@ test.describe('Triage API', () => {
       expect(triageResponse.status()).toBe(200);
       const triage = await triageResponse.json();
 
-      await subscribeToTriageUpdates(page);
+      await subscribeToTriageUpdates(page, daemon.baseUrl, daemon.wsUrl);
 
       const broadcastPromise = waitForTriageBroadcast(page, 'triage_record_updated');
       const response = await request.post(
-        `${DAEMON_URL}/api/triage/@${triage.record._ulid}/override`,
+        `${daemon.baseUrl}/api/triage/@${triage.record._ulid}/override`,
         {
           data: {
             action: 'promote',
@@ -716,7 +713,7 @@ test.describe('Triage API', () => {
     // AC: @trait-api-endpoint ac-2 — 404 for nonexistent ref
     test('returns 404 for nonexistent triage record ref', async ({ request, daemon }) => {
       const response = await request.post(
-        `${DAEMON_URL}/api/triage/@nonexistent-triage-ref-xyz/override`,
+        `${daemon.baseUrl}/api/triage/@nonexistent-triage-ref-xyz/override`,
         {
           data: {
             action: 'defer',
@@ -736,7 +733,7 @@ test.describe('Triage API', () => {
     // AC: @trait-api-endpoint ac-3 — invalid action validation
     test('returns 400 for invalid action on override', async ({ request, daemon }) => {
       const response = await request.post(
-        `${DAEMON_URL}/api/triage/@${FIXTURE_TRIAGE_TRIAGED_ULID}/override`,
+        `${daemon.baseUrl}/api/triage/@${FIXTURE_TRIAGE_TRIAGED_ULID}/override`,
         {
           data: {
             action: 'invalid-action',
@@ -757,14 +754,14 @@ test.describe('Triage API', () => {
     // AC: @triage-daemon-api ac-5 — execute action on triaged record
     test('executes action and transitions record to acted_on', async ({ request, daemon }) => {
       // First create a fresh inbox item and triage record in 'triaged' status
-      const inboxResponse = await request.post(`${DAEMON_URL}/api/inbox`, {
+      const inboxResponse = await request.post(`${daemon.baseUrl}/api/inbox`, {
         data: { text: `Act test item ${Date.now()}` },
       });
       expect(inboxResponse.status()).toBe(200);
       const inbox = await inboxResponse.json();
 
       // Create triage record
-      const triageResponse = await request.post(`${DAEMON_URL}/api/triage`, {
+      const triageResponse = await request.post(`${daemon.baseUrl}/api/triage`, {
         data: {
           inbox_ref: `@${inbox.item._ulid}`,
           action: 'delete',
@@ -777,7 +774,7 @@ test.describe('Triage API', () => {
 
       // Act on it (delete action — removes the inbox item)
       const actResponse = await request.post(
-        `${DAEMON_URL}/api/triage/@${triageRef}/act`
+        `${daemon.baseUrl}/api/triage/@${triageRef}/act`
       );
 
       expect(actResponse.status()).toBe(200);
@@ -791,13 +788,13 @@ test.describe('Triage API', () => {
     // AC: @triage-daemon-api ac-5 — defer action
     test('executes defer action successfully', async ({ request, daemon }) => {
       // Create a fresh inbox item + triage record for defer action
-      const inboxResponse = await request.post(`${DAEMON_URL}/api/inbox`, {
+      const inboxResponse = await request.post(`${daemon.baseUrl}/api/inbox`, {
         data: { text: `Defer act test ${Date.now()}` },
       });
       expect(inboxResponse.status()).toBe(200);
       const inbox = await inboxResponse.json();
 
-      const triageResponse = await request.post(`${DAEMON_URL}/api/triage`, {
+      const triageResponse = await request.post(`${daemon.baseUrl}/api/triage`, {
         data: {
           inbox_ref: `@${inbox.item._ulid}`,
           action: 'defer',
@@ -808,7 +805,7 @@ test.describe('Triage API', () => {
       const triage = await triageResponse.json();
 
       const actResponse = await request.post(
-        `${DAEMON_URL}/api/triage/@${triage.record._ulid}/act`
+        `${daemon.baseUrl}/api/triage/@${triage.record._ulid}/act`
       );
 
       expect(actResponse.status()).toBe(200);
@@ -823,12 +820,12 @@ test.describe('Triage API', () => {
       daemon,
     }) => {
       // Create fresh inbox item + triage + act
-      const inboxResponse = await request.post(`${DAEMON_URL}/api/inbox`, {
+      const inboxResponse = await request.post(`${daemon.baseUrl}/api/inbox`, {
         data: { text: `List verification act ${Date.now()}` },
       });
       const inbox = await inboxResponse.json();
 
-      const triageResponse = await request.post(`${DAEMON_URL}/api/triage`, {
+      const triageResponse = await request.post(`${daemon.baseUrl}/api/triage`, {
         data: {
           inbox_ref: `@${inbox.item._ulid}`,
           action: 'defer',
@@ -837,11 +834,11 @@ test.describe('Triage API', () => {
       });
       const triage = await triageResponse.json();
 
-      await request.post(`${DAEMON_URL}/api/triage/@${triage.record._ulid}/act`);
+      await request.post(`${daemon.baseUrl}/api/triage/@${triage.record._ulid}/act`);
 
       // Verify the list reflects acted_on status
       const listResponse = await request.get(
-        `${DAEMON_URL}/api/triage?status=acted_on`
+        `${daemon.baseUrl}/api/triage?status=acted_on`
       );
       const list = await listResponse.json();
       const found = list.items.find((r: { _ulid: string }) => r._ulid === triage.record._ulid);
@@ -857,13 +854,13 @@ test.describe('Triage API', () => {
       daemon,
     }) => {
       // Create inbox item + triaged record with promote action so act yields result_ref
-      const inboxResponse = await request.post(`${DAEMON_URL}/api/inbox`, {
+      const inboxResponse = await request.post(`${daemon.baseUrl}/api/inbox`, {
         data: { text: `Broadcast act test ${Date.now()}` },
       });
       expect(inboxResponse.status()).toBe(200);
       const inbox = await inboxResponse.json();
 
-      const triageResponse = await request.post(`${DAEMON_URL}/api/triage`, {
+      const triageResponse = await request.post(`${daemon.baseUrl}/api/triage`, {
         data: {
           inbox_ref: `@${inbox.item._ulid}`,
           action: 'promote',
@@ -873,11 +870,11 @@ test.describe('Triage API', () => {
       expect(triageResponse.status()).toBe(200);
       const triage = await triageResponse.json();
 
-      await subscribeToTriageUpdates(page);
+      await subscribeToTriageUpdates(page, daemon.baseUrl, daemon.wsUrl);
 
       const broadcastPromise = waitForTriageBroadcast(page, 'triage_record_acted');
       const actResponse = await request.post(
-        `${DAEMON_URL}/api/triage/@${triage.record._ulid}/act`
+        `${daemon.baseUrl}/api/triage/@${triage.record._ulid}/act`
       );
       expect(actResponse.status()).toBe(200);
       const acted = await actResponse.json();
@@ -894,7 +891,7 @@ test.describe('Triage API', () => {
     // AC: @triage-daemon-api ac-8 — 409 for already acted_on record
     test('returns 409 when acting on already acted_on record', async ({ request, daemon }) => {
       const response = await request.post(
-        `${DAEMON_URL}/api/triage/@${FIXTURE_TRIAGE_ACTED_ULID}/act`
+        `${daemon.baseUrl}/api/triage/@${FIXTURE_TRIAGE_ACTED_ULID}/act`
       );
 
       expect(response.status()).toBe(409);
@@ -913,7 +910,7 @@ test.describe('Triage API', () => {
       daemon,
     }) => {
       const response = await request.post(
-        `${DAEMON_URL}/api/triage/@${FIXTURE_TRIAGE_PENDING_ULID}/act`
+        `${daemon.baseUrl}/api/triage/@${FIXTURE_TRIAGE_PENDING_ULID}/act`
       );
 
       expect(response.status()).toBe(422);
@@ -928,7 +925,7 @@ test.describe('Triage API', () => {
     // AC: @trait-api-endpoint ac-2 — 404 for nonexistent ref
     test('returns 404 for nonexistent triage record ref', async ({ request, daemon }) => {
       const response = await request.post(
-        `${DAEMON_URL}/api/triage/@nonexistent-triage-xyz/act`
+        `${daemon.baseUrl}/api/triage/@nonexistent-triage-xyz/act`
       );
 
       expect(response.status()).toBe(404);
@@ -947,7 +944,7 @@ test.describe('Triage API', () => {
       daemon,
     }) => {
       // Create fresh inbox item
-      const inboxResponse = await request.post(`${DAEMON_URL}/api/inbox`, {
+      const inboxResponse = await request.post(`${daemon.baseUrl}/api/inbox`, {
         data: { text: `Upsert test ${Date.now()}` },
       });
       expect(inboxResponse.status()).toBe(200);
@@ -955,7 +952,7 @@ test.describe('Triage API', () => {
       const inboxUlid = inbox.item._ulid;
 
       // First triage — defer
-      const firstResponse = await request.post(`${DAEMON_URL}/api/triage`, {
+      const firstResponse = await request.post(`${daemon.baseUrl}/api/triage`, {
         data: {
           inbox_ref: `@${inboxUlid}`,
           action: 'defer',
@@ -967,7 +964,7 @@ test.describe('Triage API', () => {
       const firstUlid = firstBody.record._ulid;
 
       // Second triage — spec-gap (should upsert, same ULID)
-      const secondResponse = await request.post(`${DAEMON_URL}/api/triage`, {
+      const secondResponse = await request.post(`${daemon.baseUrl}/api/triage`, {
         data: {
           inbox_ref: `@${inboxUlid}`,
           action: 'spec-gap',
@@ -982,7 +979,7 @@ test.describe('Triage API', () => {
       expect(secondBody.record.action).toBe('spec-gap');
 
       // Only 1 record for this inbox item
-      const listResponse = await request.get(`${DAEMON_URL}/api/triage`);
+      const listResponse = await request.get(`${daemon.baseUrl}/api/triage`);
       const list = await listResponse.json();
       const recordsForItem = list.items.filter(
         (r: { inbox_ref: string }) => r.inbox_ref === inboxUlid

--- a/packages/web-ui/tests/e2e/api-watcher.spec.ts
+++ b/packages/web-ui/tests/e2e/api-watcher.spec.ts
@@ -56,15 +56,12 @@ import { writeFileSync } from 'fs';
 import { join } from 'path';
 import { test, expect } from '../fixtures/test-base';
 
-const DAEMON_WS_URL = 'ws://localhost:3456/ws';
-const DAEMON_HTTP_URL = 'http://localhost:3456';
-
 /**
  * Connect to the daemon WebSocket from the browser context.
  * Stores WebSocket in window.__testWs for subsequent calls.
  */
-async function connectWebSocket(page: import('@playwright/test').Page): Promise<void> {
-  await page.goto(DAEMON_HTTP_URL + '/api/health');
+async function connectWebSocket(page: import('@playwright/test').Page, baseUrl: string, wsUrl: string): Promise<void> {
+  await page.goto(baseUrl + '/api/health');
 
   await page.evaluate((wsUrl: string) => {
     return new Promise<void>((resolve, reject) => {
@@ -100,7 +97,7 @@ async function connectWebSocket(page: import('@playwright/test').Page): Promise<
         }
       };
     });
-  }, DAEMON_WS_URL);
+  }, wsUrl + '/ws');
 }
 
 /**
@@ -324,8 +321,8 @@ test.describe('File Watcher API', () => {
     }
   });
 
-  test.beforeEach(async ({ page }) => {
-    await connectWebSocket(page);
+  test.beforeEach(async ({ page, daemon }) => {
+    await connectWebSocket(page, daemon.baseUrl, daemon.wsUrl);
   });
 
   // AC: @daemon-server ac-4
@@ -387,7 +384,7 @@ test.describe('File Watcher API', () => {
     await subscribeTopic(page, 'files:updates');
 
     // Get a task from the fixture
-    const tasksResponse = await request.get(`${DAEMON_HTTP_URL}/api/tasks`);
+    const tasksResponse = await request.get(`${daemon.baseUrl}/api/tasks`);
     const tasksBody = await tasksResponse.json();
     expect(tasksBody.items.length).toBeGreaterThan(0);
     const taskRef = tasksBody.items[0]._ulid;
@@ -396,7 +393,7 @@ test.describe('File Watcher API', () => {
     const broadcastPromise = waitForBroadcast(page, 'files:updates');
 
     // Add a note via HTTP API — daemon writes to project.tasks.yaml, watcher detects it
-    const noteResponse = await request.post(`${DAEMON_HTTP_URL}/api/tasks/${taskRef}/note`, {
+    const noteResponse = await request.post(`${daemon.baseUrl}/api/tasks/${taskRef}/note`, {
       data: {
         content: 'E2E file watcher detection test note',
         author: '@test',
@@ -532,7 +529,7 @@ test.describe('File Watcher API', () => {
     expect(errorBroadcast.data.error.length).toBeGreaterThan(0);
 
     // AC: @daemon-server ac-6 — daemon did NOT crash, still responds to health check
-    const healthResponse = await request.get(`${DAEMON_HTTP_URL}/api/health`);
+    const healthResponse = await request.get(`${daemon.baseUrl}/api/health`);
     expect(healthResponse.status()).toBe(200);
     const health = await healthResponse.json();
     expect(health.status).toBe('ok');
@@ -576,7 +573,7 @@ test.describe('File Watcher API', () => {
     expect(recoveryBroadcast).toHaveProperty('msg_id');
 
     // Final health check
-    const healthResponse = await request.get(`${DAEMON_HTTP_URL}/api/health`);
+    const healthResponse = await request.get(`${daemon.baseUrl}/api/health`);
     expect(healthResponse.status()).toBe(200);
   });
 });

--- a/packages/web-ui/tests/e2e/api-websocket.spec.ts
+++ b/packages/web-ui/tests/e2e/api-websocket.spec.ts
@@ -56,9 +56,6 @@
 
 import { test, expect } from '../fixtures/test-base';
 
-const DAEMON_WS_URL = 'ws://localhost:3456/ws';
-const DAEMON_HTTP_URL = 'http://localhost:3456';
-
 /**
  * Connect to the daemon WebSocket from the browser context.
  * Returns a promise that resolves with the connected event payload.
@@ -67,10 +64,12 @@ const DAEMON_HTTP_URL = 'http://localhost:3456';
  * which properly handles WebSocket HTTP upgrades (101 Switching Protocols).
  */
 async function connectWebSocket(
-  page: import('@playwright/test').Page
+  page: import('@playwright/test').Page,
+  baseUrl: string,
+  wsUrl: string,
 ): Promise<{ sessionId: string; wsHandle: unknown }> {
   // Navigate to daemon root first so browser is in the right origin
-  await page.goto(DAEMON_HTTP_URL + '/api/health');
+  await page.goto(baseUrl + '/api/health');
 
   // Open WebSocket and wait for the 'connected' event
   const sessionId = await page.evaluate((wsUrl: string) => {
@@ -111,7 +110,7 @@ async function connectWebSocket(
         }
       };
     });
-  }, DAEMON_WS_URL);
+  }, wsUrl + '/ws');
 
   return { sessionId, wsHandle: null };
 }
@@ -221,7 +220,7 @@ test.describe('WebSocket Protocol API', () => {
   test.describe('Connection Lifecycle', () => {
     // AC: @api-contract ac-25, @trait-websocket-protocol ac-1
     test('connects to /ws and receives connected event with session_id', async ({ page, daemon }) => {
-      await page.goto(DAEMON_HTTP_URL + '/api/health');
+      await page.goto(daemon.baseUrl + '/api/health');
 
       const result = await page.evaluate((wsUrl: string) => {
         return new Promise<{ event: string; session_id: string; rawMessage: string }>(
@@ -255,7 +254,7 @@ test.describe('WebSocket Protocol API', () => {
             };
           }
         );
-      }, DAEMON_WS_URL);
+      }, daemon.wsUrl + '/ws');
 
       // AC: @api-contract ac-25
       expect(result.event).toBe('connected');
@@ -267,7 +266,7 @@ test.describe('WebSocket Protocol API', () => {
 
     // AC: @api-contract ac-25, @trait-websocket-protocol ac-1
     test('each connection gets a unique session_id', async ({ page, daemon }) => {
-      await page.goto(DAEMON_HTTP_URL + '/api/health');
+      await page.goto(daemon.baseUrl + '/api/health');
 
       const sessionIds = await page.evaluate((wsUrl: string) => {
         return new Promise<string[]>((resolve, reject) => {
@@ -314,7 +313,7 @@ test.describe('WebSocket Protocol API', () => {
             })
             .catch(reject);
         });
-      }, DAEMON_WS_URL);
+      }, daemon.wsUrl + '/ws');
 
       expect(sessionIds).toHaveLength(2);
       expect(sessionIds[0]).not.toBe(sessionIds[1]);
@@ -326,9 +325,9 @@ test.describe('WebSocket Protocol API', () => {
       daemon,
       request,
     }) => {
-      await page.goto(DAEMON_HTTP_URL + '/api/health');
+      await page.goto(daemon.baseUrl + '/api/health');
 
-      const baselineResponse = await request.get(`${DAEMON_HTTP_URL}/api/health`);
+      const baselineResponse = await request.get(`${daemon.baseUrl}/api/health`);
       expect(baselineResponse.ok()).toBe(true);
       const baseline = await baselineResponse.json();
       const baselineConnections = baseline.connections as number;
@@ -372,9 +371,9 @@ test.describe('WebSocket Protocol API', () => {
             };
           }
         });
-      }, DAEMON_WS_URL);
+      }, daemon.wsUrl + '/ws');
 
-      const afterConnectResponse = await request.get(`${DAEMON_HTTP_URL}/api/health`);
+      const afterConnectResponse = await request.get(`${daemon.baseUrl}/api/health`);
       expect(afterConnectResponse.ok()).toBe(true);
       const afterConnect = await afterConnectResponse.json();
       expect(afterConnect.connections).toBe(baselineConnections + 2);
@@ -399,7 +398,7 @@ test.describe('WebSocket Protocol API', () => {
 
       let finalConnections: number | null = null;
       for (let attempt = 0; attempt < 20; attempt++) {
-        const healthResponse = await request.get(`${DAEMON_HTTP_URL}/api/health`);
+        const healthResponse = await request.get(`${daemon.baseUrl}/api/health`);
         const health = await healthResponse.json();
         finalConnections = health.connections as number;
         if (finalConnections === baselineConnections + 1) {
@@ -422,9 +421,9 @@ test.describe('WebSocket Protocol API', () => {
   });
 
   test.describe('Command Protocol', () => {
-    test.beforeEach(async ({ page }) => {
+    test.beforeEach(async ({ page, daemon }) => {
       // Establish WebSocket connection before each test
-      await connectWebSocket(page);
+      await connectWebSocket(page, daemon.baseUrl, daemon.wsUrl);
     });
 
     // AC: @api-contract ac-26, @api-contract ac-27, @trait-websocket-protocol ac-2
@@ -573,8 +572,8 @@ test.describe('WebSocket Protocol API', () => {
   });
 
   test.describe('Broadcast Events', () => {
-    test.beforeEach(async ({ page }) => {
-      await connectWebSocket(page);
+    test.beforeEach(async ({ page, daemon }) => {
+      await connectWebSocket(page, daemon.baseUrl, daemon.wsUrl);
     });
 
     // AC: @api-contract ac-28, @api-contract ac-29, @trait-websocket-protocol ac-2, ac-3, @daemon-server ac-4
@@ -586,12 +585,12 @@ test.describe('WebSocket Protocol API', () => {
         async () => {
           // Trigger a mutation via HTTP API that causes file change broadcast
           // Add a note to an existing task (fixture tasks exist)
-          const tasksResponse = await request.get(`${DAEMON_HTTP_URL}/api/tasks`);
+          const tasksResponse = await request.get(`${daemon.baseUrl}/api/tasks`);
           const tasksBody = await tasksResponse.json();
           expect(tasksBody.items.length).toBeGreaterThan(0);
 
           const taskRef = tasksBody.items[0]._ulid;
-          const noteResponse = await request.post(`${DAEMON_HTTP_URL}/api/tasks/${taskRef}/note`, {
+          const noteResponse = await request.post(`${daemon.baseUrl}/api/tasks/${taskRef}/note`, {
             data: {
               content: 'E2E WebSocket broadcast test note',
               author: '@test',
@@ -627,7 +626,7 @@ test.describe('WebSocket Protocol API', () => {
     // AC: @api-contract ac-29, @trait-websocket-protocol ac-3
     test('sequence numbers increment across broadcasts', async ({ page, daemon, request }) => {
       // Get first task from fixture
-      const tasksResponse = await request.get(`${DAEMON_HTTP_URL}/api/tasks`);
+      const tasksResponse = await request.get(`${daemon.baseUrl}/api/tasks`);
       const tasksBody = await tasksResponse.json();
       const taskRef = tasksBody.items[0]._ulid;
 
@@ -671,14 +670,14 @@ test.describe('WebSocket Protocol API', () => {
 
       // Trigger first broadcast
       const firstBroadcastPromise = waitForNextBroadcast(page);
-      await request.post(`${DAEMON_HTTP_URL}/api/tasks/${taskRef}/note`, {
+      await request.post(`${daemon.baseUrl}/api/tasks/${taskRef}/note`, {
         data: { content: 'Seq test note 1', author: '@test' },
       });
       const first = await firstBroadcastPromise;
 
       // Trigger second broadcast
       const secondBroadcastPromise = waitForNextBroadcast(page);
-      await request.post(`${DAEMON_HTTP_URL}/api/tasks/${taskRef}/note`, {
+      await request.post(`${daemon.baseUrl}/api/tasks/${taskRef}/note`, {
         data: { content: 'Seq test note 2', author: '@test' },
       });
       const second = await secondBroadcastPromise;
@@ -710,7 +709,7 @@ test.describe('WebSocket Protocol API', () => {
       expect(unsubAck.success).toBe(true);
 
       // Get a task to trigger a mutation
-      const tasksResponse = await request.get(`${DAEMON_HTTP_URL}/api/tasks`);
+      const tasksResponse = await request.get(`${daemon.baseUrl}/api/tasks`);
       const tasksBody = await tasksResponse.json();
       const taskRef = tasksBody.items[0]._ulid;
 
@@ -759,7 +758,7 @@ test.describe('WebSocket Protocol API', () => {
             });
           });
         },
-        { taskRefParam: taskRef, daemonUrl: DAEMON_HTTP_URL }
+        { taskRefParam: taskRef, daemonUrl: daemon.baseUrl }
       );
 
       // AC: @api-contract ac-28 — unsubscribed clients don't receive broadcasts
@@ -770,7 +769,7 @@ test.describe('WebSocket Protocol API', () => {
   test.describe('Connection Lifecycle - Clean Close', () => {
     // AC: @api-contract ac-31 — close code 1000 for clean close
     test('clean close uses code 1000', async ({ page, daemon }) => {
-      await page.goto(DAEMON_HTTP_URL + '/api/health');
+      await page.goto(daemon.baseUrl + '/api/health');
 
       const closeCode = await page.evaluate((wsUrl: string) => {
         return new Promise<number>((resolve, reject) => {
@@ -802,7 +801,7 @@ test.describe('WebSocket Protocol API', () => {
             reject(new Error('WebSocket error'));
           };
         });
-      }, DAEMON_WS_URL);
+      }, daemon.wsUrl + '/ws');
 
       // AC: @api-contract ac-31 — clean close uses code 1000
       expect(closeCode).toBe(1000);
@@ -815,7 +814,7 @@ test.describe('WebSocket Protocol API', () => {
     // Note: 30s ping interval and 90s pong timeout cannot be verified within E2E timeout budget.
     // This test verifies the connection remains functional after a brief idle period.
     test('connection remains active and responsive after idle', async ({ page, daemon }) => {
-      await connectWebSocket(page);
+      await connectWebSocket(page, daemon.baseUrl, daemon.wsUrl);
 
       // Wait 2 seconds and verify connection is still active by sending a ping
       await page.waitForTimeout(2000);

--- a/packages/web-ui/tests/e2e/tasks.spec.ts
+++ b/packages/web-ui/tests/e2e/tasks.spec.ts
@@ -415,7 +415,7 @@ test.describe('Tasks View', () => {
       expect(taskRef).toBeTruthy();
 
       // Simulate external update via API (would trigger WebSocket event)
-      const response = await fetch(`http://localhost:3456/api/tasks/${taskRef}/note`, {
+      const response = await fetch(`${daemon.baseUrl}/api/tasks/${taskRef}/note`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/packages/web-ui/tests/e2e/triage.spec.ts
+++ b/packages/web-ui/tests/e2e/triage.spec.ts
@@ -198,9 +198,9 @@ test.describe('Interactive Triage UI', () => {
   });
 
   // AC: @interactive-triage-ui ac-7
-  test('action filter narrows cards by triage action and resets card index', async ({ page, request }) => {
+  test('action filter narrows cards by triage action and resets card index', async ({ page, request, daemon }) => {
     let targetAction = 'defer';
-    const triageListResponse = await request.get('http://localhost:3456/api/triage?limit=1000');
+    const triageListResponse = await request.get(`${daemon.baseUrl}/api/triage?limit=1000`);
     expect(triageListResponse.ok()).toBe(true);
     const triageListBody = await triageListResponse.json();
     const existingAction = triageListBody.items.find((item: { action?: string | null }) => item.action)?.action;
@@ -208,14 +208,14 @@ test.describe('Interactive Triage UI', () => {
     if (existingAction) {
       targetAction = existingAction;
     } else {
-      const inboxResponse = await request.post('http://localhost:3456/api/inbox', {
+      const inboxResponse = await request.post(`${daemon.baseUrl}/api/inbox`, {
         data: { text: `Action filter test item ${Date.now()}` },
       });
       expect(inboxResponse.status()).toBe(200);
       const inboxBody = await inboxResponse.json();
       const inboxUlid = inboxBody.item._ulid;
 
-      const triageResponse = await request.post('http://localhost:3456/api/triage', {
+      const triageResponse = await request.post(`${daemon.baseUrl}/api/triage`, {
         data: {
           inbox_ref: `@${inboxUlid}`,
           action: targetAction,
@@ -319,7 +319,7 @@ test.describe('Triage real-time updates via WebSocket', () => {
     const initialProgress = await progressEl.textContent();
 
     // Create a fresh inbox item to triage (so we don't conflict with fixture records)
-    const inboxResp = await request.post('http://localhost:3456/api/inbox', {
+    const inboxResp = await request.post(`${daemon.baseUrl}/api/inbox`, {
       data: { text: `Real-time update test item ${Date.now()}` },
     });
     expect(inboxResp.status()).toBe(200);
@@ -329,7 +329,7 @@ test.describe('Triage real-time updates via WebSocket', () => {
     // POST triage decision via API (simulates another client acting on the item).
     // The daemon broadcasts triage:updates after mutation, which the triage page
     // receives and calls loadTriageData() to refresh the displayed count.
-    const triageResp = await request.post('http://localhost:3456/api/triage', {
+    const triageResp = await request.post(`${daemon.baseUrl}/api/triage`, {
       data: {
         inbox_ref: `@${newInboxUlid}`,
         action: 'defer',

--- a/packages/web-ui/tests/fixtures/test-base.ts
+++ b/packages/web-ui/tests/fixtures/test-base.ts
@@ -4,11 +4,11 @@ import { mkdirSync, cpSync, rmSync, existsSync, writeFileSync } from 'fs';
 import { join, dirname } from 'path';
 import { tmpdir } from 'os';
 import { fileURLToPath } from 'url';
+import { createServer } from 'net';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-const DAEMON_PORT = 3456;
 // E2E tests use dedicated fixtures to avoid breaking unit tests
 const E2E_FIXTURES = join(__dirname, '../fixtures');
 // Path to built web UI (daemon serves this for E2E tests)
@@ -17,44 +17,37 @@ const WEB_UI_BUILD = join(__dirname, '../../build');
 interface DaemonFixture {
   tempDir: string;
   kspecDir: string;
+  /** Ephemeral port the test daemon is listening on */
+  port: number;
+  /** Base URL for HTTP requests (http://localhost:<port>) */
+  baseUrl: string;
+  /** Base URL for WebSocket connections (ws://localhost:<port>) */
+  wsUrl: string;
   /** Create a valid second project for multi-project tests */
   createSecondProject: () => Promise<string>;
 }
 
-async function cleanupExistingDaemon(): Promise<void> {
-  // Kill any daemon that might be running on port 3456
-  try {
-    if (process.platform === 'win32') {
-      // Windows: use netstat to find PID, then taskkill
-      const result = spawnSync('netstat', ['-ano'], { encoding: 'utf-8' });
-      const lines = result.stdout.split('\n');
-      for (const line of lines) {
-        if (line.includes(':' + DAEMON_PORT) && line.includes('LISTENING')) {
-          const parts = line.trim().split(/\s+/);
-          const pid = parts[parts.length - 1];
-          if (pid && /^\d+$/.test(pid)) {
-            spawnSync('taskkill', ['/F', '/PID', pid], { stdio: 'ignore' });
-          }
-        }
+// AC: @e2e-test-daemon-isolation ac-1 — ephemeral port allocation
+async function getAvailablePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = createServer();
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        server.close(() => reject(new Error('Failed to allocate ephemeral port')));
+        return;
       }
-    } else {
-      // Unix: use lsof
-      const result = spawnSync('lsof', ['-ti', ':' + DAEMON_PORT], { encoding: 'utf-8' });
-      if (result.stdout.trim()) {
-        const pids = result.stdout.trim().split('\n');
-        for (const pid of pids) {
-          try {
-            process.kill(parseInt(pid, 10), 'SIGTERM');
-          } catch {
-            // Process may already be gone
-          }
+      const { port } = address;
+      server.close((error) => {
+        if (error) {
+          reject(error);
+          return;
         }
-      }
-    }
-    await new Promise((r) => setTimeout(r, 1000));
-  } catch {
-    // Command may not be available on all systems
-  }
+        resolve(port);
+      });
+    });
+  });
 }
 
 async function checkBunAvailable(): Promise<boolean> {
@@ -69,7 +62,12 @@ async function checkBunAvailable(): Promise<boolean> {
 }
 
 export const test = base.extend<{ daemon: DaemonFixture }>({
-  daemon: async ({}, use) => {
+  // AC: @e2e-test-daemon-isolation ac-5 — dynamic baseURL from daemon fixture
+  baseURL: async ({ daemon }, use) => {
+    await use(daemon.baseUrl);
+  },
+
+  daemon: [async ({}, use) => {
     // Check Bun is available (daemon requires it)
     if (!(await checkBunAvailable())) {
       throw new Error(
@@ -77,13 +75,27 @@ export const test = base.extend<{ daemon: DaemonFixture }>({
       );
     }
 
-    // Clean up any existing daemon
-    await cleanupExistingDaemon();
+    // AC: @e2e-test-daemon-isolation ac-1 — use ephemeral port, never hardcoded
+    // AC: @e2e-test-daemon-isolation ac-2 — never kill user daemons
+    const port = await getAvailablePort();
+    const baseUrl = `http://localhost:${port}`;
+    const wsUrl = `ws://localhost:${port}`;
 
     // Create temp directory with .kspec subdirectory
     const tempDir = join(tmpdir(), 'kspec-e2e-' + Date.now());
     const kspecDir = join(tempDir, '.kspec');
     mkdirSync(kspecDir, { recursive: true });
+
+    // AC: @e2e-test-daemon-isolation ac-3 — isolated HOME/config
+    const isolatedHome = join(tempDir, '.home');
+    const configDir = join(isolatedHome, '.config', 'kspec');
+    mkdirSync(configDir, { recursive: true });
+    const isolatedEnv = {
+      ...process.env,
+      HOME: isolatedHome,
+      USERPROFILE: isolatedHome,
+      WEB_UI_DIR: WEB_UI_BUILD,
+    };
 
     // Copy E2E test fixtures to .kspec subdirectory (simulating shadow worktree mode)
     if (existsSync(E2E_FIXTURES)) {
@@ -107,13 +119,9 @@ export const test = base.extend<{ daemon: DaemonFixture }>({
     execSync('git config user.name "Test"', { cwd: tempDir, stdio: 'ignore' });
 
     // Set up shadow worktree simulation for kspec to detect .kspec/ as spec directory
-    // The shadow detection checks if .kspec/.git is a file starting with "gitdir:"
-    // We create a fake .git file that satisfies this check
     const gitWorktreesDir = join(tempDir, '.git', 'worktrees', '-kspec');
     mkdirSync(gitWorktreesDir, { recursive: true });
-    // Create the .git file in .kspec pointing to the worktree location
     writeFileSync(join(kspecDir, '.git'), `gitdir: ${gitWorktreesDir}\n`);
-    // Create minimal worktree metadata so git doesn't complain
     writeFileSync(join(gitWorktreesDir, 'gitdir'), `${join(tempDir, '.git')}\n`);
     writeFileSync(join(gitWorktreesDir, 'HEAD'), 'ref: refs/heads/kspec-meta\n');
 
@@ -125,15 +133,14 @@ export const test = base.extend<{ daemon: DaemonFixture }>({
       );
     }
 
-    // Start daemon - pass project root (tempDir), daemon derives .kspec internally
-    // Set WEB_UI_DIR so daemon serves the built web UI
+    // Start daemon on ephemeral port with isolated HOME
     const startResult = spawnSync(
       'kspec',
-      ['serve', 'start', '--daemon', '--port', String(DAEMON_PORT), '--kspec-dir', tempDir],
+      ['serve', 'start', '--daemon', '--port', String(port), '--kspec-dir', tempDir],
       {
         cwd: tempDir,
         encoding: 'utf-8',
-        env: { ...process.env, WEB_UI_DIR: WEB_UI_BUILD }
+        env: isolatedEnv,
       }
     );
 
@@ -146,7 +153,7 @@ export const test = base.extend<{ daemon: DaemonFixture }>({
     const pollInterval = 100;
     for (let i = 0; i < maxAttempts; i++) {
       try {
-        const response = await fetch(`http://localhost:${DAEMON_PORT}/api/health`);
+        const response = await fetch(`${baseUrl}/api/health`);
         if (response.ok) break;
       } catch {
         // Daemon not ready yet
@@ -163,10 +170,8 @@ export const test = base.extend<{ daemon: DaemonFixture }>({
       const secondProjectPath = tempDir + '-second';
       const secondKspecDir = join(secondProjectPath, '.kspec');
 
-      // Create project directory with valid .kspec structure
       mkdirSync(secondKspecDir, { recursive: true });
 
-      // Create minimal kynetic.yaml
       writeFileSync(
         join(secondKspecDir, 'kynetic.yaml'),
         `kynetic: "1.0"
@@ -174,7 +179,6 @@ project: Second Test Project
 `
       );
 
-      // Create project.tasks.yaml (empty tasks file)
       writeFileSync(
         join(secondKspecDir, 'project.tasks.yaml'),
         `# Tasks for second test project
@@ -182,20 +186,18 @@ tasks: []
 `
       );
 
-      // Initialize git repo in second project
       execSync('git init', { cwd: secondProjectPath, stdio: 'ignore' });
       execSync('git config user.email "test@test.com"', { cwd: secondProjectPath, stdio: 'ignore' });
       execSync('git config user.name "Test"', { cwd: secondProjectPath, stdio: 'ignore' });
 
-      // Set up shadow worktree simulation (same as main project)
       const gitWorktreesDir = join(secondProjectPath, '.git', 'worktrees', '-kspec');
       mkdirSync(gitWorktreesDir, { recursive: true });
       writeFileSync(join(secondKspecDir, '.git'), `gitdir: ${gitWorktreesDir}\n`);
       writeFileSync(join(gitWorktreesDir, 'gitdir'), `${join(secondProjectPath, '.git')}\n`);
       writeFileSync(join(gitWorktreesDir, 'HEAD'), 'ref: refs/heads/kspec-meta\n');
 
-      // Register second project with daemon
-      const response = await fetch(`http://localhost:${DAEMON_PORT}/api/projects`, {
+      // AC: @e2e-test-daemon-isolation ac-5 — use dynamic port
+      const response = await fetch(`${baseUrl}/api/projects`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ path: secondProjectPath }),
@@ -209,25 +211,25 @@ tasks: []
       return secondProjectPath;
     }
 
-    // Provide fixture to test
-    await use({ tempDir, kspecDir, createSecondProject });
+    // AC: @e2e-test-daemon-isolation ac-5 — propagate port/URLs to all tests
+    await use({ tempDir, kspecDir, port, baseUrl, wsUrl, createSecondProject });
 
-    // Cleanup: stop daemon - pass project root to match start
+    // AC: @e2e-test-daemon-isolation ac-4 — scoped cleanup via serve stop, not process killing
     spawnSync('kspec', ['serve', 'stop', '--kspec-dir', tempDir], {
       cwd: tempDir,
       encoding: 'utf-8',
+      env: isolatedEnv,
     });
-    await new Promise((r) => setTimeout(r, 1000));
+    await new Promise((r) => setTimeout(r, 500));
 
-    // Remove temp directories (main and any second project)
+    // Remove temp directories
     try {
       rmSync(tempDir, { recursive: true, force: true });
-      // Also clean up second project if it exists
       rmSync(tempDir + '-second', { recursive: true, force: true });
     } catch {
       // Best effort cleanup
     }
-  },
+  }, { scope: 'test' }],
 });
 
 export { expect };


### PR DESCRIPTION
## Summary

- **Removes `cleanupExistingDaemon()`** which killed user daemons on port 3456 via `lsof`/`SIGTERM`
- **Ephemeral ports**: Each test daemon binds to OS-assigned port 0, eliminating port conflicts
- **HOME isolation**: Tests use isolated HOME/config directories so PID/port state never leaks
- **Scoped cleanup**: Teardown uses `kspec serve stop` instead of process killing
- **Port propagation**: All 13 spec files updated to use `daemon.baseUrl`/`daemon.wsUrl`/`daemon.port` from fixture

Extends the vitest isolation patterns (PR #658) to Playwright E2E infrastructure.

## Acceptance Criteria Coverage

| AC | Description | Status |
|----|-------------|--------|
| ac-1 | Ephemeral port (OS-assigned, port 0) | ✅ `getAvailablePort()` via `net.createServer` |
| ac-2 | Never kill user daemons | ✅ `cleanupExistingDaemon()` removed entirely |
| ac-3 | HOME/config isolation | ✅ `isolatedHome` with `.config/kspec` |
| ac-4 | Scoped cleanup via `serve stop` | ✅ `kspec serve stop --kspec-dir` in teardown |
| ac-5 | Dynamic port propagated to all fixtures | ✅ All spec files use `daemon.baseUrl` |

## Files Changed (15)

- `test-base.ts` — Core fixture rewrite (ephemeral port, HOME isolation, cleanup)
- `playwright.config.ts` — Removed hardcoded baseURL/port
- 13 spec files — Replaced hardcoded URLs with `daemon.baseUrl`/`daemon.wsUrl`

## Test Plan

- [x] Smoke tests pass (5/5)
- [x] api-server and api-tasks pass (26/31 — 5 pre-existing failures unrelated)
- [ ] Full E2E suite passes in CI
- [ ] Verify user daemon on :3456 is NOT killed when tests run

Task: @task-e2e-daemon-isolation
Spec: @e2e-test-daemon-isolation

🤖 Generated with [Claude Code](https://claude.com/claude-code)