### PR TITLE
fix: update repository URLs from kynetic-ai to lepahc org

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Features, Bug Reports, Questions
-    url: https://github.com/kynetic-ai/kynetic-spec/discussions/new/choose
+    url: https://github.com/lepahc/kynetic-spec/discussions/new/choose
     about: Preferred starting point if you have any questions or suggestions about configuration, features or behavior.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -28,7 +28,7 @@ npx @kynetic-ai/spec <command>
 For development or pre-release versions:
 
 ```bash
-git clone https://github.com/kynetic-ai/kynetic-spec.git ~/tools/kspec
+git clone https://github.com/lepahc/kynetic-spec.git ~/tools/kspec
 cd ~/tools/kspec
 npm install && npm run build && npm link
 ```
@@ -36,7 +36,7 @@ npm install && npm run build && npm link
 **For agents developing kspec itself**, use the bootstrap script which handles setup automatically:
 
 ```bash
-git clone https://github.com/kynetic-ai/kynetic-spec.git
+git clone https://github.com/lepahc/kynetic-spec.git
 cd kynetic-spec
 node scripts/bootstrap.cjs
 ```

--- a/package.json
+++ b/package.json
@@ -10,15 +10,15 @@
     "specification",
     "yaml"
   ],
-  "homepage": "https://github.com/kynetic-ai/kynetic-spec#readme",
+  "homepage": "https://github.com/lepahc/kynetic-spec#readme",
   "bugs": {
-    "url": "https://github.com/kynetic-ai/kynetic-spec/issues"
+    "url": "https://github.com/lepahc/kynetic-spec/issues"
   },
   "license": "MIT",
   "author": "Kynetic AI",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/kynetic-ai/kynetic-spec.git"
+    "url": "git+https://github.com/lepahc/kynetic-spec.git"
   },
   "bin": {
     "kspec": "./dist/cli/index.js"


### PR DESCRIPTION
## Summary
- Update GitHub repo URLs from \`kynetic-ai/kynetic-spec\` to \`lepahc/kynetic-spec\` in:
  - \`package.json\` — homepage, bugs.url, repository.url
  - \`INSTALL.md\` — two \`git clone\` examples
  - \`.github/ISSUE_TEMPLATE/config.yml\` — discussions link
- Unblocks the v0.13.0 npm publish (provenance was failing because the OIDC attestation comes from \`lepahc\` but package.json claimed \`kynetic-ai\`).

## Test plan
- [ ] Merge to main
- [ ] Re-trigger publish via \`gh workflow run publish.yml --ref main\` to publish v0.13.0 to npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)