### PR TITLE
fix: support git < 2.42 in kspec init (--orphan worktree fallback)

### DIFF
--- a/src/parser/shadow.ts
+++ b/src/parser/shadow.ts
@@ -11,6 +11,7 @@
 
 import { execFile, spawn, spawnSync } from "node:child_process";
 import * as fs from "node:fs/promises";
+import { tmpdir } from "node:os";
 import * as path from "node:path";
 import { promisify } from "node:util";
 import { fileURLToPath } from "node:url";
@@ -72,6 +73,147 @@ function runGitSync(
     ok: !result.error && result.status === 0,
     stdout: (result.stdout || "").toString(),
   };
+}
+
+/**
+ * Parse git version from `git --version` output.
+ * Returns [major, minor, patch] or null if unparseable.
+ */
+export function getGitVersion(
+  cwd?: string,
+): [number, number, number] | null {
+  const result = spawnSync("git", ["--version"], {
+    cwd,
+    stdio: ["ignore", "pipe", "pipe"],
+    encoding: "utf-8",
+  });
+  if (result.error || result.status !== 0) return null;
+  const match = (result.stdout || "").match(/(\d+)\.(\d+)\.(\d+)/);
+  if (!match) return null;
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+/**
+ * Check if the installed git supports `git worktree add --orphan` (requires >= 2.42.0).
+ */
+export function gitSupportsOrphanWorktree(cwd?: string): boolean {
+  const version = getGitVersion(cwd);
+  if (!version) return false;
+  const [major, minor] = version;
+  return major > 2 || (major === 2 && minor >= 42);
+}
+
+/**
+ * Fallback for creating an orphan branch when git < 2.42.
+ *
+ * Strategy:
+ * 1. Create a temp bare repo in the OS temp directory
+ * 2. Create an orphan branch with an empty commit there
+ * 3. Push that branch to the project repo (via file:// protocol)
+ * 4. Clean up the temp repo
+ * 5. Attach using standard `git worktree add <dir> <branch>`
+ *
+ * This approach NEVER modifies the project's working tree.
+ *
+ * AC: @config-shadow ac-10
+ */
+export async function createOrphanBranchFallback(
+  projectRoot: string,
+  branchName: string,
+  directoryName: string,
+): Promise<void> {
+  const tmpDir = await fs.mkdtemp(path.join(tmpdir(), "kspec-orphan-"));
+
+  try {
+    // 1. Init a bare repo in the temp dir
+    await runGitAsync(tmpDir, ["init", "--bare"]);
+
+    // 2. Create the orphan branch using a temporary non-bare clone.
+    //    We need a working tree to make a commit, so clone the bare repo.
+    const workDir = await fs.mkdtemp(path.join(tmpdir(), "kspec-orphan-work-"));
+
+    try {
+      await runGitAsync(workDir, ["clone", tmpDir, "."]);
+      await runGitAsync(workDir, [
+        "config",
+        "user.email",
+        "kspec@localhost",
+      ]);
+      await runGitAsync(workDir, [
+        "config",
+        "user.name",
+        "kspec",
+      ]);
+
+      // Create an orphan branch (checkout --orphan works on all git versions)
+      await runGitAsync(workDir, [
+        "checkout",
+        "--orphan",
+        branchName,
+      ]);
+
+      // Remove any files that might have been staged
+      try {
+        await runGitAsync(workDir, ["rm", "-rf", "."]);
+      } catch {
+        // May fail if nothing to remove (empty repo) - that's fine
+      }
+
+      // Create an empty initial commit
+      await runGitAsync(workDir, [
+        "commit",
+        "--allow-empty",
+        "-m",
+        `Initialize ${branchName}`,
+      ]);
+
+      // Push the orphan branch back to the bare repo
+      await runGitAsync(workDir, [
+        "push",
+        "origin",
+        branchName,
+      ]);
+    } finally {
+      await fs.rm(workDir, { recursive: true, force: true });
+    }
+
+    // 3. Push from the temp bare repo to the project repo
+    //    Use file:// protocol to ensure git treats it as a proper remote
+    await runGitAsync(tmpDir, [
+      "push",
+      `file://${path.resolve(projectRoot)}`,
+      branchName,
+    ]);
+  } finally {
+    // 4. Clean up the temp bare repo
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  }
+
+  // 5. Attach worktree using standard git worktree add (no --orphan flag)
+  await runGitAsync(projectRoot, [
+    "worktree",
+    "add",
+    directoryName,
+    branchName,
+  ]);
+
+  // 6. Remove all tracked files from the worktree since the fallback
+  //    created an empty commit but `git worktree add` may still populate
+  //    the index from the branch. Clear anything that appeared.
+  try {
+    const { stdout } = await runGitAsync(
+      path.join(projectRoot, directoryName),
+      ["ls-files"],
+    );
+    if (stdout.trim()) {
+      await runGitAsync(
+        path.join(projectRoot, directoryName),
+        ["rm", "-rf", "."],
+      );
+    }
+  } catch {
+    // Nothing to remove — expected for an empty commit
+  }
 }
 
 // Import getVerboseMode for checking CLI --debug-shadow flag
@@ -1868,14 +2010,23 @@ export async function initializeShadow(
       } else if (!status.branchExists) {
         // AC: @shadow-init-remote ac-2 ac-3 - No remote branch or no remote - create orphan branch
         // AC: @config-shadow ac-1 — use configured branch name
-        await runGitAsync(projectRoot, [
-          "worktree",
-          "add",
-          "--orphan",
-          "-b",
-          branchName,
-          directoryName,
-        ]);
+        // AC: @config-shadow ac-10 — fallback for git < 2.42
+        if (gitSupportsOrphanWorktree(projectRoot)) {
+          await runGitAsync(projectRoot, [
+            "worktree",
+            "add",
+            "--orphan",
+            "-b",
+            branchName,
+            directoryName,
+          ]);
+        } else {
+          await createOrphanBranchFallback(
+            projectRoot,
+            branchName,
+            directoryName,
+          );
+        }
         result.branchCreated = true;
       } else {
         // Attach to existing local branch

--- a/tests/shadow.test.ts
+++ b/tests/shadow.test.ts
@@ -28,6 +28,9 @@ import {
   setVerboseModeGetter,
   shadowAutoCommit,
   checkConfigMismatch,
+  getGitVersion,
+  gitSupportsOrphanWorktree,
+  createOrphanBranchFallback,
   type ShadowOptions,
 } from '../src/parser/shadow.js';
 import { initContext } from '../src/parser/yaml.js';
@@ -1874,6 +1877,172 @@ describe('Shadow Branch', () => {
         expect(shadow?.branchName).toBe(customBranch);
         expect(shadow?.worktreeDir).toBe(customDirPath);
       });
+    });
+  });
+
+  // ══════════════════════════════════════════════════════════════════════════
+  // Git Version Detection & Orphan Worktree Fallback
+  // AC: @config-shadow ac-10 — fallback for git < 2.42
+  // ══════════════════════════════════════════════════════════════════════════
+
+  describe('Git Version Detection', () => {
+    // AC: @config-shadow ac-10
+    it('getGitVersion returns a valid version tuple', () => {
+      const version = getGitVersion();
+      expect(version).not.toBeNull();
+      expect(version).toHaveLength(3);
+      expect(version![0]).toBeGreaterThanOrEqual(1);
+      expect(version![1]).toBeGreaterThanOrEqual(0);
+      expect(version![2]).toBeGreaterThanOrEqual(0);
+    });
+
+    // AC: @config-shadow ac-10
+    it('gitSupportsOrphanWorktree returns a boolean', () => {
+      const result = gitSupportsOrphanWorktree();
+      expect(typeof result).toBe('boolean');
+    });
+  });
+
+  describe('createOrphanBranchFallback (git < 2.42 compatibility)', () => {
+    // AC: @config-shadow ac-10
+    it('creates orphan branch and worktree without --orphan flag', async () => {
+      // Initialize a git repo
+      execSync('git init', { cwd: testDir, stdio: 'pipe' });
+      execSync('git config user.email "test@test.com"', { cwd: testDir, stdio: 'pipe' });
+      execSync('git config user.name "Test"', { cwd: testDir, stdio: 'pipe' });
+      await fs.writeFile(path.join(testDir, 'README.md'), '# Test');
+      execSync('git add . && git commit -m "initial"', { cwd: testDir, stdio: 'pipe' });
+
+      // Use the fallback directly
+      await createOrphanBranchFallback(testDir, 'orphan-test', '.orphan-wt');
+
+      // Verify the branch was created
+      const hasBranch = await branchExists(testDir, 'orphan-test');
+      expect(hasBranch).toBe(true);
+
+      // Verify the worktree was created and is valid
+      const worktreeDir = path.join(testDir, '.orphan-wt');
+      expect(await isValidWorktree(worktreeDir)).toBe(true);
+
+      // Verify the orphan branch has no parent (orphan = first commit has no parents)
+      const parents = execSync('git log --format=%P -1 orphan-test', {
+        cwd: testDir,
+        encoding: 'utf-8',
+      }).trim();
+      expect(parents).toBe('');
+
+      // Verify the orphan branch does NOT share history with main
+      try {
+        const mergeBase = execSync('git merge-base main orphan-test', {
+          cwd: testDir,
+          encoding: 'utf-8',
+          stdio: ['pipe', 'pipe', 'pipe'],
+        }).trim();
+        // If merge-base succeeds, branches share history — that's wrong
+        expect(mergeBase).toBe('');
+      } catch {
+        // Expected: merge-base fails when branches share no common ancestor
+      }
+    });
+
+    // AC: @config-shadow ac-10
+    it('does not modify the project working tree', async () => {
+      // Initialize a git repo with some content
+      execSync('git init', { cwd: testDir, stdio: 'pipe' });
+      execSync('git config user.email "test@test.com"', { cwd: testDir, stdio: 'pipe' });
+      execSync('git config user.name "Test"', { cwd: testDir, stdio: 'pipe' });
+      await fs.writeFile(path.join(testDir, 'README.md'), '# Test');
+      await fs.writeFile(path.join(testDir, 'src.ts'), 'export const x = 1;');
+      execSync('git add . && git commit -m "initial"', { cwd: testDir, stdio: 'pipe' });
+
+      // Run the fallback
+      await createOrphanBranchFallback(testDir, 'safe-orphan', '.safe-wt');
+
+      // Working tree should be unchanged — only the worktree dir itself is new/untracked.
+      // No modifications to existing tracked files on the main branch.
+      const statusAfter = execSync('git status --porcelain', {
+        cwd: testDir,
+        encoding: 'utf-8',
+      }).trim();
+      // Filter out the worktree directory itself (expected to be untracked)
+      const changesExcludingWorktree = statusAfter
+        .split('\n')
+        .filter(line => !line.includes('.safe-wt'))
+        .join('\n')
+        .trim();
+      expect(changesExcludingWorktree).toBe('');
+
+      // Original files should still be present and unchanged
+      const readme = await fs.readFile(path.join(testDir, 'README.md'), 'utf-8');
+      expect(readme).toBe('# Test');
+      const src = await fs.readFile(path.join(testDir, 'src.ts'), 'utf-8');
+      expect(src).toBe('export const x = 1;');
+
+      // Current branch should still be whatever it was (not switched)
+      const currentBranch = execSync('git rev-parse --abbrev-ref HEAD', {
+        cwd: testDir,
+        encoding: 'utf-8',
+      }).trim();
+      expect(currentBranch).not.toBe('safe-orphan');
+    });
+
+    // AC: @config-shadow ac-10
+    it('works with custom branch names', async () => {
+      execSync('git init', { cwd: testDir, stdio: 'pipe' });
+      execSync('git config user.email "test@test.com"', { cwd: testDir, stdio: 'pipe' });
+      execSync('git config user.name "Test"', { cwd: testDir, stdio: 'pipe' });
+      await fs.writeFile(path.join(testDir, 'README.md'), '# Test');
+      execSync('git add . && git commit -m "initial"', { cwd: testDir, stdio: 'pipe' });
+
+      await createOrphanBranchFallback(testDir, 'my-custom-specs', '.my-specs');
+
+      expect(await branchExists(testDir, 'my-custom-specs')).toBe(true);
+      expect(await isValidWorktree(path.join(testDir, '.my-specs'))).toBe(true);
+    });
+
+    // AC: @config-shadow ac-10
+    it('initializeShadow produces a healthy shadow regardless of git version', async () => {
+      // This test verifies end-to-end: initializeShadow → detect → status
+      // It works on any git version since it exercises whatever path is chosen
+      execSync('git init', { cwd: testDir, stdio: 'pipe' });
+      execSync('git config user.email "test@test.com"', { cwd: testDir, stdio: 'pipe' });
+      execSync('git config user.name "Test"', { cwd: testDir, stdio: 'pipe' });
+      await fs.writeFile(path.join(testDir, 'README.md'), '# Test');
+      execSync('git add . && git commit -m "initial"', { cwd: testDir, stdio: 'pipe' });
+
+      const result = await initializeShadow(testDir, { projectName: 'Test Project' });
+
+      expect(result.success).toBe(true);
+      expect(result.branchCreated).toBe(true);
+      expect(result.worktreeCreated).toBe(true);
+
+      // Verify the result is fully healthy
+      const status = await getShadowStatus(testDir);
+      expect(status.healthy).toBe(true);
+      expect(status.branchExists).toBe(true);
+      expect(status.worktreeExists).toBe(true);
+      expect(status.worktreeLinked).toBe(true);
+    });
+
+    // AC: @config-shadow ac-10
+    it('cleans up temp directories on success', async () => {
+      execSync('git init', { cwd: testDir, stdio: 'pipe' });
+      execSync('git config user.email "test@test.com"', { cwd: testDir, stdio: 'pipe' });
+      execSync('git config user.name "Test"', { cwd: testDir, stdio: 'pipe' });
+      await fs.writeFile(path.join(testDir, 'README.md'), '# Test');
+      execSync('git add . && git commit -m "initial"', { cwd: testDir, stdio: 'pipe' });
+
+      // Count kspec-orphan temp dirs before
+      const tmpBase = require('node:os').tmpdir();
+      const beforeDirs = (await fs.readdir(tmpBase))
+        .filter(d => d.startsWith('kspec-orphan'));
+
+      await createOrphanBranchFallback(testDir, 'cleanup-test', '.cleanup-wt');
+
+      // Count after — should not increase (temp dirs cleaned up)
+      const afterDirs = (await fs.readdir(tmpBase))
+        .filter(d => d.startsWith('kspec-orphan'));
+      expect(afterDirs.length).toBeLessThanOrEqual(beforeDirs.length);
     });
   });
 });


### PR DESCRIPTION
## Summary

- Add backward-compatible fallback for `kspec init` on git < 2.42 (Debian 12, Ubuntu 22.04)
- `git worktree add --orphan` was introduced in git 2.42 (Aug 2023); older versions fail
- Fallback creates orphan branch via temp bare repo in `/tmp`, then attaches with standard `git worktree add` — never modifies the project working tree
- Auto-detects git version and selects the appropriate path

## Changes

- `src/parser/shadow.ts`: Add `getGitVersion()`, `gitSupportsOrphanWorktree()`, and `createOrphanBranchFallback()`. Modify `initializeShadow()` to use fallback when needed.
- `tests/shadow.test.ts`: 7 new tests covering version detection, fallback correctness, working tree safety, custom branch names, and temp directory cleanup.

## Test plan

- [x] All 94 shadow tests pass
- [x] Full test suite (3 shards) passes with no new failures
- [x] `kspec validate` passes
- [x] TypeScript compiles cleanly
- [x] Fallback verified: creates orphan branch, does not modify working tree, cleans up temp dirs

Task: @01KK5E7WQ76A3HJAD8BCF6PF3A
Spec: @config-shadow ac-10

🤖 Generated with [Claude Code](https://claude.com/claude-code)