### PR TITLE
fix(agents): strip CLAUDECODE env var before spawning subprocesses

### DIFF
--- a/src/agents/spawner.ts
+++ b/src/agents/spawner.ts
@@ -100,9 +100,11 @@ export function spawnAgent(
 ): SpawnedAgent {
   const { cwd, env = {}, extraArgs, clientOptions = {} } = options;
 
-  // Merge environment variables
+  // Merge environment variables, removing CLAUDECODE to prevent nested session
+  // detection when the daemon was started from within a Claude Code environment.
+  const { CLAUDECODE: _, ...cleanProcessEnv } = process.env;
   const processEnv = {
-    ...process.env,
+    ...cleanProcessEnv,
     ...adapter.env,
     ...env,
   };


### PR DESCRIPTION
## Summary

- Strip `CLAUDECODE` environment variable in `spawnAgent()` before spawning agent subprocesses
- Prevents Claude Code from detecting a "nested session" and refusing to start when the kspec daemon was launched from within a Claude Code environment (e.g., Claude-Terminal)

## Test plan

- [ ] Start kspec daemon from within Claude-Terminal or any Claude Code session
- [ ] Run `kspec agent dispatch start` on a project with eligible tasks
- [ ] Verify agents spawn and complete successfully instead of failing with "Query closed before response received"

Fixes #700

🤖 Generated with [Claude Code](https://claude.com/claude-code)