### PR TITLE
fix(ci): add Setup Bun to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
       - name: Build
         run: npm run build
 


### PR DESCRIPTION
## Summary
- Adds the `Setup Bun` step to `.github/workflows/publish.yml` so the full test suite passes during the publish job.
- `tests/daemon-api/websocket-protocol.test.ts` spawns `dist/daemon/index.js` with `bun`. The publish workflow runs the full suite before npm publish but had no bun setup, so the v0.13.0 publish attempt exited with 8 `spawn bun ENOENT` failures.
- Aligns `publish.yml` with `test.yml` (which already has this step).

## Test plan
- [ ] Merge to main
- [ ] Re-trigger publish via `gh workflow run publish.yml --ref main` (or recreate the v0.13.0 GH release) to publish v0.13.0 to npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)