### PR TITLE
fix: add missing @elysiajs/static dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
       ],
       "dependencies": {
         "@elysiajs/cors": "^1.1.3",
+        "@elysiajs/static": "^1.4.7",
         "chalk": "^5.3.0",
         "chokidar": "^4.0.3",
         "cli-table3": "^0.6.5",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   },
   "dependencies": {
     "@elysiajs/cors": "^1.1.3",
+    "@elysiajs/static": "^1.4.7",
     "chalk": "^5.3.0",
     "chokidar": "^4.0.3",
     "cli-table3": "^0.6.5",

--- a/tests/package-distribution.test.ts
+++ b/tests/package-distribution.test.ts
@@ -99,6 +99,19 @@ describe('Package Distribution', () => {
     });
   });
 
+  describe('published root package includes daemon runtime dependencies', () => {
+    it('declares @elysiajs/static for global installs', async () => {
+      // AC: @web-ui ac-1
+      const packageJsonPath = path.join(PACKAGE_ROOT, 'package.json');
+      const content = await fs.readFile(packageJsonPath, 'utf-8');
+      const pkg = JSON.parse(content);
+
+      expect(pkg.dependencies?.['@elysiajs/cors']).toBeTruthy();
+      expect(pkg.dependencies?.['@elysiajs/static']).toBeTruthy();
+      expect(pkg.dependencies?.elysia).toBeTruthy();
+    });
+  });
+
   // AC: @package-distribution ac-5
   describe('plugin/ directory contains valid plugin structure', () => {
     it('plugin/.claude-plugin/plugin.json exists with correct version', async () => {


### PR DESCRIPTION
## Summary
- add @elysiajs/static to the published root package dependencies
- sync the root lockfile entry for the new runtime dependency
- add a packaging regression test covering daemon runtime deps needed by global installs

## Verification
- npx vitest run tests/package-distribution.test.ts
- npm test

## Notes
- kspec validate is currently failing on unrelated pre-existing meta/reference/completeness issues in the repository baseline (for example duplicate @observations refs and missing skill content), not from this change.

Task: @01KK5E7VM0ZQ7SXE5547293KH6
Spec: @web-ui
