### PR TITLE
fix(cli): allow kspec setup to proceed without agent environment

### DIFF
--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -1664,6 +1664,13 @@ export async function runSetupPipeline(
             status: "done",
             message: `KSPEC_AUTHOR="${author}"`,
           });
+        } else if (detected.type === "unknown") {
+          // AC: @cmd-setup ac-1 - show manual instructions for unknown agents
+          steps.push({
+            name: "Configure author",
+            status: "skipped",
+            message: `no auto-config for unknown agent — set KSPEC_AUTHOR manually`,
+          });
         }
       }
     }
@@ -1867,10 +1874,9 @@ export function registerSetupCommand(program: Command): void {
           : detectAgent();
         const dryRun = options.dryRun || false;
 
+        // AC: @cmd-setup ac-1 - proceed with setup even when no agent is detected
         if (detected.type === "unknown") {
-          warn("Could not auto-detect agent environment");
-          printManualInstructions("unknown");
-          return;
+          warn("Could not auto-detect agent environment — proceeding with core setup steps");
         }
 
         // AC: @setup-pipeline-unification ac-3 - delegate to runSetupPipeline()
@@ -1941,6 +1947,11 @@ export function registerSetupCommand(program: Command): void {
               console.log(
                 chalk.gray("Restart your agent session for changes to take effect."),
               );
+            }
+
+            // AC: @cmd-setup ac-1 - print manual KSPEC_AUTHOR instructions for unknown agents
+            if (detected.type === "unknown") {
+              printManualInstructions("unknown");
             }
           },
         );

--- a/tests/setup.test.ts
+++ b/tests/setup.test.ts
@@ -3,6 +3,7 @@ import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import { execSync, spawnSync } from 'node:child_process';
 import { SHADOW_BRANCH_NAME, SHADOW_WORKTREE_DIR } from '../src/parser/shadow.js';
+import { kspec, createTempDir, cleanupTempDir, initGitRepo } from './helpers/cli.js';
 
 describe('kspec setup', () => {
   const testDir = path.join('/tmp', `kspec-setup-test-${Date.now()}`);
@@ -136,5 +137,90 @@ describe('kspec setup', () => {
     // Should prompt with the expected message
     expect(result.stdout).toContain(`${SHADOW_BRANCH_NAME} branch exists but .kspec worktree is missing. Create it?`);
     expect(result.status).toBe(1); // Exit with error since user declined
+  });
+});
+
+describe('kspec setup without agent environment', () => {
+  let tempDir: string;
+  const kspecBinPath = path.join(process.cwd(), 'dist', 'cli', 'index.js');
+
+  // Build a minimal env that has NO agent detection vars at all.
+  // This prevents false detection (e.g. AIDER_DARK_MODE !== undefined).
+  function cleanEnv(): Record<string, string> {
+    return {
+      PATH: process.env.PATH || '',
+      HOME: '/tmp/fake-home-no-claude', // Prevent ~/.claude fallback
+      NODE_PATH: process.env.NODE_PATH || '',
+      KSPEC_AUTHOR: '', // Explicitly unset so Configure author step runs
+    };
+  }
+
+  function runSetup(args: string): { exitCode: number; stdout: string; stderr: string } {
+    const result = spawnSync('node', [kspecBinPath, 'setup', ...args.split(' ').filter(Boolean)], {
+      cwd: tempDir,
+      encoding: 'utf-8',
+      timeout: 30_000,
+      env: cleanEnv(),
+    });
+    return {
+      exitCode: result.status ?? 1,
+      stdout: (result.stdout || '').trim(),
+      stderr: (result.stderr || '').trim(),
+    };
+  }
+
+  beforeEach(async () => {
+    tempDir = await createTempDir('kspec-setup-no-agent-');
+    initGitRepo(tempDir);
+
+    // Create initial commit
+    await fs.writeFile(path.join(tempDir, 'README.md'), '# Test', 'utf-8');
+    execSync('git add README.md && git commit -m "Initial"', {
+      cwd: tempDir,
+      stdio: 'pipe',
+    });
+
+    // Initialize kspec project so setup pipeline has something to work with
+    kspec('init --name test-project --no-prompt', tempDir);
+  });
+
+  afterEach(async () => {
+    await cleanupTempDir(tempDir);
+  });
+
+  // AC: @cmd-setup ac-1
+  it('should proceed with core setup steps when no agent environment is detected', () => {
+    const result = runSetup('--dry-run');
+
+    // Should NOT exit with error
+    expect(result.exitCode).toBe(0);
+    // Should warn about missing agent but proceed
+    expect(result.stderr).toContain('Could not auto-detect agent environment');
+    // Should still run the pipeline and show setup summary steps
+    expect(result.stdout).toContain('Agent detection');
+    expect(result.stdout).toContain('unknown');
+    expect(result.stdout).toContain('Install core skills');
+    expect(result.stdout).toContain('Render skills');
+    expect(result.stdout).toContain('Generate kspec-agents.md');
+  });
+
+  // AC: @cmd-setup ac-1
+  it('should print manual KSPEC_AUTHOR instructions for unknown agents', () => {
+    const result = runSetup('--dry-run');
+
+    expect(result.exitCode).toBe(0);
+    // Should show manual instructions for setting KSPEC_AUTHOR
+    expect(result.stdout).toContain('KSPEC_AUTHOR');
+    expect(result.stdout).toContain('export KSPEC_AUTHOR');
+  });
+
+  // AC: @cmd-setup ac-1
+  it('should show skipped Configure author step for unknown agents', () => {
+    const result = runSetup('--dry-run');
+
+    expect(result.exitCode).toBe(0);
+    // Should show Configure author as skipped with manual instructions message
+    expect(result.stdout).toContain('Configure author');
+    expect(result.stdout).toContain('no auto-config for unknown agent');
   });
 });


### PR DESCRIPTION
## Summary
- When no agent environment is detected, `kspec setup` previously exited early with a warning and did nothing
- Now it warns but proceeds with the full setup pipeline: core skills, skill rendering, kspec-agents.md generation, built-in agents
- Agent-specific steps (hooks, permissions, memory seeding) are gracefully skipped for unknown agents
- Manual `KSPEC_AUTHOR` instructions are printed after the pipeline completes

## Test plan
- [x] AC `@cmd-setup ac-1`: 3 new tests verify unknown agent proceeds through pipeline, prints manual instructions, shows skipped Configure author step
- [x] All existing setup tests pass (28/28 across setup, enhanced-setup, pipeline-unification)
- [x] Full shard1 passes (1307 tests)
- [x] Pre-existing codex config test failure is unrelated

Task: @01KK5E7ZTASR8W3AX2WBHFMGV2
Spec: @cmd-setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)