### PR TITLE
fix: resolve 4 test failures under full-suite load

### DIFF
--- a/tests/agent-dispatch-engine.test.ts
+++ b/tests/agent-dispatch-engine.test.ts
@@ -2499,6 +2499,24 @@ describe("Autonomous dispatch prompt guardrails", () => {
       kspecCliPath: MOCK_KSPEC_CLI,
       coalesceWindowMs: 0,
     });
+    // Mock workspace provisioning and bootstrap — this test validates prompt content,
+    // not workspace setup. Without these mocks, workspace provisioning may fail silently
+    // under full-suite load and runInvocation is never reached.
+    vi.spyOn(workspaceModule, "getDispatchWorkspaceHealth").mockResolvedValue({
+      exists: true,
+      healthy: true,
+      reason: null,
+      metadata: null,
+    });
+    const mockMetadata = buildMockWorkspaceMetadata(testDir);
+    vi.spyOn(workspaceModule, "provisionDispatchWorkspace").mockResolvedValue({
+      cwd: testDir,
+      metadataPath: path.join(testDir, ".kspec-dispatch-workspace.json"),
+      metadata: mockMetadata,
+    });
+    vi.spyOn(bootstrapModule, "ensureWorkspaceBootstrap").mockResolvedValue({
+      metadata: mockMetadata,
+    });
 
     await engine.start();
     await engine.handleStateChange({

--- a/tests/canonical-task-workspace-contract.test.ts
+++ b/tests/canonical-task-workspace-contract.test.ts
@@ -278,7 +278,7 @@ describe("canonical task workspace contract", () => {
   });
 
   // AC: @canonical-task-workspace-contract ac-6
-  it("persists cleanup eligibility into canonical workspace metadata during runtime reconciliation", async () => {
+  it("persists cleanup eligibility into canonical workspace metadata during runtime reconciliation", { timeout: 30_000 }, async () => {
     await seedRepo(tempDir);
     git(tempDir, "checkout -b agent-dev");
 

--- a/tests/canonical-task-workspace-contract.test.ts
+++ b/tests/canonical-task-workspace-contract.test.ts
@@ -278,151 +278,155 @@ describe("canonical task workspace contract", () => {
   });
 
   // AC: @canonical-task-workspace-contract ac-6
-  it("persists cleanup eligibility into canonical workspace metadata during runtime reconciliation", { timeout: 30_000 }, async () => {
-    await seedRepo(tempDir);
-    git(tempDir, "checkout -b agent-dev");
+  it(
+    "persists cleanup eligibility into canonical workspace metadata during runtime reconciliation",
+    { timeout: 30_000 },
+    async () => {
+      await seedRepo(tempDir);
+      git(tempDir, "checkout -b agent-dev");
 
-    const completedTaskId = testUlid("TASK", 14);
-    const completedTaskRef = `@${completedTaskId}`;
-    const completedWorkspace = await provisionDispatchWorkspace({
-      projectDir: tempDir,
-      taskRef: completedTaskRef,
-      task: {
-        title: "Cleanup Eligibility Completed",
-        slugs: ["task-cleanup-eligibility-completed"],
-      },
-    });
+      const completedTaskId = testUlid("TASK", 14);
+      const completedTaskRef = `@${completedTaskId}`;
+      const completedWorkspace = await provisionDispatchWorkspace({
+        projectDir: tempDir,
+        taskRef: completedTaskRef,
+        task: {
+          title: "Cleanup Eligibility Completed",
+          slugs: ["task-cleanup-eligibility-completed"],
+        },
+      });
 
-    const cancelledTaskId = testUlid("TASK", 15);
-    const cancelledTaskRef = `@${cancelledTaskId}`;
-    const cancelledWorkspace = await provisionDispatchWorkspace({
-      projectDir: tempDir,
-      taskRef: cancelledTaskRef,
-      task: {
-        title: "Cleanup Eligibility Cancelled",
-        slugs: ["task-cleanup-eligibility-cancelled"],
-      },
-    });
+      const cancelledTaskId = testUlid("TASK", 15);
+      const cancelledTaskRef = `@${cancelledTaskId}`;
+      const cancelledWorkspace = await provisionDispatchWorkspace({
+        projectDir: tempDir,
+        taskRef: cancelledTaskRef,
+        task: {
+          title: "Cleanup Eligibility Cancelled",
+          slugs: ["task-cleanup-eligibility-cancelled"],
+        },
+      });
 
-    const engine = new DispatchEngine({
-      projectDir: tempDir,
-      specDir: tempDir,
-      kspecCliPath: MOCK_KSPEC_CLI,
-      reconcileIntervalMs: 0,
-      coalesceWindowMs: 0,
-    });
-    await engine.start();
+      const engine = new DispatchEngine({
+        projectDir: tempDir,
+        specDir: tempDir,
+        kspecCliPath: MOCK_KSPEC_CLI,
+        reconcileIntervalMs: 0,
+        coalesceWindowMs: 0,
+      });
+      await engine.start();
 
-    await engine.handleStateChange({
-      taskId: completedTaskId,
-      taskRef: completedTaskRef,
-      fromStatus: "pending_review",
-      toStatus: "completed",
-      timestamp: Date.now(),
-      task: {
-        _ulid: completedTaskId,
-        title: "Cleanup Eligibility Completed",
-        slugs: ["task-cleanup-eligibility-completed"],
-        status: "completed",
-        type: "task",
-        priority: 1,
-        blocked_by: [],
-        depends_on: [],
-        context: [],
-        tags: [],
-        vcs_refs: [],
-        notes: [],
-        todos: [],
-        created_at: new Date().toISOString(),
-        automation: "eligible",
-      } as never,
-    });
+      await engine.handleStateChange({
+        taskId: completedTaskId,
+        taskRef: completedTaskRef,
+        fromStatus: "pending_review",
+        toStatus: "completed",
+        timestamp: Date.now(),
+        task: {
+          _ulid: completedTaskId,
+          title: "Cleanup Eligibility Completed",
+          slugs: ["task-cleanup-eligibility-completed"],
+          status: "completed",
+          type: "task",
+          priority: 1,
+          blocked_by: [],
+          depends_on: [],
+          context: [],
+          tags: [],
+          vcs_refs: [],
+          notes: [],
+          todos: [],
+          created_at: new Date().toISOString(),
+          automation: "eligible",
+        } as never,
+      });
 
-    let completedMetadata = await readWorkspaceRecord(
-      completedWorkspace.metadataPath,
-      completedTaskRef,
-    );
-    expect(completedMetadata).toMatchObject({
-      cleanup: {
-        eligible: true,
-        reason: "integrated-into-base-branch",
-      },
-    });
+      let completedMetadata = await readWorkspaceRecord(
+        completedWorkspace.metadataPath,
+        completedTaskRef,
+      );
+      expect(completedMetadata).toMatchObject({
+        cleanup: {
+          eligible: true,
+          reason: "integrated-into-base-branch",
+        },
+      });
 
-    await engine.handleStateChange({
-      taskId: completedTaskId,
-      taskRef: completedTaskRef,
-      fromStatus: "completed",
-      toStatus: "pending",
-      timestamp: Date.now(),
-      task: {
-        _ulid: completedTaskId,
-        title: "Cleanup Eligibility Completed",
-        slugs: ["task-cleanup-eligibility-completed"],
-        status: "pending",
-        type: "task",
-        priority: 1,
-        blocked_by: [],
-        depends_on: [],
-        context: [],
-        tags: [],
-        vcs_refs: [],
-        notes: [],
-        todos: [],
-        created_at: new Date().toISOString(),
-        automation: "eligible",
-      } as never,
-    });
+      await engine.handleStateChange({
+        taskId: completedTaskId,
+        taskRef: completedTaskRef,
+        fromStatus: "completed",
+        toStatus: "pending",
+        timestamp: Date.now(),
+        task: {
+          _ulid: completedTaskId,
+          title: "Cleanup Eligibility Completed",
+          slugs: ["task-cleanup-eligibility-completed"],
+          status: "pending",
+          type: "task",
+          priority: 1,
+          blocked_by: [],
+          depends_on: [],
+          context: [],
+          tags: [],
+          vcs_refs: [],
+          notes: [],
+          todos: [],
+          created_at: new Date().toISOString(),
+          automation: "eligible",
+        } as never,
+      });
 
-    completedMetadata = await readWorkspaceRecord(
-      completedWorkspace.metadataPath,
-      completedTaskRef,
-    );
-    expect(completedMetadata).toMatchObject({
-      cleanup: {
-        eligible: true,
-        reason: "task-reset",
-      },
-    });
+      completedMetadata = await readWorkspaceRecord(
+        completedWorkspace.metadataPath,
+        completedTaskRef,
+      );
+      expect(completedMetadata).toMatchObject({
+        cleanup: {
+          eligible: true,
+          reason: "task-reset",
+        },
+      });
 
-    await engine.handleStateChange({
-      taskId: cancelledTaskId,
-      taskRef: cancelledTaskRef,
-      fromStatus: "in_progress",
-      toStatus: "cancelled",
-      timestamp: Date.now(),
-      task: {
-        _ulid: cancelledTaskId,
-        title: "Cleanup Eligibility Cancelled",
-        slugs: ["task-cleanup-eligibility-cancelled"],
-        status: "cancelled",
-        type: "task",
-        priority: 1,
-        blocked_by: [],
-        depends_on: [],
-        context: [],
-        tags: [],
-        vcs_refs: [],
-        notes: [],
-        todos: [],
-        created_at: new Date().toISOString(),
-        automation: "eligible",
-      } as never,
-    });
+      await engine.handleStateChange({
+        taskId: cancelledTaskId,
+        taskRef: cancelledTaskRef,
+        fromStatus: "in_progress",
+        toStatus: "cancelled",
+        timestamp: Date.now(),
+        task: {
+          _ulid: cancelledTaskId,
+          title: "Cleanup Eligibility Cancelled",
+          slugs: ["task-cleanup-eligibility-cancelled"],
+          status: "cancelled",
+          type: "task",
+          priority: 1,
+          blocked_by: [],
+          depends_on: [],
+          context: [],
+          tags: [],
+          vcs_refs: [],
+          notes: [],
+          todos: [],
+          created_at: new Date().toISOString(),
+          automation: "eligible",
+        } as never,
+      });
 
-    const cancelledMetadata = await readWorkspaceRecord(
-      cancelledWorkspace.metadataPath,
-      cancelledTaskRef,
-    );
-    expect(cancelledMetadata).toMatchObject({
-      cleanup: {
-        eligible: true,
-        reason: "task-abandoned",
-      },
-    });
+      const cancelledMetadata = await readWorkspaceRecord(
+        cancelledWorkspace.metadataPath,
+        cancelledTaskRef,
+      );
+      expect(cancelledMetadata).toMatchObject({
+        cleanup: {
+          eligible: true,
+          reason: "task-abandoned",
+        },
+      });
 
-    await engine.stop();
-  });
+      await engine.stop();
+    },
+  );
 });
 
 // AC: @trait-error-guidance ac-1 — N/A: dispatch worktree isolation is an internal runtime surface,

--- a/tests/dispatch-runtime-bootstrap-contract.test.ts
+++ b/tests/dispatch-runtime-bootstrap-contract.test.ts
@@ -501,7 +501,7 @@ describe("dispatch runtime bootstrap contract", () => {
   });
 
   // AC: @dispatch-runtime-bootstrap-contract ac-4
-  it("records explicit bootstrap invalidation reasons for config, head, and prior failure changes", async () => {
+  it("records explicit bootstrap invalidation reasons for config, head, and prior failure changes", { timeout: 30_000 }, async () => {
     await seedRepo(tempDir);
     const configPath = path.join(tempDir, "kspec.config.yaml");
     await fs.writeFile(
@@ -658,7 +658,7 @@ describe("dispatch runtime bootstrap contract", () => {
     ).resolves.toBe("1\n");
   });
 
-  it("repairs missing direct dependencies before reusing a previously successful bootstrap", async () => {
+  it("repairs missing direct dependencies before reusing a previously successful bootstrap", { timeout: 30_000 }, async () => {
     await seedRepo(tempDir);
     await setupLocalFileDependencyProject(tempDir);
     await fs.writeFile(

--- a/tests/dispatch-runtime-bootstrap-contract.test.ts
+++ b/tests/dispatch-runtime-bootstrap-contract.test.ts
@@ -501,109 +501,124 @@ describe("dispatch runtime bootstrap contract", () => {
   });
 
   // AC: @dispatch-runtime-bootstrap-contract ac-4
-  it("records explicit bootstrap invalidation reasons for config, head, and prior failure changes", { timeout: 30_000 }, async () => {
-    await seedRepo(tempDir);
-    const configPath = path.join(tempDir, "kspec.config.yaml");
-    await fs.writeFile(
-      configPath,
-      [
-        "dispatch:",
-        "  base_branch: agent-dev",
-        "  bootstrap:",
-        "    steps:",
-        "      - run: mkdir -p .dispatch-cache && echo run >> .dispatch-cache/history",
-      ].join("\n"),
-      "utf-8",
-    );
+  it(
+    "records explicit bootstrap invalidation reasons for config, head, and prior failure changes",
+    { timeout: 30_000 },
+    async () => {
+      await seedRepo(tempDir);
+      const configPath = path.join(tempDir, "kspec.config.yaml");
+      await fs.writeFile(
+        configPath,
+        [
+          "dispatch:",
+          "  base_branch: agent-dev",
+          "  bootstrap:",
+          "    steps:",
+          "      - run: mkdir -p .dispatch-cache && echo run >> .dispatch-cache/history",
+        ].join("\n"),
+        "utf-8",
+      );
 
-    const taskRef = `@${testUlid("TASK", 24)}`;
-    let workspace = await provisionDispatchWorkspace({
-      projectDir: tempDir,
-      taskRef,
-      task: { title: "Bootstrap Invalidation Signals", slugs: ["bootstrap-invalidation-signals"] },
-    });
+      const taskRef = `@${testUlid("TASK", 24)}`;
+      let workspace = await provisionDispatchWorkspace({
+        projectDir: tempDir,
+        taskRef,
+        task: {
+          title: "Bootstrap Invalidation Signals",
+          slugs: ["bootstrap-invalidation-signals"],
+        },
+      });
 
-    let bootstrapped = await ensureWorkspaceBootstrap({
-      projectDir: tempDir,
-      workspaceDir: workspace.cwd,
-      metadataPath: workspace.metadataPath,
-      metadata: workspace.metadata,
-      role: "worker",
-      agent: makeAgent(),
-      env: {},
-    });
+      let bootstrapped = await ensureWorkspaceBootstrap({
+        projectDir: tempDir,
+        workspaceDir: workspace.cwd,
+        metadataPath: workspace.metadataPath,
+        metadata: workspace.metadata,
+        role: "worker",
+        agent: makeAgent(),
+        env: {},
+      });
 
-    await fs.writeFile(
-      configPath,
-      [
-        "dispatch:",
-        "  base_branch: agent-dev",
-        "  bootstrap:",
-        "    steps:",
-        "      - run: mkdir -p .dispatch-cache && echo run >> .dispatch-cache/history",
-        "        idempotent: true",
-      ].join("\n"),
-      "utf-8",
-    );
-    workspace = await provisionDispatchWorkspace({
-      projectDir: tempDir,
-      taskRef,
-      task: { title: "Bootstrap Invalidation Signals", slugs: ["bootstrap-invalidation-signals"] },
-    });
-    bootstrapped = await ensureWorkspaceBootstrap({
-      projectDir: tempDir,
-      workspaceDir: workspace.cwd,
-      metadataPath: workspace.metadataPath,
-      metadata: workspace.metadata,
-      role: "worker",
-      agent: makeAgent(),
-      env: {},
-    });
-    expect(bootstrapped.metadata.bootstrap.invalidationReasons).toContain(
-      "bootstrap-config-changed",
-    );
+      await fs.writeFile(
+        configPath,
+        [
+          "dispatch:",
+          "  base_branch: agent-dev",
+          "  bootstrap:",
+          "    steps:",
+          "      - run: mkdir -p .dispatch-cache && echo run >> .dispatch-cache/history",
+          "        idempotent: true",
+        ].join("\n"),
+        "utf-8",
+      );
+      workspace = await provisionDispatchWorkspace({
+        projectDir: tempDir,
+        taskRef,
+        task: {
+          title: "Bootstrap Invalidation Signals",
+          slugs: ["bootstrap-invalidation-signals"],
+        },
+      });
+      bootstrapped = await ensureWorkspaceBootstrap({
+        projectDir: tempDir,
+        workspaceDir: workspace.cwd,
+        metadataPath: workspace.metadataPath,
+        metadata: workspace.metadata,
+        role: "worker",
+        agent: makeAgent(),
+        env: {},
+      });
+      expect(bootstrapped.metadata.bootstrap.invalidationReasons).toContain(
+        "bootstrap-config-changed",
+      );
 
-    await fs.writeFile(path.join(workspace.cwd, "runtime.txt"), "runtime\n", "utf-8");
-    git(workspace.cwd, "add runtime.txt");
-    git(workspace.cwd, 'commit -m "runtime change"');
-    workspace = await provisionDispatchWorkspace({
-      projectDir: tempDir,
-      taskRef,
-      task: { title: "Bootstrap Invalidation Signals", slugs: ["bootstrap-invalidation-signals"] },
-    });
-    bootstrapped = await ensureWorkspaceBootstrap({
-      projectDir: tempDir,
-      workspaceDir: workspace.cwd,
-      metadataPath: workspace.metadataPath,
-      metadata: workspace.metadata,
-      role: "worker",
-      agent: makeAgent(),
-      env: {},
-    });
-    expect(bootstrapped.metadata.bootstrap.invalidationReasons).toContain(
-      "canonical-branch-head-changed",
-    );
+      await fs.writeFile(path.join(workspace.cwd, "runtime.txt"), "runtime\n", "utf-8");
+      git(workspace.cwd, "add runtime.txt");
+      git(workspace.cwd, 'commit -m "runtime change"');
+      workspace = await provisionDispatchWorkspace({
+        projectDir: tempDir,
+        taskRef,
+        task: {
+          title: "Bootstrap Invalidation Signals",
+          slugs: ["bootstrap-invalidation-signals"],
+        },
+      });
+      bootstrapped = await ensureWorkspaceBootstrap({
+        projectDir: tempDir,
+        workspaceDir: workspace.cwd,
+        metadataPath: workspace.metadataPath,
+        metadata: workspace.metadata,
+        role: "worker",
+        agent: makeAgent(),
+        env: {},
+      });
+      expect(bootstrapped.metadata.bootstrap.invalidationReasons).toContain(
+        "canonical-branch-head-changed",
+      );
 
-    await updateWorkspaceRecord(workspace.metadataPath, taskRef, (record) => {
-      record.bootstrap.status = "failed";
-      record.bootstrap.roleStates.worker.status = "failed";
-    });
-    const failedRecord = await readWorkspaceRecord(workspace.metadataPath, taskRef);
-    bootstrapped = await ensureWorkspaceBootstrap({
-      projectDir: tempDir,
-      workspaceDir: workspace.cwd,
-      metadataPath: workspace.metadataPath,
-      metadata: {
-        ...workspace.metadata,
-        bootstrap: failedRecord.bootstrap,
-        bootstrapState: failedRecord.bootstrap,
-      },
-      role: "worker",
-      agent: makeAgent(),
-      env: {},
-    });
-    expect(bootstrapped.metadata.bootstrap.invalidationReasons).toContain("prior-bootstrap-failed");
-  });
+      await updateWorkspaceRecord(workspace.metadataPath, taskRef, (record) => {
+        record.bootstrap.status = "failed";
+        record.bootstrap.roleStates.worker.status = "failed";
+      });
+      const failedRecord = await readWorkspaceRecord(workspace.metadataPath, taskRef);
+      bootstrapped = await ensureWorkspaceBootstrap({
+        projectDir: tempDir,
+        workspaceDir: workspace.cwd,
+        metadataPath: workspace.metadataPath,
+        metadata: {
+          ...workspace.metadata,
+          bootstrap: failedRecord.bootstrap,
+          bootstrapState: failedRecord.bootstrap,
+        },
+        role: "worker",
+        agent: makeAgent(),
+        env: {},
+      });
+      expect(bootstrapped.metadata.bootstrap.invalidationReasons).toContain(
+        "prior-bootstrap-failed",
+      );
+    },
+  );
 
   // AC: @dispatch-runtime-bootstrap-contract ac-5
   it("reuses prior bootstrap results on later worker invocations when no invalidation signal exists", async () => {
@@ -658,95 +673,99 @@ describe("dispatch runtime bootstrap contract", () => {
     ).resolves.toBe("1\n");
   });
 
-  it("repairs missing direct dependencies before reusing a previously successful bootstrap", { timeout: 30_000 }, async () => {
-    await seedRepo(tempDir);
-    await setupLocalFileDependencyProject(tempDir);
-    await fs.writeFile(
-      path.join(tempDir, "kspec.config.yaml"),
-      ["dispatch:", "  base_branch: agent-dev"].join("\n"),
-      "utf-8",
-    );
+  it(
+    "repairs missing direct dependencies before reusing a previously successful bootstrap",
+    { timeout: 30_000 },
+    async () => {
+      await seedRepo(tempDir);
+      await setupLocalFileDependencyProject(tempDir);
+      await fs.writeFile(
+        path.join(tempDir, "kspec.config.yaml"),
+        ["dispatch:", "  base_branch: agent-dev"].join("\n"),
+        "utf-8",
+      );
 
-    const taskRef = `@${testUlid("TASK", 30)}`;
-    let workspace = await provisionDispatchWorkspace({
-      projectDir: tempDir,
-      taskRef,
-      task: { title: "Dependency Repair Bootstrap", slugs: ["dependency-repair-bootstrap"] },
-    });
+      const taskRef = `@${testUlid("TASK", 30)}`;
+      let workspace = await provisionDispatchWorkspace({
+        projectDir: tempDir,
+        taskRef,
+        task: { title: "Dependency Repair Bootstrap", slugs: ["dependency-repair-bootstrap"] },
+      });
 
-    await ensureWorkspaceBootstrap({
-      projectDir: tempDir,
-      workspaceDir: workspace.cwd,
-      metadataPath: workspace.metadataPath,
-      metadata: workspace.metadata,
-      role: "worker",
-      agent: makeAgent(),
-      env: {},
-    });
-    await expect(
-      fs.stat(path.join(workspace.cwd, "node_modules", "local-dep")),
-    ).resolves.toBeTruthy();
+      await ensureWorkspaceBootstrap({
+        projectDir: tempDir,
+        workspaceDir: workspace.cwd,
+        metadataPath: workspace.metadataPath,
+        metadata: workspace.metadata,
+        role: "worker",
+        agent: makeAgent(),
+        env: {},
+      });
+      await expect(
+        fs.stat(path.join(workspace.cwd, "node_modules", "local-dep")),
+      ).resolves.toBeTruthy();
 
-    await fs.rm(path.join(workspace.cwd, "node_modules"), { recursive: true, force: true });
+      await fs.rm(path.join(workspace.cwd, "node_modules"), { recursive: true, force: true });
 
-    workspace = await provisionDispatchWorkspace({
-      projectDir: tempDir,
-      taskRef,
-      task: { title: "Dependency Repair Bootstrap", slugs: ["dependency-repair-bootstrap"] },
-    });
-    const record = await readWorkspaceRecord(workspace.metadataPath, taskRef);
-    const repaired = await ensureWorkspaceBootstrap({
-      projectDir: tempDir,
-      workspaceDir: workspace.cwd,
-      metadataPath: workspace.metadataPath,
-      metadata: {
-        ...workspace.metadata,
-        bootstrap: record.bootstrap,
-        bootstrapState: record.bootstrap,
-      },
-      role: "worker",
-      agent: makeAgent(),
-      env: {},
-    });
+      workspace = await provisionDispatchWorkspace({
+        projectDir: tempDir,
+        taskRef,
+        task: { title: "Dependency Repair Bootstrap", slugs: ["dependency-repair-bootstrap"] },
+      });
+      const record = await readWorkspaceRecord(workspace.metadataPath, taskRef);
+      const repaired = await ensureWorkspaceBootstrap({
+        projectDir: tempDir,
+        workspaceDir: workspace.cwd,
+        metadataPath: workspace.metadataPath,
+        metadata: {
+          ...workspace.metadata,
+          bootstrap: record.bootstrap,
+          bootstrapState: record.bootstrap,
+        },
+        role: "worker",
+        agent: makeAgent(),
+        env: {},
+      });
 
-    expect(repaired.reused).toBe(false);
-    expect(repaired.ranSteps).toBe(true);
-    expect(repaired.metadata.bootstrap.invalidationReasons).toContain(
-      "workspace-dependencies-missing",
-    );
-    expect(
-      repaired.metadata.bootstrap.steps.some(
-        (step) => step.name === "install-workspace-dependencies",
-      ),
-    ).toBe(true);
-    await expect(
-      fs.stat(path.join(workspace.cwd, "node_modules", "local-dep")),
-    ).resolves.toBeTruthy();
+      expect(repaired.reused).toBe(false);
+      expect(repaired.ranSteps).toBe(true);
+      expect(repaired.metadata.bootstrap.invalidationReasons).toContain(
+        "workspace-dependencies-missing",
+      );
+      expect(
+        repaired.metadata.bootstrap.steps.some(
+          (step) => step.name === "install-workspace-dependencies",
+        ),
+      ).toBe(true);
+      await expect(
+        fs.stat(path.join(workspace.cwd, "node_modules", "local-dep")),
+      ).resolves.toBeTruthy();
 
-    workspace = await provisionDispatchWorkspace({
-      projectDir: tempDir,
-      taskRef,
-      task: { title: "Dependency Repair Bootstrap", slugs: ["dependency-repair-bootstrap"] },
-    });
-    const postRepairRecord = await readWorkspaceRecord(workspace.metadataPath, taskRef);
-    const reusedAfterRepair = await ensureWorkspaceBootstrap({
-      projectDir: tempDir,
-      workspaceDir: workspace.cwd,
-      metadataPath: workspace.metadataPath,
-      metadata: {
-        ...workspace.metadata,
-        bootstrap: postRepairRecord.bootstrap,
-        bootstrapState: postRepairRecord.bootstrap,
-      },
-      role: "worker",
-      agent: makeAgent(),
-      env: {},
-    });
+      workspace = await provisionDispatchWorkspace({
+        projectDir: tempDir,
+        taskRef,
+        task: { title: "Dependency Repair Bootstrap", slugs: ["dependency-repair-bootstrap"] },
+      });
+      const postRepairRecord = await readWorkspaceRecord(workspace.metadataPath, taskRef);
+      const reusedAfterRepair = await ensureWorkspaceBootstrap({
+        projectDir: tempDir,
+        workspaceDir: workspace.cwd,
+        metadataPath: workspace.metadataPath,
+        metadata: {
+          ...workspace.metadata,
+          bootstrap: postRepairRecord.bootstrap,
+          bootstrapState: postRepairRecord.bootstrap,
+        },
+        role: "worker",
+        agent: makeAgent(),
+        env: {},
+      });
 
-    expect(reusedAfterRepair.reused).toBe(true);
-    expect(reusedAfterRepair.ranSteps).toBe(false);
-    expect(reusedAfterRepair.metadata.bootstrap.invalidationReasons).toEqual([]);
-  });
+      expect(reusedAfterRepair.reused).toBe(true);
+      expect(reusedAfterRepair.ranSteps).toBe(false);
+      expect(reusedAfterRepair.metadata.bootstrap.invalidationReasons).toEqual([]);
+    },
+  );
 
   // AC: @dispatch-runtime-bootstrap-contract ac-6
   // AC: @trait-error-guidance ac-1


### PR DESCRIPTION
## Summary

- Add workspace provisioning mocks to worker guardrails test in `agent-dispatch-engine.test.ts` (matches existing reviewer test pattern) — test validates prompt content, not workspace setup
- Increase per-test timeout from 15s to 30s for 3 tests doing heavy git/npm I/O that exceed the default under parallel contention (`dispatch-runtime-bootstrap-contract.test.ts` ×2, `canonical-task-workspace-contract.test.ts` ×1)

All 4 tests passed in isolation but failed under full-suite parallel load due to resource contention.

## Test plan

- [x] All 4 previously-failing tests pass in isolation
- [x] Full test suite passes: 1856 suites, 6601 tests, 0 failures

Task: @01KMNY3N

🤖 Generated with [Claude Code](https://claude.com/claude-code)