### PR TITLE
fix(guard): use exact match for shadow branch deletion check

### DIFF
--- a/src/cli/commands/guard.ts
+++ b/src/cli/commands/guard.ts
@@ -11,6 +11,7 @@
 import type { Command } from "commander";
 import { EXIT_CODES } from "../exit-codes.js";
 import { isJsonMode, output } from "../output.js";
+import { SHADOW_BRANCH_NAME } from "../../parser/shadow.js";
 
 /**
  * Decision from a guard check
@@ -81,13 +82,12 @@ function isInKspec(command: string, cwd: string | undefined): boolean {
 /**
  * Check if a command attempts to delete the kspec-meta branch.
  */
-function isKspecMetaDeletion(command: string): boolean {
+function isShadowBranchDeletion(command: string): boolean {
   // Remove quote characters to catch split-quote bypasses like git "branch" -D kspec-meta
   const unquoted = command.replace(/["']/g, "");
-  return (
-    unquoted.includes("git branch -d kspec-meta") ||
-    unquoted.includes("git branch -D kspec-meta")
-  );
+  // Escape branch name for regex and use word boundary to avoid matching prefixed branches
+  const escaped = SHADOW_BRANCH_NAME.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`git\\s+branch\\s+-[dD]\\s+(?:.*\\s+)?${escaped}(?:\\s|$)`).test(unquoted);
 }
 
 /**
@@ -135,12 +135,12 @@ export function evaluateWorktreeGuard(input: PreToolUseInput): GuardDecision {
     return { decision: "allow" };
   }
 
-  // Block kspec-meta branch deletion from anywhere
-  if (isKspecMetaDeletion(command)) {
+  // Block shadow branch deletion from anywhere
+  if (isShadowBranchDeletion(command)) {
     return {
       decision: "block",
       reason:
-        "[kspec-worktree-guard] BLOCKED: Cannot delete kspec-meta branch. This is the main branch for the .kspec worktree.",
+        `[kspec-worktree-guard] BLOCKED: Cannot delete ${SHADOW_BRANCH_NAME} branch. This is the main branch for the .kspec worktree.`,
     };
   }
 

--- a/tests/guard-worktree.test.ts
+++ b/tests/guard-worktree.test.ts
@@ -277,6 +277,14 @@ describe("evaluateWorktreeGuard", () => {
       });
       expect(result.decision).toBe("block");
     });
+
+    it("allows deleting branches with kspec-meta prefix", () => {
+      const result = evaluateWorktreeGuard({
+        tool_input: { command: "git branch -D kspec-meta-backup-2026-02-28" },
+        cwd: "/home/user/project",
+      });
+      expect(result.decision).toBe("allow");
+    });
   });
 
   // AC: @native-guard-commands ac-worktree-guard - cd to .kspec detection


### PR DESCRIPTION
## Summary
- Worktree guard used substring matching for shadow branch deletion detection, which incorrectly blocked deleting branches with a `kspec-meta` prefix (e.g. `kspec-meta-backup-2026-02-28`)
- Switch to regex with word boundary for exact branch name matching
- Use `SHADOW_BRANCH_NAME` constant instead of hardcoding `kspec-meta`, so the guard works with any configured shadow branch name

## Test plan
- [x] Existing 45 guard tests pass
- [x] New test: allows deleting branches with `kspec-meta` prefix
- [x] Verified fix works end-to-end (deleted `kspec-meta-backup-2026-02-28` after rebuild)

🤖 Generated with [Claude Code](https://claude.ai/code)