### PR TITLE
Merge dev: task-storage compatibility, proxy isolation, dispatch stability

### DIFF
--- a/packages/daemon/src/routes/aggregation.ts
+++ b/packages/daemon/src/routes/aggregation.ts
@@ -32,6 +32,7 @@ import type {
 } from "@kynetic-ai/shared";
 import type { EntityCacheAccessor } from "./entity-cache-types.js";
 import { wrapResponse } from "./response-envelope.js";
+import { taskStorageIncompatibilityResponse } from "./task-storage-error.js";
 
 interface AggregationRouteOptions {
   getEntityCache?: EntityCacheAccessor;
@@ -44,7 +45,7 @@ export function createAggregationRoutes(_options: AggregationRouteOptions = {}) 
     new Elysia({ prefix: "/api/aggregation" })
       // AC: @ui-api-aggregation ac-1 - Task status summary with dependency-aware distinctions
       // AC: @daemon-read-path ac-no-per-request-sync, ac-index-from-cache — serve from cached task index
-      .get("/tasks/summary", async ({ projectContext }) => {
+      .get("/tasks/summary", async ({ error: errorResponse, projectContext }) => {
         const cache = getEntityCache?.(projectContext.path);
         const tasksDomainState = cache?.getDomainState("tasks");
 
@@ -56,19 +57,27 @@ export function createAggregationRoutes(_options: AggregationRouteOptions = {}) 
           );
         }
 
+        // AC: @api-contract ac-task-storage-incompatibility-* — translate the
+        // deterministic storage error into a 409 instead of bubbling as a 500.
         let tasks: LoadedTask[];
-        if (cache && tasksDomainState === "ready") {
-          const cachedTasks = cache.getTaskIndex();
-          if (cachedTasks) {
-            // AC: @daemon-read-path ac-index-from-cache — build from cached data
-            tasks = cachedTasks as unknown as LoadedTask[];
+        try {
+          if (cache && tasksDomainState === "ready") {
+            const cachedTasks = cache.getTaskIndex();
+            if (cachedTasks) {
+              // AC: @daemon-read-path ac-index-from-cache — build from cached data
+              tasks = cachedTasks as unknown as LoadedTask[];
+            } else {
+              const ctx = await initContext(projectContext.path, { syncMode: "skip" });
+              tasks = await resolveTaskDataManager(ctx).loadAllTasks(ctx);
+            }
           } else {
             const ctx = await initContext(projectContext.path, { syncMode: "skip" });
             tasks = await resolveTaskDataManager(ctx).loadAllTasks(ctx);
           }
-        } else {
-          const ctx = await initContext(projectContext.path, { syncMode: "skip" });
-          tasks = await resolveTaskDataManager(ctx).loadAllTasks(ctx);
+        } catch (err) {
+          const conflict = taskStorageIncompatibilityResponse(err, { cache });
+          if (conflict) return errorResponse(conflict.status, conflict.body);
+          throw err;
         }
 
         // Count tasks by status
@@ -106,7 +115,7 @@ export function createAggregationRoutes(_options: AggregationRouteOptions = {}) 
       // AC: @daemon-read-path ac-index-from-cache — build alignment/reference indexes from cached entity data
       // Note: validate() requires full context for deep schema/ref validation,
       // but index building uses cached entity data when available.
-      .get("/validation", async ({ projectContext }) => {
+      .get("/validation", async ({ error: errorResponse, projectContext }) => {
         const cache = getEntityCache?.(projectContext.path);
         const tasksDomainState = cache?.getDomainState("tasks");
         const itemsDomainState = cache?.getDomainState("items");
@@ -130,12 +139,20 @@ export function createAggregationRoutes(_options: AggregationRouteOptions = {}) 
 
         // Resolve tasks and items from cache when available
         // AC: @daemon-read-path ac-index-from-cache — indexes built from cached data
+        // AC: @api-contract ac-task-storage-incompatibility-* — return 409 with
+        // recovery guidance when storage incompatibility blocks the validation read.
         let tasks: LoadedTask[];
-        if (cache && tasksDomainState === "ready") {
-          tasks = (cache.getTaskIndex() ?? []) as unknown as LoadedTask[];
-        } else {
-          const ctx = await initContext(projectContext.path, { syncMode: "skip" });
-          tasks = await resolveTaskDataManager(ctx).loadAllTasks(ctx);
+        try {
+          if (cache && tasksDomainState === "ready") {
+            tasks = (cache.getTaskIndex() ?? []) as unknown as LoadedTask[];
+          } else {
+            const ctx = await initContext(projectContext.path, { syncMode: "skip" });
+            tasks = await resolveTaskDataManager(ctx).loadAllTasks(ctx);
+          }
+        } catch (err) {
+          const conflict = taskStorageIncompatibilityResponse(err, { cache });
+          if (conflict) return errorResponse(conflict.status, conflict.body);
+          throw err;
         }
 
         let items: LoadedSpecItem[];

--- a/packages/daemon/src/routes/command.ts
+++ b/packages/daemon/src/routes/command.ts
@@ -269,7 +269,10 @@ async function executeCommand(
         runWithOutputState(
           () =>
             runWithoutSpecDirOverride(() =>
-              runWithWorkingDirectory(() => program.parseAsync(argv, { from: "user" }), projectPath),
+              runWithWorkingDirectory(
+                () => program.parseAsync(argv, { from: "user" }),
+                projectPath,
+              ),
             ),
           { outputFormat: "text", verboseMode: false },
         ),

--- a/packages/daemon/src/routes/command.ts
+++ b/packages/daemon/src/routes/command.ts
@@ -31,6 +31,7 @@ import {
   runWithWorkingDirectory,
 } from "../../parser/yaml.js";
 import { runWithOutputState } from "../../cli/output.js";
+import { runWithDaemonProxySuppressed } from "../../cli/daemon-proxy.js";
 
 // ── Types ──────────────────────────────────────────────────────────
 
@@ -264,12 +265,14 @@ async function executeCommand(
 
   try {
     const parseCommand = () =>
-      runWithOutputState(
-        () =>
-          runWithoutSpecDirOverride(() =>
-            runWithWorkingDirectory(() => program.parseAsync(argv, { from: "user" }), projectPath),
-          ),
-        { outputFormat: "text", verboseMode: false },
+      runWithDaemonProxySuppressed(() =>
+        runWithOutputState(
+          () =>
+            runWithoutSpecDirOverride(() =>
+              runWithWorkingDirectory(() => program.parseAsync(argv, { from: "user" }), projectPath),
+            ),
+          { outputFormat: "text", verboseMode: false },
+        ),
       );
 
     await commandExecutionStorage.run(capture, async () => {

--- a/packages/daemon/src/routes/diff.ts
+++ b/packages/daemon/src/routes/diff.ts
@@ -22,6 +22,7 @@ import {
 } from "../../parser/index.js";
 import { loadReviewRecords, findReviewByRef } from "../../parser/reviews.js";
 import { parseUnifiedDiff } from "../../utils/git-diff-parser.js";
+import { taskStorageIncompatibilityResponse } from "./task-storage-error.js";
 
 // ─── Git Helpers ───
 
@@ -384,7 +385,19 @@ export function createDiffRoutes() {
           // Spec content
           if (subject.type === "spec") {
             const items = await loadAllItems(ctx);
-            const tasks = await resolveTaskDataManager(ctx).loadAllTasks(ctx);
+            // AC: @api-contract ac-task-storage-incompatibility-* — translate the
+            // storage error into a structured 409 instead of a 500.
+            let tasks;
+            try {
+              tasks = await resolveTaskDataManager(ctx).loadAllTasks(ctx);
+            } catch (err) {
+              const conflict = taskStorageIncompatibilityResponse(err);
+              if (conflict) {
+                set.status = conflict.status;
+                return conflict.body;
+              }
+              throw err;
+            }
             const index = new ReferenceIndex(tasks, items);
             const resolved = index.resolve(subject.ref);
 
@@ -488,7 +501,19 @@ export function createDiffRoutes() {
 
           // Task subject — return task details
           if (subject.type === "task") {
-            const tasks = await resolveTaskDataManager(ctx).loadAllTasks(ctx);
+            // AC: @api-contract ac-task-storage-incompatibility-not-not-found —
+            // do not collapse the storage error into a task-ref not_found here.
+            let tasks;
+            try {
+              tasks = await resolveTaskDataManager(ctx).loadAllTasks(ctx);
+            } catch (err) {
+              const conflict = taskStorageIncompatibilityResponse(err);
+              if (conflict) {
+                set.status = conflict.status;
+                return conflict.body;
+              }
+              throw err;
+            }
             const items = await loadAllItems(ctx);
             const index = new ReferenceIndex(tasks, items);
             const resolved = index.resolve(subject.ref);

--- a/packages/daemon/src/routes/items.ts
+++ b/packages/daemon/src/routes/items.ts
@@ -34,6 +34,7 @@ import { getRelatedSessionsForItem } from "./session-related.js";
 import type { EntityCacheAccessor } from "./entity-cache-types.js";
 import type { ItemSummary } from "../../daemon/entity-cache.js";
 import { wrapResponse } from "./response-envelope.js";
+import { taskStorageIncompatibilityResponse } from "./task-storage-error.js";
 
 interface ItemsRouteOptions {
   getEntityCache?: EntityCacheAccessor;
@@ -354,9 +355,21 @@ export function createItemsRoutes(_options: ItemsRouteOptions = {}) {
             (batchCache && batchItemsDomainState === "ready" ? batchCache.getItemIndex() : null) ??
             (await loadAllItems(await getBatchCtx()));
           const batchTasksDomainState = batchCache?.getDomainState("tasks");
-          const tasks =
-            (batchCache && batchTasksDomainState === "ready" ? batchCache.getTaskIndex() : null) ??
-            (await resolveTaskDataManager(await getBatchCtx()).loadAllTasks(await getBatchCtx()));
+          // AC: @api-contract ac-task-storage-incompatibility-* — surface 409 with
+          // structured guidance instead of a 500 when batch resolution needs tasks
+          // from a legacy/unmigrated project.
+          let tasks;
+          try {
+            tasks =
+              (batchCache && batchTasksDomainState === "ready"
+                ? batchCache.getTaskIndex()
+                : null) ??
+              (await resolveTaskDataManager(await getBatchCtx()).loadAllTasks(await getBatchCtx()));
+          } catch (err) {
+            const conflict = taskStorageIncompatibilityResponse(err, { cache: batchCache });
+            if (conflict) return errorResponse(conflict.status, conflict.body);
+            throw err;
+          }
 
           const resolvedItems = [];
           const unresolved: string[] = [];
@@ -426,9 +439,19 @@ export function createItemsRoutes(_options: ItemsRouteOptions = {}) {
             // Try to resolve via cached item index (avoid loading all items from disk)
             const cachedItems = cache!.getItemIndex();
             const tasksDomainReady = cache!.getDomainState("tasks") === "ready";
-            const tasks = tasksDomainReady
-              ? (cache!.getTaskIndex() as unknown as LoadedTask[])
-              : await resolveTaskDataManager(await getCtx()).loadAllTasks(await getCtx());
+            // AC: @api-contract ac-task-storage-incompatibility-* — return 409 with
+            // recovery guidance instead of an unhandled error when the cache is
+            // not yet warm and the disk read hits a legacy/unmigrated project.
+            let tasks: LoadedTask[];
+            try {
+              tasks = tasksDomainReady
+                ? (cache!.getTaskIndex() as unknown as LoadedTask[])
+                : await resolveTaskDataManager(await getCtx()).loadAllTasks(await getCtx());
+            } catch (err) {
+              const conflict = taskStorageIncompatibilityResponse(err, { cache });
+              if (conflict) return errorResponse(conflict.status, conflict.body);
+              throw err;
+            }
             if (cachedItems) {
               const index = new ReferenceIndex(
                 tasks ?? [],
@@ -490,9 +513,18 @@ export function createItemsRoutes(_options: ItemsRouteOptions = {}) {
           // Detail not in cache — load from disk
           const items = await loadAllItems(await getCtx());
           // AC: @daemon-entity-cache ac-serve-from-memory — use cached tasks when available
-          const tasks =
-            (cache && cache.getDomainState("tasks") === "ready" ? cache.getTaskIndex() : null) ??
-            (await resolveTaskDataManager(await getCtx()).loadAllTasks(await getCtx()));
+          // AC: @api-contract ac-task-storage-incompatibility-* — translate task-storage
+          // failures into a structured 409 instead of a 500.
+          let tasks;
+          try {
+            tasks =
+              (cache && cache.getDomainState("tasks") === "ready" ? cache.getTaskIndex() : null) ??
+              (await resolveTaskDataManager(await getCtx()).loadAllTasks(await getCtx()));
+          } catch (err) {
+            const conflict = taskStorageIncompatibilityResponse(err, { cache });
+            if (conflict) return errorResponse(conflict.status, conflict.body);
+            throw err;
+          }
           const index = new ReferenceIndex(tasks as unknown as LoadedTask[], items);
 
           // Compute parent relationships from path structure
@@ -596,7 +628,14 @@ export function createItemsRoutes(_options: ItemsRouteOptions = {}) {
             // AC: @shadow-lazy-read-sync ac-daemon-bypass — skip drift-check on daemon reads
             const ctx = await initContext(projectContext.path, { syncMode: "skip" });
             items = await loadAllItems(ctx);
-            tasks = await resolveTaskDataManager(ctx).loadAllTasks(ctx);
+            // AC: @api-contract ac-task-storage-incompatibility-* — surface a structured 409
+            try {
+              tasks = await resolveTaskDataManager(ctx).loadAllTasks(ctx);
+            } catch (err) {
+              const conflict = taskStorageIncompatibilityResponse(err, { cache });
+              if (conflict) return errorResponse(conflict.status, conflict.body);
+              throw err;
+            }
           }
 
           const refIndex = new ReferenceIndex(tasks, items);
@@ -678,7 +717,14 @@ export function createItemsRoutes(_options: ItemsRouteOptions = {}) {
             // AC: @shadow-lazy-read-sync ac-daemon-bypass — skip drift-check on daemon reads
             const ctx = await initContext(projectContext.path, { syncMode: "skip" });
             items = await loadAllItems(ctx);
-            tasks = await resolveTaskDataManager(ctx).loadAllTasks(ctx);
+            // AC: @api-contract ac-task-storage-incompatibility-* — surface a structured 409
+            try {
+              tasks = await resolveTaskDataManager(ctx).loadAllTasks(ctx);
+            } catch (err) {
+              const conflict = taskStorageIncompatibilityResponse(err, { cache });
+              if (conflict) return errorResponse(conflict.status, conflict.body);
+              throw err;
+            }
             sessionsDir = ctx.sessionsDir;
           }
 

--- a/packages/daemon/src/routes/plans.ts
+++ b/packages/daemon/src/routes/plans.ts
@@ -30,6 +30,7 @@ import type { PlanIndexSummary } from "../../daemon/entity-cache.js";
 import { enumArrayUnion } from "./enum-utils.js";
 import type { EntityCacheAccessor } from "./entity-cache-types.js";
 import { wrapResponse } from "./response-envelope.js";
+import { taskStorageIncompatibilityResponse } from "./task-storage-error.js";
 
 interface PlansRouteOptions {
   getEntityCache?: EntityCacheAccessor;
@@ -68,7 +69,7 @@ export function createPlansRoutes(_options: PlansRouteOptions = {}) {
       // AC: @daemon-entity-cache ac-serve-from-memory — serve from cache when available
       .get(
         "/",
-        async ({ query, projectContext }) => {
+        async ({ query, error: errorResponse, projectContext }) => {
           // AC: @daemon-entity-cache ac-serve-from-memory — defer initContext for cache hits
           const cache = getEntityCache?.(projectContext.path);
 
@@ -96,6 +97,8 @@ export function createPlansRoutes(_options: PlansRouteOptions = {}) {
           }
 
           // Try cache for tasks (needed for progress computation)
+          // AC: @api-contract ac-task-storage-incompatibility-* — translate the
+          // storage error into a structured 409 instead of a 500.
           const tasksDomainState = cache?.getDomainState("tasks");
           let tasks;
           if (cache && tasksDomainState === "ready") {
@@ -103,7 +106,13 @@ export function createPlansRoutes(_options: PlansRouteOptions = {}) {
           }
           if (!tasks) {
             const ctx = await getCtx();
-            tasks = await resolveTaskDataManager(ctx).loadAllTasks(ctx);
+            try {
+              tasks = await resolveTaskDataManager(ctx).loadAllTasks(ctx);
+            } catch (err) {
+              const conflict = taskStorageIncompatibilityResponse(err, { cache });
+              if (conflict) return errorResponse(conflict.status, conflict.body);
+              throw err;
+            }
           }
 
           // Apply status filter
@@ -184,13 +193,21 @@ export function createPlansRoutes(_options: PlansRouteOptions = {}) {
         }
 
         // Try cache for tasks (needed for progress computation)
+        // AC: @api-contract ac-task-storage-incompatibility-* — translate the
+        // storage error into a structured 409 instead of a 500.
         const tasksDomainState = cache?.getDomainState("tasks");
         let tasks;
         if (cache && tasksDomainState === "ready") {
           tasks = cache.getTaskIndex();
         }
         if (!tasks) {
-          tasks = await resolveTaskDataManager(await getCtx()).loadAllTasks(await getCtx());
+          try {
+            tasks = await resolveTaskDataManager(await getCtx()).loadAllTasks(await getCtx());
+          } catch (err) {
+            const conflict = taskStorageIncompatibilityResponse(err, { cache });
+            if (conflict) return errorResponse(conflict.status, conflict.body);
+            throw err;
+          }
         }
 
         const detail: PlanDetail = {

--- a/packages/daemon/src/routes/refs.ts
+++ b/packages/daemon/src/routes/refs.ts
@@ -25,6 +25,7 @@ import {
 import { buildRefIndex } from "./ref-resolution.js";
 import type { EntityCacheAccessor } from "./entity-cache-types.js";
 import { wrapResponse } from "./response-envelope.js";
+import { taskStorageIncompatibilityResponse } from "./task-storage-error.js";
 
 interface RefsRouteOptions {
   getEntityCache?: EntityCacheAccessor;
@@ -40,7 +41,7 @@ export function createRefsRoutes(options: RefsRouteOptions = {}) {
       // AC: @trait-api-endpoint ac-1 - Returns 2xx with JSON body
       // AC: @daemon-entity-cache ac-serve-from-memory — serve from cache when available
       // AC: @daemon-entity-cache ac-warming-availability — return loading indicator during warmup
-      .get("/", async ({ projectContext }) => {
+      .get("/", async ({ error: errorResponse, projectContext }) => {
         // AC: @daemon-entity-cache ac-serve-from-memory — try cache for tasks, items, and plans
         const cache = getEntityCache?.(projectContext.path);
         const tasksDomainState = cache?.getDomainState("tasks");
@@ -68,17 +69,27 @@ export function createRefsRoutes(options: RefsRouteOptions = {}) {
           return _ctx;
         };
 
-        const [tasks, items, plans] = await Promise.all([
-          cache && tasksDomainState === "ready" && cache.getTaskIndex()
-            ? Promise.resolve(cache.getTaskIndex()!)
-            : getCtx().then((ctx) => resolveTaskDataManager(ctx).loadAllTasks(ctx)),
-          cache && itemsDomainState === "ready" && cache.getItemIndex()
-            ? Promise.resolve(cache.getItemIndex()!)
-            : getCtx().then((ctx) => loadAllItems(ctx)),
-          cache && plansDomainState === "ready" && cache.getPlansIndex()
-            ? Promise.resolve(cache.getPlansIndex()!)
-            : getCtx().then((ctx) => loadPlans(ctx)),
-        ]);
+        // AC: @api-contract ac-task-storage-incompatibility-* — translate the
+        // deterministic task-storage error into a 409 so ref resolution does
+        // not surface as an opaque 500 on legacy/unmigrated projects.
+        let tasks, items, plans;
+        try {
+          [tasks, items, plans] = await Promise.all([
+            cache && tasksDomainState === "ready" && cache.getTaskIndex()
+              ? Promise.resolve(cache.getTaskIndex()!)
+              : getCtx().then((ctx) => resolveTaskDataManager(ctx).loadAllTasks(ctx)),
+            cache && itemsDomainState === "ready" && cache.getItemIndex()
+              ? Promise.resolve(cache.getItemIndex()!)
+              : getCtx().then((ctx) => loadAllItems(ctx)),
+            cache && plansDomainState === "ready" && cache.getPlansIndex()
+              ? Promise.resolve(cache.getPlansIndex()!)
+              : getCtx().then((ctx) => loadPlans(ctx)),
+          ]);
+        } catch (err) {
+          const conflict = taskStorageIncompatibilityResponse(err, { cache });
+          if (conflict) return errorResponse(conflict.status, conflict.body);
+          throw err;
+        }
         // TaskSummary and ItemSummary are structurally compatible with ReferenceIndex's
         // needs (indexItem uses _ulid + slugs; buildRefIndex uses title, type, status)
         const index = new ReferenceIndex(

--- a/packages/daemon/src/routes/reviews.ts
+++ b/packages/daemon/src/routes/reviews.ts
@@ -77,6 +77,7 @@ import { enumArrayUnion, enumUnion } from "./enum-utils.js";
 import type { EntityCacheAccessor } from "./entity-cache-types.js";
 import type { ReviewIndexSummary } from "../../daemon/entity-cache.js";
 import { wrapResponse } from "./response-envelope.js";
+import { taskStorageIncompatibilityResponse } from "./task-storage-error.js";
 
 interface ReviewsRouteOptions {
   pubsub: PubSubManager;
@@ -186,7 +187,7 @@ export function createReviewsRoutes(options: ReviewsRouteOptions) {
       // AC: @review-records-web-ui ac-7 - Task filter for task detail page integration
       .get(
         "/",
-        async ({ query, projectContext }) => {
+        async ({ query, error: errorResponse, projectContext }) => {
           // AC: @daemon-entity-cache ac-serve-from-memory — defer initContext for cache hits
           const cache = getEntityCache?.(projectContext.path);
 
@@ -224,11 +225,20 @@ export function createReviewsRoutes(options: ReviewsRouteOptions) {
           }
 
           // Try cache for tasks and items (for ref resolution)
+          // AC: @api-contract ac-task-storage-incompatibility-* — translate the storage
+          // error into a 409 so the reviews list does not surface as a 500.
           const tasksDomainState = cache?.getDomainState("tasks");
           const itemsDomainState = cache?.getDomainState("items");
-          const tasks =
-            (cache && tasksDomainState === "ready" ? cache.getTaskIndex() : null) ??
-            (await resolveTaskDataManager(await getCtx()).loadAllTasks(await getCtx()));
+          let tasks;
+          try {
+            tasks =
+              (cache && tasksDomainState === "ready" ? cache.getTaskIndex() : null) ??
+              (await resolveTaskDataManager(await getCtx()).loadAllTasks(await getCtx()));
+          } catch (err) {
+            const conflict = taskStorageIncompatibilityResponse(err, { cache });
+            if (conflict) return errorResponse(conflict.status, conflict.body);
+            throw err;
+          }
           const specItems =
             (cache && itemsDomainState === "ready" ? cache.getItemIndex() : null) ??
             (await loadAllItems(await getCtx()));
@@ -1055,8 +1065,25 @@ export function createReviewsRoutes(options: ReviewsRouteOptions) {
 
           // AC: @review-task-lifecycle-integration ac-4
           // Auto-transition tasks to needs_work on changes_requested verdict
+          // AC: @api-contract ac-task-storage-incompatibility-* — surface storage
+          // incompatibility as a structured 409 instead of a 500. The verdict has
+          // already been committed; the response signals the post-verdict task
+          // transition could not run because of the project's storage state.
           if (decision === "request_changes") {
-            const allTasks = await resolveTaskDataManager(ctx).loadAllTasks(ctx);
+            let allTasks;
+            try {
+              allTasks = await resolveTaskDataManager(ctx).loadAllTasks(ctx);
+            } catch (err) {
+              const verdictCache = getEntityCache?.(projectContext.path);
+              const conflict = taskStorageIncompatibilityResponse(err, { cache: verdictCache });
+              if (conflict) {
+                if (verdictCache) {
+                  await verdictCache.writeThrough("reviews");
+                }
+                return errorResponse(conflict.status, conflict.body);
+              }
+              throw err;
+            }
             const transitioned = await handleVerdictTaskTransition(
               ctx,
               updated,

--- a/packages/daemon/src/routes/sessions.ts
+++ b/packages/daemon/src/routes/sessions.ts
@@ -49,6 +49,7 @@ import { enumArrayUnion } from "./enum-utils.js";
 import type { EntityCacheAccessor } from "./entity-cache-types.js";
 import { wrapResponse } from "./response-envelope.js";
 import { listSessionSummariesFromDisk } from "./session-summary-utils.js";
+import { taskStorageIncompatibilityResponse } from "./task-storage-error.js";
 
 interface SessionRouteOptions {
   getEntityCache?: EntityCacheAccessor;
@@ -111,6 +112,10 @@ async function filterSessionSummaries(
           message?: string;
           suggestion?: string;
           details?: Array<{ field: string; message: string }>;
+          code?: string;
+          field?: string;
+          cache_domain?: string;
+          cache_domain_state?: string;
         };
       };
     }
@@ -189,7 +194,10 @@ async function filterSessionSummaries(
   let tasks: LoadedTask[] | null = null;
   let items: Awaited<ReturnType<typeof loadAllItems>> | null = null;
   // AC: @daemon-entity-cache ac-serve-from-memory — use cached task/item indexes for alignment filtering
-  const ensureAlignmentContext = async () => {
+  type EnsureAlignmentResult =
+    | { tasks: LoadedTask[]; items: LoadedSpecItem[] }
+    | { conflict: ReturnType<typeof taskStorageIncompatibilityResponse> };
+  const ensureAlignmentContext = async (): Promise<EnsureAlignmentResult> => {
     if (!tasks) {
       const tasksDomainReady = entityCache && entityCache.getDomainState("tasks") === "ready";
       if (tasksDomainReady) {
@@ -197,7 +205,15 @@ async function filterSessionSummaries(
         tasks = (entityCache!.getTaskIndex() ?? []) as unknown as LoadedTask[];
       } else {
         const ctx = await resolveCtx();
-        tasks = await resolveTaskDataManager(ctx).loadAllTasks(ctx);
+        try {
+          tasks = await resolveTaskDataManager(ctx).loadAllTasks(ctx);
+        } catch (err) {
+          // AC: @api-contract ac-task-storage-incompatibility-* — propagate the
+          // structured 409 envelope back to the caller instead of throwing.
+          const conflict = taskStorageIncompatibilityResponse(err, { cache: entityCache });
+          if (conflict) return { conflict };
+          throw err;
+        }
       }
     }
     if (!items) {
@@ -210,11 +226,16 @@ async function filterSessionSummaries(
         items = await loadAllItems(ctx);
       }
     }
-    return { tasks, items };
+    return { tasks: tasks!, items: items! };
   };
 
   if (query.task_id) {
-    const { tasks: loadedTasks, items: loadedItems } = await ensureAlignmentContext();
+    const alignment = await ensureAlignmentContext();
+    if ("conflict" in alignment) {
+      const conflict = alignment.conflict!;
+      return { error: { status: conflict.status, body: conflict.body } };
+    }
+    const { tasks: loadedTasks, items: loadedItems } = alignment;
     const refIndex = new ReferenceIndex(loadedTasks, loadedItems);
     const resolved = refIndex.resolve(
       query.task_id.startsWith("@") ? query.task_id.slice(1) : query.task_id,
@@ -241,7 +262,12 @@ async function filterSessionSummaries(
   }
 
   if (query.spec_ref) {
-    const { tasks: loadedTasks, items: loadedItems } = await ensureAlignmentContext();
+    const alignment = await ensureAlignmentContext();
+    if ("conflict" in alignment) {
+      const conflict = alignment.conflict!;
+      return { error: { status: conflict.status, body: conflict.body } };
+    }
+    const { tasks: loadedTasks, items: loadedItems } = alignment;
     const refIndex = new ReferenceIndex(loadedTasks, loadedItems);
     const alignmentIndex = new AlignmentIndex(loadedTasks, loadedItems);
     alignmentIndex.buildLinks(refIndex);
@@ -367,6 +393,9 @@ export function createSessionRoutes(_options: SessionRouteOptions = {}) {
 
           // AC: @ui-api-ref-resolution ac-1 — Resolve task_title for session summaries
           // AC: @daemon-entity-cache ac-serve-from-memory — use cached tasks/items when available
+          // AC: @api-contract ac-task-storage-incompatibility-* — bubble up a structured 409
+          // when this enrichment hits the legacy/unmigrated storage state; the existing
+          // generic catch downgrade still applies to other non-critical failures.
           let refIndex: ReferenceIndex | null = null;
           const taskIdsPresent = paginated.some((s) => s.task_id);
           if (taskIdsPresent) {
@@ -374,9 +403,16 @@ export function createSessionRoutes(_options: SessionRouteOptions = {}) {
               const cache = getEntityCache?.(projectContext.path);
               const tasksDomainReady = cache && cache.getDomainState("tasks") === "ready";
               const itemsDomainReady = cache && cache.getDomainState("items") === "ready";
-              const tasks = tasksDomainReady
-                ? (cache!.getTaskIndex() as unknown as LoadedTask[])
-                : await resolveTaskDataManager(await getCtx()).loadAllTasks(await getCtx());
+              let tasks: LoadedTask[] | undefined;
+              try {
+                tasks = tasksDomainReady
+                  ? (cache!.getTaskIndex() as unknown as LoadedTask[])
+                  : await resolveTaskDataManager(await getCtx()).loadAllTasks(await getCtx());
+              } catch (storageErr) {
+                const conflict = taskStorageIncompatibilityResponse(storageErr, { cache });
+                if (conflict) return errorResponse(conflict.status, conflict.body);
+                throw storageErr;
+              }
               const items = itemsDomainReady
                 ? (cache!.getItemIndex() as unknown as LoadedSpecItem[])
                 : await loadAllItems(await getCtx());

--- a/packages/daemon/src/routes/task-storage-error.ts
+++ b/packages/daemon/src/routes/task-storage-error.ts
@@ -1,0 +1,121 @@
+/**
+ * Daemon Route Helper — task-storage incompatibility error mapping.
+ *
+ * Translates deterministic task-storage compatibility/migration failures
+ * (legacy monolithic storage, split-but-unmigrated state) into a stable
+ * 409 Conflict response shape for any daemon API route that needs task
+ * data from disk. Generic TaskDataManagerError values (task-not-found,
+ * mutation validation, etc.) return no match so callers keep their
+ * existing not_found/validation/transition handling intact.
+ *
+ * AC: @api-contract ac-task-storage-incompatibility-conflict-status
+ * AC: @api-contract ac-task-storage-incompatibility-error-code
+ * AC: @api-contract ac-task-storage-incompatibility-guidance
+ * AC: @api-contract ac-task-storage-incompatibility-not-not-found
+ * AC: @api-contract ac-task-storage-incompatibility-field-context
+ * AC: @api-contract ac-task-storage-incompatibility-cache-domain-context
+ * AC: @api-contract ac-task-storage-incompatibility-cache-state-context
+ */
+
+import type { ErrorResponse } from "@kynetic-ai/shared";
+import {
+  isDeterministicTaskStorageIncompatibility,
+  TaskDataManagerError,
+} from "../../parser/index.js";
+import type { CacheDomainState, RouteEntityCache } from "./entity-cache-types.js";
+
+/** Stable HTTP status returned for task-storage incompatibility. */
+export const TASK_STORAGE_INCOMPATIBLE_STATUS = 409 as const;
+
+/** Stable top-level `error` discriminator for task-storage incompatibility. */
+export const TASK_STORAGE_INCOMPATIBLE_ERROR_CODE = "task_storage_incompatible" as const;
+
+/**
+ * Options for {@link taskStorageIncompatibilityResponse}.
+ *
+ * When neither `cacheDomainState` nor `cache` is provided, the response
+ * omits `cache_domain_state`. When `cache` is provided without
+ * `cacheDomainState`, the helper looks up the state for `cacheDomain`
+ * (defaulting to "tasks") on the cache.
+ */
+export interface TaskStorageIncompatibilityOptions {
+  /**
+   * Cache domain identifier the failure is associated with. Defaults to
+   * "tasks" — the only domain that currently raises deterministic
+   * task-storage incompatibilities.
+   */
+  cacheDomain?: string;
+  /**
+   * Explicit cache domain state to surface when known. Takes precedence
+   * over deriving the state from `cache`.
+   */
+  cacheDomainState?: CacheDomainState;
+  /**
+   * Entity cache accessor to derive the domain state from when an explicit
+   * state is not supplied.
+   */
+  cache?: RouteEntityCache | null;
+}
+
+/**
+ * Materialized 409 response for a deterministic task-storage incompatibility.
+ * Routes return the body via their preferred mechanism (Elysia's `error()`
+ * helper, `set.status = …`, etc.).
+ */
+export interface TaskStorageIncompatibilityResponse {
+  status: typeof TASK_STORAGE_INCOMPATIBLE_STATUS;
+  body: ErrorResponse;
+}
+
+/**
+ * Convert a candidate error into a structured task-storage incompatibility
+ * response, or return `null` when the error is not a deterministic
+ * task-storage incompatibility. Routes layered on `resolveTaskDataManager`
+ * call this in their catch blocks so legacy/unmigrated projects surface
+ * a stable 409 with recovery guidance instead of collapsing to 404
+ * not_found (or escaping as an unhandled 500).
+ *
+ * Generic {@link TaskDataManagerError} values — task-not-found, validation,
+ * mutation — return `null` so existing not_found/validation/transition
+ * handling remains intact.
+ */
+export function taskStorageIncompatibilityResponse(
+  err: unknown,
+  options: TaskStorageIncompatibilityOptions = {},
+): TaskStorageIncompatibilityResponse | null {
+  if (!isDeterministicTaskStorageIncompatibility(err)) {
+    return null;
+  }
+
+  // The type guard narrows `err` to TaskDataManagerError, but TS infers a
+  // structural shape without the class-private suggestion/field. Casting
+  // back to the concrete class keeps the call-site ergonomics simple.
+  const sourceErr = err as TaskDataManagerError;
+
+  const cacheDomain = options.cacheDomain ?? "tasks";
+  const cacheDomainState: CacheDomainState | undefined =
+    options.cacheDomainState ??
+    (cacheDomain && options.cache ? options.cache.getDomainState(cacheDomain) : undefined);
+
+  const body: ErrorResponse = {
+    error: TASK_STORAGE_INCOMPATIBLE_ERROR_CODE,
+    message: sourceErr.message,
+  };
+  if (sourceErr.code) {
+    body.code = sourceErr.code;
+  }
+  if (sourceErr.suggestion) {
+    body.suggestion = sourceErr.suggestion;
+  }
+  if (sourceErr.field) {
+    body.field = sourceErr.field;
+  }
+  if (cacheDomain) {
+    body.cache_domain = cacheDomain;
+  }
+  if (cacheDomainState !== undefined) {
+    body.cache_domain_state = cacheDomainState;
+  }
+
+  return { status: TASK_STORAGE_INCOMPATIBLE_STATUS, body };
+}

--- a/packages/daemon/src/routes/tasks.ts
+++ b/packages/daemon/src/routes/tasks.ts
@@ -46,6 +46,7 @@ import { resolveRefTitle, resolveRefEntries } from "./ref-resolution.js";
 
 import type { EntityCacheAccessor, WriteThroughHint } from "./entity-cache-types.js";
 import { wrapResponse } from "./response-envelope.js";
+import { taskStorageIncompatibilityResponse } from "./task-storage-error.js";
 
 interface TasksRouteOptions {
   pubsub: PubSubManager;
@@ -80,7 +81,7 @@ export function createTasksRoutes(options: TasksRouteOptions) {
       // AC: @daemon-entity-cache ac-warming-availability — return loading indicator if warming
       .get(
         "/",
-        async ({ query, projectContext }) => {
+        async ({ query, error: errorResponse, projectContext }) => {
           // AC: @daemon-entity-cache ac-serve-from-memory, ac-warming-availability
           // AC: @shadow-lazy-read-sync ac-daemon-bypass — cache-first path bypasses per-request drift-check
           const cache = getEntityCache?.(projectContext.path);
@@ -109,20 +110,35 @@ export function createTasksRoutes(options: TasksRouteOptions) {
 
           // AC: @daemon-entity-cache ac-serve-from-memory — use cached index when ready
           // AC: @daemon-entity-cache ac-graceful-degradation — fall back to disk if degraded
+          // AC: @api-contract ac-task-storage-incompatibility-* — direct disk reads that
+          // hit a deterministic task-storage incompatibility surface as 409.
           let summaries;
-          if (cache && tasksDomainState === "ready") {
-            const cachedTasks = cache.getTaskIndex();
-            if (cachedTasks) {
-              // Apply status and automation filters (matching listTasks contract)
-              summaries = cachedTasks;
-              if (query.status) {
-                const statusFilters = Array.isArray(query.status) ? query.status : [query.status];
-                summaries = summaries.filter((t) => statusFilters.includes(t.status));
-              }
-              if (query.automation) {
-                summaries = summaries.filter((t) => t.automation === query.automation);
+          try {
+            if (cache && tasksDomainState === "ready") {
+              const cachedTasks = cache.getTaskIndex();
+              if (cachedTasks) {
+                // Apply status and automation filters (matching listTasks contract)
+                summaries = cachedTasks;
+                if (query.status) {
+                  const statusFilters = Array.isArray(query.status) ? query.status : [query.status];
+                  summaries = summaries.filter((t) => statusFilters.includes(t.status));
+                }
+                if (query.automation) {
+                  summaries = summaries.filter((t) => t.automation === query.automation);
+                }
+              } else {
+                const ctx = await getCtx();
+                summaries = await resolveTaskDataManager(ctx).listTasks(ctx, {
+                  status: query.status
+                    ? Array.isArray(query.status)
+                      ? query.status
+                      : [query.status]
+                    : undefined,
+                  automation: query.automation || undefined,
+                });
               }
             } else {
+              // AC: @task-data-manager ac-2 — list uses index-only summaries
               const ctx = await getCtx();
               summaries = await resolveTaskDataManager(ctx).listTasks(ctx, {
                 status: query.status
@@ -133,17 +149,10 @@ export function createTasksRoutes(options: TasksRouteOptions) {
                 automation: query.automation || undefined,
               });
             }
-          } else {
-            // AC: @task-data-manager ac-2 — list uses index-only summaries
-            const ctx = await getCtx();
-            summaries = await resolveTaskDataManager(ctx).listTasks(ctx, {
-              status: query.status
-                ? Array.isArray(query.status)
-                  ? query.status
-                  : [query.status]
-                : undefined,
-              automation: query.automation || undefined,
-            });
+          } catch (err) {
+            const conflict = taskStorageIncompatibilityResponse(err, { cache });
+            if (conflict) return errorResponse(conflict.status, conflict.body);
+            throw err;
           }
 
           // Apply filters not supported by TaskListFilters
@@ -324,6 +333,11 @@ export function createTasksRoutes(options: TasksRouteOptions) {
             try {
               task = await resolveTaskDataManager(ctx).getTask(ctx, params.ref);
             } catch (err) {
+              // AC: @api-contract ac-task-storage-incompatibility-not-not-found —
+              // deterministic task-storage incompatibility must surface as 409,
+              // not be collapsed into a task-ref not_found.
+              const conflict = taskStorageIncompatibilityResponse(err, { cache });
+              if (conflict) return errorResponse(conflict.status, conflict.body);
               if (err instanceof TaskDataManagerError) {
                 return errorResponse(404, {
                   error: "not_found",
@@ -447,7 +461,16 @@ export function createTasksRoutes(options: TasksRouteOptions) {
             // AC: @shadow-lazy-read-sync ac-daemon-bypass — daemon fallback reads skip
             // per-request drift-check; freshness is handled by background sync scheduler
             const ctx = await initContext(projectContext.path, { syncMode: "skip" });
-            tasks = await resolveTaskDataManager(ctx).loadAllTasks(ctx);
+            // AC: @api-contract ac-task-storage-incompatibility-* — surface a
+            // structured 409 for legacy/unmigrated projects instead of letting
+            // the storage error escape as an unhandled 500.
+            try {
+              tasks = await resolveTaskDataManager(ctx).loadAllTasks(ctx);
+            } catch (err) {
+              const conflict = taskStorageIncompatibilityResponse(err, { cache });
+              if (conflict) return errorResponse(conflict.status, conflict.body);
+              throw err;
+            }
             items = await loadAllItems(ctx);
             sessionsDir = ctx.sessionsDir;
           }
@@ -485,12 +508,16 @@ export function createTasksRoutes(options: TasksRouteOptions) {
         async ({ params, error: errorResponse, projectContext }) => {
           // AC: @multi-directory-daemon ac-1, ac-24 - Use project context from middleware
           const ctx = await initContext(projectContext.path);
+          const startEntityCache = getEntityCache?.(projectContext.path);
 
           // AC: @task-data-manager ac-3 — resolve task via manager
           let task: LoadedTask;
           try {
             task = await resolveTaskDataManager(ctx).getTask(ctx, params.ref);
           } catch (err) {
+            // AC: @api-contract ac-task-storage-incompatibility-not-not-found
+            const conflict = taskStorageIncompatibilityResponse(err, { cache: startEntityCache });
+            if (conflict) return errorResponse(conflict.status, conflict.body);
             if (err instanceof TaskDataManagerError) {
               return errorResponse(404, {
                 error: "not_found",
@@ -583,6 +610,7 @@ export function createTasksRoutes(options: TasksRouteOptions) {
         async ({ params, body, error: errorResponse, projectContext }) => {
           // AC: @multi-directory-daemon ac-1, ac-24 - Use project context from middleware
           const ctx = await initContext(projectContext.path);
+          const noteEntityCache = getEntityCache?.(projectContext.path);
 
           // AC: @trait-api-endpoint ac-3 - Validate body
           if (!body.content || typeof body.content !== "string") {
@@ -610,6 +638,9 @@ export function createTasksRoutes(options: TasksRouteOptions) {
               { operation: "task", ref: params.ref, detail: "add note" },
             );
           } catch (err) {
+            // AC: @api-contract ac-task-storage-incompatibility-not-not-found
+            const conflict = taskStorageIncompatibilityResponse(err, { cache: noteEntityCache });
+            if (conflict) return errorResponse(conflict.status, conflict.body);
             if (err instanceof TaskDataManagerError) {
               return errorResponse(404, {
                 error: "not_found",
@@ -665,12 +696,16 @@ export function createTasksRoutes(options: TasksRouteOptions) {
         "/:ref/submit",
         async ({ params, error: errorResponse, projectContext }) => {
           const ctx = await initContext(projectContext.path);
+          const submitEntityCache = getEntityCache?.(projectContext.path);
 
           // AC: @task-data-manager ac-3 — resolve task via manager
           let task: LoadedTask;
           try {
             task = await resolveTaskDataManager(ctx).getTask(ctx, params.ref);
           } catch (err) {
+            // AC: @api-contract ac-task-storage-incompatibility-not-not-found
+            const conflict = taskStorageIncompatibilityResponse(err, { cache: submitEntityCache });
+            if (conflict) return errorResponse(conflict.status, conflict.body);
             if (err instanceof TaskDataManagerError) {
               return errorResponse(404, {
                 error: "not_found",
@@ -749,12 +784,18 @@ export function createTasksRoutes(options: TasksRouteOptions) {
         "/:ref/complete",
         async ({ params, body, error: errorResponse, projectContext }) => {
           const ctx = await initContext(projectContext.path);
+          const completeEntityCache = getEntityCache?.(projectContext.path);
 
           // AC: @task-data-manager ac-3 — resolve task via manager
           let task: LoadedTask;
           try {
             task = await resolveTaskDataManager(ctx).getTask(ctx, params.ref);
           } catch (err) {
+            // AC: @api-contract ac-task-storage-incompatibility-not-not-found
+            const conflict = taskStorageIncompatibilityResponse(err, {
+              cache: completeEntityCache,
+            });
+            if (conflict) return errorResponse(conflict.status, conflict.body);
             if (err instanceof TaskDataManagerError) {
               return errorResponse(404, {
                 error: "not_found",
@@ -832,12 +873,16 @@ export function createTasksRoutes(options: TasksRouteOptions) {
         "/:ref/block",
         async ({ params, body, error: errorResponse, projectContext }) => {
           const ctx = await initContext(projectContext.path);
+          const blockEntityCache = getEntityCache?.(projectContext.path);
 
           // AC: @task-data-manager ac-3 — resolve task via manager
           let task: LoadedTask;
           try {
             task = await resolveTaskDataManager(ctx).getTask(ctx, params.ref);
           } catch (err) {
+            // AC: @api-contract ac-task-storage-incompatibility-not-not-found
+            const conflict = taskStorageIncompatibilityResponse(err, { cache: blockEntityCache });
+            if (conflict) return errorResponse(conflict.status, conflict.body);
             if (err instanceof TaskDataManagerError) {
               return errorResponse(404, {
                 error: "not_found",

--- a/packages/daemon/src/routes/triage.ts
+++ b/packages/daemon/src/routes/triage.ts
@@ -49,6 +49,7 @@ import type { PubSubManager } from "../websocket/pubsub.js";
 import { enumArrayUnion, enumUnion } from "./enum-utils.js";
 import type { EntityCacheAccessor } from "./entity-cache-types.js";
 import { wrapResponse } from "./response-envelope.js";
+import { taskStorageIncompatibilityResponse } from "./task-storage-error.js";
 
 interface TriageRouteOptions {
   pubsub: PubSubManager;
@@ -540,7 +541,18 @@ export function createTriageRoutes(options: TriageRouteOptions) {
           }
 
           // AC: @triage-daemon-api ac-5 - Execute the action
-          const result = await executeTriageAction(record, ctx);
+          // AC: @api-contract ac-task-storage-incompatibility-* — promote actions
+          // call resolveTaskDataManager(ctx).createTask(); surface the deterministic
+          // storage error as a structured 409 instead of a 500.
+          let result: Awaited<ReturnType<typeof executeTriageAction>>;
+          try {
+            result = await executeTriageAction(record, ctx);
+          } catch (err) {
+            const actCacheForError = getEntityCache?.(projectContext.path);
+            const conflict = taskStorageIncompatibilityResponse(err, { cache: actCacheForError });
+            if (conflict) return errorResponse(conflict.status, conflict.body);
+            throw err;
+          }
 
           // Transition to acted_on
           record.status = "acted_on";

--- a/packages/daemon/src/routes/validation.ts
+++ b/packages/daemon/src/routes/validation.ts
@@ -28,6 +28,7 @@ import { grepItem } from "../../utils/grep.js";
 import { enumUnion } from "./enum-utils.js";
 import type { EntityCacheAccessor } from "./entity-cache-types.js";
 import { wrapResponse } from "./response-envelope.js";
+import { taskStorageIncompatibilityResponse } from "./task-storage-error.js";
 
 interface ValidationRouteOptions {
   getEntityCache?: EntityCacheAccessor;
@@ -42,7 +43,7 @@ export function createValidationRoutes(_options: ValidationRouteOptions = {}) {
       // AC: @daemon-read-path ac-no-per-request-sync, ac-index-from-cache — serve from cached entity data
       .get(
         "/search",
-        async ({ query, projectContext }) => {
+        async ({ query, error: errorResponse, projectContext }) => {
           const cache = getEntityCache?.(projectContext.path);
           const tasksDomainState = cache?.getDomainState("tasks");
           const itemsDomainState = cache?.getDomainState("items");
@@ -75,12 +76,20 @@ export function createValidationRoutes(_options: ValidationRouteOptions = {}) {
           // Search needs full entities (description, notes, AC content) — summaries
           // strip those fields, breaking grepItem matches. Use detail tier which is
           // populated alongside the index during domain load.
+          // AC: @api-contract ac-task-storage-incompatibility-* — translate the
+          // storage error into a structured 409 instead of a 500.
           let tasks: LoadedTask[];
-          if (cache && tasksDomainState === "ready") {
-            tasks = cache.getAllTaskDetails() ?? [];
-          } else {
-            const ctx = await getCtx();
-            tasks = await resolveTaskDataManager(ctx).loadAllTasks(ctx);
+          try {
+            if (cache && tasksDomainState === "ready") {
+              tasks = cache.getAllTaskDetails() ?? [];
+            } else {
+              const ctx = await getCtx();
+              tasks = await resolveTaskDataManager(ctx).loadAllTasks(ctx);
+            }
+          } catch (err) {
+            const conflict = taskStorageIncompatibilityResponse(err, { cache });
+            if (conflict) return errorResponse(conflict.status, conflict.body);
+            throw err;
           }
 
           let items: LoadedSpecItem[];
@@ -274,7 +283,7 @@ export function createValidationRoutes(_options: ValidationRouteOptions = {}) {
 
       // AC: @api-contract ac-21 - Get alignment stats and warnings
       // AC: @daemon-read-path ac-index-from-cache — build alignment/reference indexes from cached entity data
-      .get("/alignment", async ({ projectContext }) => {
+      .get("/alignment", async ({ error: errorResponse, projectContext }) => {
         // AC: @multi-directory-daemon ac-1, ac-24 - Use project context from middleware
         const cache = getEntityCache?.(projectContext.path);
         const tasksDomainState = cache?.getDomainState("tasks");
@@ -293,12 +302,20 @@ export function createValidationRoutes(_options: ValidationRouteOptions = {}) {
 
         // Resolve tasks and items from cache when available
         // AC: @daemon-read-path ac-index-from-cache — indexes built from cached data
+        // AC: @api-contract ac-task-storage-incompatibility-* — return 409 with
+        // recovery guidance when storage incompatibility blocks the alignment read.
         let tasks: LoadedTask[];
-        if (cache && tasksDomainState === "ready") {
-          tasks = (cache.getTaskIndex() ?? []) as unknown as LoadedTask[];
-        } else {
-          const ctx = await initContext(projectContext.path, { syncMode: "skip" });
-          tasks = await resolveTaskDataManager(ctx).loadAllTasks(ctx);
+        try {
+          if (cache && tasksDomainState === "ready") {
+            tasks = (cache.getTaskIndex() ?? []) as unknown as LoadedTask[];
+          } else {
+            const ctx = await initContext(projectContext.path, { syncMode: "skip" });
+            tasks = await resolveTaskDataManager(ctx).loadAllTasks(ctx);
+          }
+        } catch (err) {
+          const conflict = taskStorageIncompatibilityResponse(err, { cache });
+          if (conflict) return errorResponse(conflict.status, conflict.body);
+          throw err;
         }
 
         let items: LoadedSpecItem[];

--- a/packages/shared/src/api.ts
+++ b/packages/shared/src/api.ts
@@ -82,6 +82,11 @@ export interface PaginatedResponse<T> {
 /**
  * Standard error response
  * AC: @api-contract ac-22, ac-23, ac-24
+ * AC: @api-contract ac-task-storage-incompatibility-error-code
+ * AC: @api-contract ac-task-storage-incompatibility-guidance
+ * AC: @api-contract ac-task-storage-incompatibility-field-context
+ * AC: @api-contract ac-task-storage-incompatibility-cache-domain-context
+ * AC: @api-contract ac-task-storage-incompatibility-cache-state-context
  */
 export interface ErrorResponse {
   error: string;
@@ -90,6 +95,33 @@ export interface ErrorResponse {
   details?: Array<{ field: string; message: string }>;
   current?: string;
   valid_transitions?: string[];
+  /**
+   * Inner stable error code identifying the specific failure class. Used by
+   * task-storage incompatibility responses to preserve the underlying
+   * TaskDataManagerError code (e.g. "legacy_task_storage_removed",
+   * "split_task_storage_unmigrated") even when the top-level `error`
+   * collapses them into a single API discriminator.
+   */
+  code?: string;
+  /**
+   * Affected configuration or storage field when the failure identifies one
+   * (e.g. "task_storage.format" for task-storage incompatibility errors).
+   * Distinct from `details[].field`, which is reserved for per-field
+   * validation diagnostics on 400/422 responses.
+   */
+  field?: string;
+  /**
+   * Identifies the cache domain associated with the failure when the error
+   * is tied to a cache-backed domain (e.g. "tasks").
+   */
+  cache_domain?: string;
+  /**
+   * Current state of the affected cache domain when the daemon can report
+   * one. Mirrors the daemon's internal DomainState enum
+   * ("unloaded" | "loading" | "ready" | "degraded"). Distinct from the
+   * envelope `meta.cache_status`, which only exposes "ready" | "loading".
+   */
+  cache_domain_state?: string;
 }
 
 /**

--- a/src/agent-runtime/dispatch.ts
+++ b/src/agent-runtime/dispatch.ts
@@ -1005,16 +1005,17 @@ export class DispatchEngine {
     // AC: @agent-dispatch-engine ac-19, ac-20 - Start periodic reconciliation
     if (this.reconcileIntervalMs > 0) {
       this.reconcileTimer = setInterval(() => {
-        if (this.running) {
-          const p = this._reconcile()
-            .catch((err) => {
-              console.error("[dispatch] Reconciliation error:", err);
-            })
-            .finally(() => {
-              this.inFlightReconciles.delete(p);
-            });
-          this.inFlightReconciles.add(p);
+        if (!this.running || this.inFlightReconciles.size > 0) {
+          return;
         }
+        const p = this._reconcile()
+          .catch((err) => {
+            console.error("[dispatch] Reconciliation error:", err);
+          })
+          .finally(() => {
+            this.inFlightReconciles.delete(p);
+          });
+        this.inFlightReconciles.add(p);
       }, this.reconcileIntervalMs);
       this.reconcileTimer.unref();
     }

--- a/src/agent-runtime/event-bus.ts
+++ b/src/agent-runtime/event-bus.ts
@@ -378,9 +378,13 @@ export class EventBus {
    * Correlation IDs that no longer appear in retained events cannot be resolved
    * through the bus's causation history anymore, so keeping their depth counters
    * only grows memory across long-running daemons.
+   *
+   * Note: we cannot skip pruning based on `chainDepths.size <= ringBuffer.size`
+   * — a single correlated event followed by N uncorrelated events leaves a
+   * stale chainDepths entry even though the size invariant holds.
    */
   private _pruneChainDepthsToRecentEvents(): void {
-    if (this.chainDepths.size <= this.ringBuffer.size) return;
+    if (this.chainDepths.size === 0) return;
 
     const retainedCorrelationIds = new Set(
       this.getRecentEvents()

--- a/src/agent-runtime/event-bus.ts
+++ b/src/agent-runtime/event-bus.ts
@@ -160,6 +160,10 @@ class RingBuffer<T> {
   get size(): number {
     return this.count;
   }
+
+  get maxSize(): number {
+    return this.capacity;
+  }
 }
 
 // ─── EventBus ─────────────────────────────────────────────────────────────────
@@ -291,6 +295,7 @@ export class EventBus {
 
     // AC: @dispatch-event-envelope ac-6 - Store in ring buffer
     this.ringBuffer.push(envelope);
+    this._pruneChainDepthsToRecentEvents();
 
     // AC: @dispatch-event-envelope ac-4 - Per-source sequential delivery
     this._deliverToSubscribers(envelope);
@@ -360,13 +365,35 @@ export class EventBus {
    */
   clear(): void {
     this.subscriptions = [];
-    this.ringBuffer = new RingBuffer(this.ringBuffer["capacity"]);
+    this.ringBuffer = new RingBuffer(this.ringBuffer.maxSize);
     this.taskDedupMap.clear();
     this.chainDepths.clear();
     this.sourceDeliveryChains.clear();
   }
 
   // ─── Private ────────────────────────────────────────────────────────────────
+
+  /**
+   * Keep chain-depth retention aligned with the recent-event ring buffer.
+   * Correlation IDs that no longer appear in retained events cannot be resolved
+   * through the bus's causation history anymore, so keeping their depth counters
+   * only grows memory across long-running daemons.
+   */
+  private _pruneChainDepthsToRecentEvents(): void {
+    if (this.chainDepths.size <= this.ringBuffer.size) return;
+
+    const retainedCorrelationIds = new Set(
+      this.getRecentEvents()
+        .map((event) => event.correlation_id)
+        .filter((id): id is string => typeof id === "string" && id.length > 0),
+    );
+
+    for (const correlationId of Array.from(this.chainDepths.keys())) {
+      if (!retainedCorrelationIds.has(correlationId)) {
+        this.chainDepths.delete(correlationId);
+      }
+    }
+  }
 
   /**
    * Deliver an event to all matching subscribers, sequentially per source.
@@ -379,7 +406,7 @@ export class EventBus {
     if (matching.length === 0) return;
 
     // Chain delivery onto the per-source promise chain to ensure
-    // events from the same source are processed sequentially
+    // events from the same source are processed sequentially.
     const sourceId = event.source_id;
     const previousChain = this.sourceDeliveryChains.get(sourceId) ?? Promise.resolve();
 
@@ -394,6 +421,15 @@ export class EventBus {
     });
 
     this.sourceDeliveryChains.set(sourceId, deliveryChain);
+    deliveryChain.finally(() => {
+      // Only clear the map entry if no newer event from the same source has
+      // chained onto this one. This preserves per-source ordering while
+      // avoiding permanent retention of settled promises for high-cardinality
+      // source IDs such as action/session/run identifiers.
+      if (this.sourceDeliveryChains.get(sourceId) === deliveryChain) {
+        this.sourceDeliveryChains.delete(sourceId);
+      }
+    });
   }
 
   /**

--- a/src/agent-runtime/invocation.ts
+++ b/src/agent-runtime/invocation.ts
@@ -555,6 +555,12 @@ export async function runInvocation(options: InvocationOptions): Promise<Invocat
     acpSessionId: null,
   };
 
+  const invocationEnv: Record<string, string> = {
+    ...env,
+    KSPEC_NO_DAEMON: "1",
+    ...(mutationLockFile ? { KSPEC_SHADOW_MUTATION_LOCK_FILE: mutationLockFile } : {}),
+  };
+
   // ─── Prompt queue for multi-turn ─────────────────────────────────────────
   // AC: @multi-turn-session-lifecycle ac-8, ac-9, ac-17
   const promptQueue = new PromptQueue(maxPromptQueueDepth);
@@ -656,9 +662,8 @@ export async function runInvocation(options: InvocationOptions): Promise<Invocat
     state.agent = await spawnAndInitialize(adapter, {
       cwd,
       env: {
-        ...env,
+        ...invocationEnv,
         KSPEC_SESSION_ID: sessionId,
-        ...(mutationLockFile ? { KSPEC_SHADOW_MUTATION_LOCK_FILE: mutationLockFile } : {}),
       },
       extraArgs,
       clientOptions: {
@@ -1057,7 +1062,7 @@ export async function runInvocation(options: InvocationOptions): Promise<Invocat
           `[AGENT-TIMEOUT] Invocation timed out after ${timeoutMinutes} minutes`,
           cwd,
           kspecCliPath,
-          mutationLockFile ? { KSPEC_SHADOW_MUTATION_LOCK_FILE: mutationLockFile } : undefined,
+          invocationEnv,
           Boolean(mutationLockFile),
         );
       }
@@ -1207,7 +1212,7 @@ export async function runInvocation(options: InvocationOptions): Promise<Invocat
         `[AGENT-FAIL] Invocation failed: ${errorMessage}`,
         cwd,
         kspecCliPath,
-        mutationLockFile ? { KSPEC_SHADOW_MUTATION_LOCK_FILE: mutationLockFile } : undefined,
+        invocationEnv,
         Boolean(mutationLockFile),
       );
 
@@ -1222,7 +1227,7 @@ export async function runInvocation(options: InvocationOptions): Promise<Invocat
           `Agent ${agent.id} failed ${consecutiveFailures} consecutive times: ${errorMessage}`,
           cwd,
           kspecCliPath,
-          mutationLockFile ? { KSPEC_SHADOW_MUTATION_LOCK_FILE: mutationLockFile } : undefined,
+          invocationEnv,
           Boolean(mutationLockFile),
         );
       }

--- a/src/agent-runtime/workspace.ts
+++ b/src/agent-runtime/workspace.ts
@@ -3706,6 +3706,12 @@ function logArtifactPreservation(
   identifier: string,
   reason: string | null,
 ): void {
+  // Preservation diagnostics can occur on every reconciliation pass for every
+  // protected artifact. Keep them opt-in so normal daemon operation does not
+  // amplify deterministic cleanup blockers into unbounded log volume.
+  if (process.env.KSPEC_DISPATCH_CLEANUP_DIAGNOSTICS !== "1") {
+    return;
+  }
   const reasonText = reason ?? "protection-source unspecified";
   console.debug(`[dispatch-cleanup] preserved ${surface} "${identifier}": ${reasonText}`);
 }

--- a/src/cli/daemon-proxy.ts
+++ b/src/cli/daemon-proxy.ts
@@ -16,6 +16,8 @@
  *     ac-legacy-port-fallback
  */
 
+import { AsyncLocalStorage } from "node:async_hooks";
+
 import {
   isNoDaemonModeEnabled,
   resolveDaemonClientEndpoint,
@@ -63,6 +65,21 @@ const REGISTRATION_TIMEOUT_MS = 5_000;
  * AC: @cli-daemon-proxy — detection result cached for CLI process lifetime
  */
 let cachedDetection: DaemonDetectionResult | null = null;
+
+/**
+ * Request-scoped guard used while the daemon's /api/command route executes
+ * CLI commands in-process. Without this, the global CLI pre-action hook can
+ * detect the same daemon and recursively POST back to /api/command.
+ */
+const daemonProxySuppressionStorage = new AsyncLocalStorage<boolean>();
+
+export function runWithDaemonProxySuppressed<T>(fn: () => T): T {
+  return daemonProxySuppressionStorage.run(true, fn);
+}
+
+function isDaemonProxySuppressed(): boolean {
+  return daemonProxySuppressionStorage.getStore() === true;
+}
 
 // ── Detection ──────────────────────────────────────────────────────
 
@@ -136,6 +153,10 @@ export async function shouldProxyCommand(opts: {
 }): Promise<
   { proxy: true; port: number; endpoint: DaemonClientEndpoint } | { proxy: false; reason?: string }
 > {
+  if (isDaemonProxySuppressed()) {
+    return { proxy: false, reason: "daemon command API execution" };
+  }
+
   // AC: @cli-daemon-proxy ac-force-direct
   if (isNoDaemonModeEnabled()) {
     return { proxy: false, reason: "KSPEC_NO_DAEMON is set" };

--- a/src/daemon/entity-cache.ts
+++ b/src/daemon/entity-cache.ts
@@ -46,7 +46,11 @@ import {
   type TaskSummary,
 } from "../parser/index.js";
 import type { MetaContext } from "../parser/meta.js";
-import type { HistoryEntry } from "../parser/task-data-manager.js";
+import {
+  isDeterministicTaskStorageIncompatibility,
+  type HistoryEntry,
+  type TaskDataManagerError,
+} from "../parser/task-data-manager.js";
 import { loadInboxItems, type LoadedInboxItem } from "../parser/yaml.js";
 import { loadTriageRecords, type LoadedTriageRecord } from "../parser/yaml.js";
 import { loadReviewRecords, type LoadedReviewRecord } from "../parser/reviews.js";
@@ -302,6 +306,27 @@ export interface CachedSessionContext {
   updated_at: string;
 }
 
+/**
+ * Tracked state for a deterministic task-storage compatibility/migration
+ * failure on the tasks cache domain. Preserved across repeat reload paths
+ * so the daemon can avoid amplifying the same unchanged condition.
+ *
+ * AC: @daemon-entity-cache ac-task-storage-incompatibility-degraded-state
+ * AC: @daemon-entity-cache ac-task-storage-incompatibility-stable-reporting
+ */
+export interface TaskStorageIncompatibilityState {
+  /** Stable error code from TaskDataManagerError (e.g. "legacy_task_storage_removed"). */
+  code: string;
+  /** Human-readable message captured from the original error. */
+  message: string;
+  /** Recovery guidance (suggestion) carried over from the original error. */
+  suggestion: string | null;
+  /** Field that drove the error, when one was reported. */
+  field: string | null;
+  /** ISO 8601 timestamp the current incompatibility was first observed. */
+  observedAt: string;
+}
+
 /** Per-domain diagnostic snapshot returned by getCacheDiagnostics(). */
 export interface DomainDiagnostic {
   state: DomainState;
@@ -309,6 +334,31 @@ export interface DomainDiagnostic {
   detailCount: number;
   lastError: string | null;
   lastInvalidatedAt: string | null;
+  /**
+   * Stable code identifying the current error class when available
+   * (e.g. "legacy_task_storage_removed"). Null when the domain is healthy
+   * or the error has no stable code.
+   *
+   * AC: @daemon-server ac-cache-diagnostics-degraded-reason
+   */
+  errorReason: string | null;
+  /**
+   * User-actionable guidance describing how to recover from the current
+   * error, when the underlying error supplied one.
+   *
+   * AC: @daemon-server ac-cache-diagnostics-recovery-guidance
+   */
+  recoveryGuidance: string | null;
+  /**
+   * True when the only path to recovery is a relevant project-state change
+   * (e.g. running a migration or updating the manifest). Surfaces the
+   * suppressed/waiting state from bounded degraded-state behavior so
+   * diagnostic clients can distinguish "stuck on user action" from
+   * "transient failure".
+   *
+   * AC: @daemon-server ac-cache-diagnostics-recovery-readiness
+   */
+  recoveryWaitingOnProjectState: boolean;
 }
 
 /** Full cache diagnostic snapshot for a single project. */
@@ -398,6 +448,25 @@ interface DomainStore<TIndex, TDetail = unknown> {
 
 interface TaskDomainStore extends DomainStore<TaskSummary[], CachedTaskDetail> {
   historyDetails: Map<string, HistoryEntry[]>;
+  /**
+   * Active deterministic task-storage incompatibility, when the tasks domain
+   * cannot load because of a legacy/unmigrated storage state. Persists across
+   * reload paths so the daemon does not amplify the unchanged condition.
+   *
+   * AC: @daemon-entity-cache ac-task-storage-incompatibility-stable-reporting
+   */
+  storageIncompatibility: TaskStorageIncompatibilityState | null;
+  /**
+   * Whether a relevant task-storage project-state change has been observed
+   * since the last evaluation. While false (and storageIncompatibility is
+   * set), the next tasks reload is suppressed entirely. Set to true when
+   * the watcher reports a change to kynetic.yaml, project.tasks.yaml, or
+   * tasks/<ULID>/ — the signals that can resolve a deterministic
+   * incompatibility.
+   *
+   * AC: @daemon-entity-cache ac-task-storage-incompatibility-rechecked-after-storage-change
+   */
+  needsTaskStorageRecheck: boolean;
 }
 
 // ─── File → Domain Mapping ───────────────────────────────────────────────────
@@ -431,6 +500,13 @@ export function fileToDomain(
     domains.push("tasks");
   }
   if (relativePath.startsWith("tasks/")) {
+    domains.push("tasks");
+  }
+  // kynetic.yaml carries the task_storage configuration; manifest changes
+  // are a relevant signal for re-evaluating task-storage compatibility.
+  // AC: @daemon-entity-cache ac-manifest-task-storage-settings-affect-tasks-domain
+  // AC: @daemon-entity-cache ac-task-storage-incompatibility-rechecked-after-storage-change
+  if (relativePath === "kynetic.yaml") {
     domains.push("tasks");
   }
 
@@ -524,6 +600,8 @@ export class ProjectEntityCache {
     index: null,
     details: new Map(),
     historyDetails: new Map(),
+    storageIncompatibility: null,
+    needsTaskStorageRecheck: true,
   };
   private items: DomainStore<ItemSummary[], LoadedSpecItem> = {
     state: "unloaded",
@@ -942,12 +1020,31 @@ export class ProjectEntityCache {
       const store = this.getStore(domain);
       const indexCount =
         store.index == null ? 0 : Array.isArray(store.index) ? store.index.length : 1; // meta index is a single object
+
+      // AC: @daemon-server ac-cache-diagnostics-degraded-reason
+      // AC: @daemon-server ac-cache-diagnostics-recovery-guidance
+      // AC: @daemon-server ac-cache-diagnostics-recovery-readiness
+      // Tasks domain surfaces deterministic task-storage incompatibility
+      // diagnostics so clients can distinguish "stuck on user action" from
+      // "transient failure". Other domains report nulls/false.
+      let errorReason: string | null = null;
+      let recoveryGuidance: string | null = null;
+      let recoveryWaitingOnProjectState = false;
+      if (domain === "tasks" && this.tasks.storageIncompatibility) {
+        errorReason = this.tasks.storageIncompatibility.code;
+        recoveryGuidance = this.tasks.storageIncompatibility.suggestion;
+        recoveryWaitingOnProjectState = !this.tasks.needsTaskStorageRecheck;
+      }
+
       domains[domain] = {
         state: store.state,
         indexCount,
         detailCount: store.details.size,
         lastError: store.lastError?.message ?? null,
         lastInvalidatedAt: store.lastInvalidatedAt ?? null,
+        errorReason,
+        recoveryGuidance,
+        recoveryWaitingOnProjectState,
       };
     }
     return { projectPath: this.projectPath, domains };
@@ -1235,6 +1332,17 @@ export class ProjectEntityCache {
   async invalidateDomain(domain: CacheDomain): Promise<void> {
     if (this.disposed) return;
 
+    // AC: @daemon-entity-cache ac-task-storage-incompatibility-rechecked-after-storage-change
+    // Watcher-driven invalidation of the tasks domain is the canonical
+    // signal of a relevant project-state change: project.tasks.yaml,
+    // tasks/<ULID>/*, and kynetic.yaml all map to "tasks" via fileToDomain.
+    // Flip the recheck flag synchronously so the upcoming reload re-evaluates
+    // current task-storage state — suppression lifts before the debounced
+    // reload actually runs.
+    if (domain === "tasks") {
+      this.tasks.needsTaskStorageRecheck = true;
+    }
+
     // AC: @daemon-entity-cache ac-write-through — skip if write-through just updated this domain
     if (this.writeThroughSkip.has(domain)) {
       this.writeThroughSkip.delete(domain);
@@ -1371,6 +1479,8 @@ export class ProjectEntityCache {
       store.details.clear();
       if (domain === "tasks") {
         this.tasks.historyDetails.clear();
+        this.tasks.storageIncompatibility = null;
+        this.tasks.needsTaskStorageRecheck = true;
       }
       store.state = "unloaded";
       store.lastError = undefined;
@@ -1519,6 +1629,19 @@ export class ProjectEntityCache {
     domain: Exclude<CacheDomain, "meta">,
     cycle?: ReloadCycle,
   ): Promise<void> {
+    // AC: @daemon-entity-cache ac-task-storage-incompatibility-stable-reporting
+    // AC: @daemon-entity-cache ac-task-storage-incompatibility-persists-when-unresolved
+    // Bounded degraded-state behavior for the tasks domain: when a previous
+    // load surfaced a deterministic task-storage incompatibility and no
+    // relevant project-state change has been observed since, skip the reload
+    // entirely. The store keeps its degraded state and lastError diagnostics;
+    // no new failure report is emitted. Initial loads, explicit loadDomain
+    // calls, writeThrough fallback reloads, and queued reloads all observe
+    // the same suppression because they all funnel through this method.
+    if (domain === "tasks" && this.isTaskStorageSuppressionActive()) {
+      return;
+    }
+
     const store = this.getStore(domain);
 
     // AC: @daemon-entity-cache ac-domain-ready-event — capture state before
@@ -1540,6 +1663,14 @@ export class ProjectEntityCache {
         store.state = "ready";
         store.lastError = undefined;
 
+        // AC: @daemon-entity-cache ac-task-storage-incompatibility-recovers-after-migration
+        // A successful load clears any prior deterministic task-storage
+        // incompatibility — the project state is now compatible.
+        if (domain === "tasks") {
+          this.tasks.storageIncompatibility = null;
+          this.tasks.needsTaskStorageRecheck = false;
+        }
+
         // AC: @daemon-entity-cache ac-domain-ready-event — only fire when
         // transitioning FROM a non-ready state. Reloads of already-ready
         // domains (ac-stale-during-reload) do not trigger the event.
@@ -1548,12 +1679,77 @@ export class ProjectEntityCache {
         }
       }
     } catch (err) {
-      if (!this.disposed) {
-        // AC: @daemon-entity-cache ac-graceful-degradation
-        store.state = "degraded";
-        store.lastError = err instanceof Error ? err : new Error(String(err));
-        console.error(`[entity-cache] Failed to load domain "${domain}":`, err);
+      if (this.disposed) {
+        return;
       }
+
+      // AC: @daemon-entity-cache ac-task-storage-incompatibility-degraded-state
+      // AC: @daemon-entity-cache ac-task-storage-incompatibility-stable-reporting
+      // Deterministic task-storage incompatibility: track the stable code so
+      // subsequent reload attempts are suppressed until a project-state
+      // change clears it. Generic TaskDataManagerError cases (validation,
+      // not-found, mutation) fall through to the normal degrade-on-error
+      // path because they may resolve on retry.
+      if (domain === "tasks" && isDeterministicTaskStorageIncompatibility(err)) {
+        this.noteTaskStorageIncompatibility(err);
+        return;
+      }
+
+      // AC: @daemon-entity-cache ac-graceful-degradation
+      // Non-deterministic failure: clear any prior storage-incompatibility
+      // marker so this generic error is not silently held under suppression
+      // intended for deterministic cases.
+      if (domain === "tasks") {
+        this.tasks.storageIncompatibility = null;
+        this.tasks.needsTaskStorageRecheck = false;
+      }
+      store.state = "degraded";
+      store.lastError = err instanceof Error ? err : new Error(String(err));
+      console.error(`[entity-cache] Failed to load domain "${domain}":`, err);
+    }
+  }
+
+  /**
+   * True when the tasks domain has an active deterministic task-storage
+   * incompatibility and no relevant project-state change has been observed
+   * since the last evaluation. Callers should bypass any reload work.
+   *
+   * AC: @daemon-entity-cache ac-task-storage-incompatibility-stable-reporting
+   * AC: @daemon-entity-cache ac-task-storage-incompatibility-persists-when-unresolved
+   */
+  private isTaskStorageSuppressionActive(): boolean {
+    return this.tasks.storageIncompatibility !== null && !this.tasks.needsTaskStorageRecheck;
+  }
+
+  /**
+   * Record a deterministic task-storage incompatibility surfaced by a load
+   * attempt. The marker keeps the tasks domain degraded with stable
+   * diagnostics; repeat observations of the same code suppress the duplicate
+   * failure log so logs do not amplify the unchanged condition.
+   *
+   * AC: @daemon-entity-cache ac-task-storage-incompatibility-degraded-state
+   * AC: @daemon-entity-cache ac-task-storage-incompatibility-stable-reporting
+   * AC: @daemon-entity-cache ac-task-storage-incompatibility-persists-when-unresolved
+   */
+  private noteTaskStorageIncompatibility(err: TaskDataManagerError & { code: string }): void {
+    const previous = this.tasks.storageIncompatibility;
+    const sameCondition = previous !== null && previous.code === err.code;
+
+    this.tasks.storageIncompatibility = {
+      code: err.code,
+      message: err.message,
+      suggestion: err.suggestion ?? null,
+      field: err.field ?? null,
+      // Preserve the original observation timestamp when the same code
+      // persists across rechecks — the condition itself has not changed.
+      observedAt: sameCondition ? previous!.observedAt : new Date().toISOString(),
+    };
+    this.tasks.needsTaskStorageRecheck = false;
+    this.tasks.state = "degraded";
+    this.tasks.lastError = err;
+
+    if (!sameCondition) {
+      console.error(`[entity-cache] Failed to load domain "tasks":`, err);
     }
   }
 
@@ -1630,6 +1826,14 @@ export class ProjectEntityCache {
     changes: PendingDomainChange[],
     cycle?: ReloadCycle,
   ): Promise<void> {
+    // AC: @daemon-entity-cache ac-task-storage-incompatibility-stable-reporting
+    // Suppression applies before any incremental path so writeThrough fallback
+    // reloads and watcher-driven incremental refreshes both honor the
+    // bounded degraded behavior when no state change has been observed.
+    if (domain === "tasks" && this.isTaskStorageSuppressionActive()) {
+      return;
+    }
+
     if (domain === "meta" && (await this.tryIncrementalMetaUpdate(changes, cycle))) {
       return;
     }
@@ -1734,7 +1938,22 @@ export class ProjectEntityCache {
       return false;
     }
 
-    const tdm = resolveTaskDataManager(ctx);
+    // AC: @daemon-entity-cache ac-task-storage-incompatibility-degraded-state
+    // resolveTaskDataManager throws a deterministic incompatibility error
+    // when the manifest is legacy/unmigrated. Funnel that into the same
+    // bounded degraded-state behavior the full-reload path uses so the
+    // incremental write-through path does not bypass suppression. Other
+    // throws propagate unchanged.
+    let tdm: ReturnType<typeof resolveTaskDataManager>;
+    try {
+      tdm = resolveTaskDataManager(ctx);
+    } catch (err) {
+      if (isDeterministicTaskStorageIncompatibility(err)) {
+        this.noteTaskStorageIncompatibility(err);
+        return true;
+      }
+      throw err;
+    }
     const nextIndex = [...this.tasks.index];
     const nextDetails = new Map(this.tasks.details);
     const nextHistoryDetails = new Map(this.tasks.historyDetails);

--- a/src/parser/split-backend.ts
+++ b/src/parser/split-backend.ts
@@ -32,7 +32,11 @@ import type { MutationMetadata, TaskStorageBackend, TaskSummary } from "./task-d
 // Re-export history types from their canonical home in task-data-manager
 export type { HistoryEntry, HistoryFieldChange } from "./task-data-manager.js";
 import type { HistoryEntry, HistoryFieldChange } from "./task-data-manager.js";
-import { TaskDataManagerError, registerBackend } from "./task-data-manager.js";
+import {
+  TaskDataManagerError,
+  TASK_STORAGE_SPLIT_UNMIGRATED_CODE,
+  registerBackend,
+} from "./task-data-manager.js";
 import type { KspecContext, LoadedTask } from "./yaml.js";
 import {
   findTaskByRef,
@@ -502,6 +506,7 @@ class SplitBackend implements TaskStorageBackend {
             suggestion:
               'Run "kspec task migrate" to convert unmigrated entries to per-task directories.',
             field: "task_storage.format",
+            code: TASK_STORAGE_SPLIT_UNMIGRATED_CODE,
           },
         );
       }

--- a/src/parser/task-data-manager.ts
+++ b/src/parser/task-data-manager.ts
@@ -234,8 +234,43 @@ export interface TaskListFilters {
 }
 
 /**
+ * Stable code for the legacy (kynetic < 1.1) monolithic task-storage failure.
+ *
+ * Identifies projects pinned to the pre-1.1 manifest version without
+ * task_storage.format: "split". The condition is deterministic: it can only
+ * be cleared by running `kspec task migrate` or upgrading the manifest.
+ */
+export const TASK_STORAGE_LEGACY_REMOVED_CODE = "legacy_task_storage_removed";
+
+/**
+ * Stable code for the split-but-unmigrated task-storage failure.
+ *
+ * Identifies projects whose manifest configures the split task-storage format
+ * while project.tasks.yaml still contains unmigrated monolithic entries. The
+ * condition is deterministic: it can only be cleared by running
+ * `kspec task migrate` or restoring a compatible task-storage state.
+ */
+export const TASK_STORAGE_SPLIT_UNMIGRATED_CODE = "split_task_storage_unmigrated";
+
+/**
+ * Codes that indicate a deterministic task-storage compatibility/migration
+ * problem. These conditions will not resolve by retrying — they require a
+ * project-state change (migration, manifest update). Callers that observe
+ * an error with one of these codes can suspend retry loops until project
+ * state changes.
+ */
+export const DETERMINISTIC_TASK_STORAGE_INCOMPATIBILITY_CODES: ReadonlySet<string> = new Set([
+  TASK_STORAGE_LEGACY_REMOVED_CODE,
+  TASK_STORAGE_SPLIT_UNMIGRATED_CODE,
+]);
+
+/**
  * Error thrown by TaskDataManager operations.
  * Includes descriptive messages and suggested actions per @trait-error-guidance.
+ *
+ * Stable error codes (see `code`) identify deterministic compatibility or
+ * migration states so callers can drive bounded degraded-state behavior
+ * without confusing them with transient mutation errors.
  */
 // AC: @trait-error-guidance ac-1, ac-2
 export class TaskDataManagerError extends Error {
@@ -243,13 +278,34 @@ export class TaskDataManagerError extends Error {
   readonly suggestion?: string;
   /** The field or value that failed, if applicable */
   readonly field?: string;
+  /** Stable error code identifying a deterministic failure class. */
+  readonly code?: string;
 
-  constructor(message: string, options?: { suggestion?: string; field?: string }) {
+  constructor(message: string, options?: { suggestion?: string; field?: string; code?: string }) {
     super(message);
     this.name = "TaskDataManagerError";
     this.suggestion = options?.suggestion;
     this.field = options?.field;
+    this.code = options?.code;
   }
+}
+
+/**
+ * Type guard for TaskDataManagerError instances carrying a deterministic
+ * task-storage incompatibility code (legacy removed, split unmigrated).
+ *
+ * Generic TaskDataManagerError cases — task-not-found, validation, mutation —
+ * return false because they may resolve on retry and should not feed into
+ * bounded degraded-state behavior.
+ */
+export function isDeterministicTaskStorageIncompatibility(
+  err: unknown,
+): err is TaskDataManagerError & { code: string } {
+  return (
+    err instanceof TaskDataManagerError &&
+    typeof err.code === "string" &&
+    DETERMINISTIC_TASK_STORAGE_INCOMPATIBILITY_CODES.has(err.code)
+  );
 }
 
 /**
@@ -1043,6 +1099,7 @@ export function resolveTaskDataManager(ctx: KspecContext): TaskDataManager {
         suggestion:
           'Run "kspec task migrate" to convert to per-task directory storage, then tasks will work normally.',
         field: "task_storage.format",
+        code: TASK_STORAGE_LEGACY_REMOVED_CODE,
       },
     );
   }

--- a/tests/agent-dispatch-engine.test.ts
+++ b/tests/agent-dispatch-engine.test.ts
@@ -6149,13 +6149,14 @@ describe("Periodic dispatch reconciliation", () => {
     });
     let reconcileStarted = false;
     let reconcileFinished = false;
-    vi.spyOn(engine as unknown as { _reconcile: () => Promise<void> }, "_reconcile").mockImplementation(
-      async () => {
-        reconcileStarted = true;
-        await reconcileGate;
-        reconcileFinished = true;
-      },
-    );
+    vi.spyOn(
+      engine as unknown as { _reconcile: () => Promise<void> },
+      "_reconcile",
+    ).mockImplementation(async () => {
+      reconcileStarted = true;
+      await reconcileGate;
+      reconcileFinished = true;
+    });
 
     await engine.start();
 

--- a/tests/agent-dispatch-engine.test.ts
+++ b/tests/agent-dispatch-engine.test.ts
@@ -6093,7 +6093,7 @@ describe("Periodic dispatch reconciliation", () => {
     await cleanupTempDir(testDir);
   });
 
-  // AC: @agent-dispatch-engine ac-19, ac-20
+  // AC: @agent-dispatch-engine ac-19, ac-20, ac-reconcile-non-overlap
   it("does not start overlapping reconcile passes when a previous pass is still running", async () => {
     await setupProjectWithAgents(testDir, []);
 
@@ -6129,6 +6129,70 @@ describe("Periodic dispatch reconciliation", () => {
 
     releaseReconcile();
     await engine.stop();
+  });
+
+  // AC: @agent-dispatch-engine ac-stop-awaits-reconciliation
+  it("stop() does not resolve until an in-flight reconciliation pass completes", async () => {
+    await setupProjectWithAgents(testDir, []);
+
+    const engine = new DispatchEngine({
+      projectDir: testDir,
+      specDir: testDir,
+      kspecCliPath: MOCK_KSPEC_CLI,
+      reconcileIntervalMs: 10,
+      coalesceWindowMs: 0,
+    });
+
+    let releaseReconcile!: () => void;
+    const reconcileGate = new Promise<void>((resolve) => {
+      releaseReconcile = resolve;
+    });
+    let reconcileStarted = false;
+    let reconcileFinished = false;
+    vi.spyOn(engine as unknown as { _reconcile: () => Promise<void> }, "_reconcile").mockImplementation(
+      async () => {
+        reconcileStarted = true;
+        await reconcileGate;
+        reconcileFinished = true;
+      },
+    );
+
+    await engine.start();
+
+    // Trigger one reconciliation pass; the gate keeps it pending.
+    await vi.advanceTimersByTimeAsync(15);
+    expect(reconcileStarted).toBe(true);
+    expect(reconcileFinished).toBe(false);
+
+    // Call stop() while reconcile is still blocked. It must NOT resolve.
+    let stopResolved = false;
+    const stopPromise = engine.stop().then(() => {
+      stopResolved = true;
+    });
+
+    // Flush microtasks and advance any timers so any non-blocking work in
+    // stop() completes. stop() should still be parked on Promise.allSettled
+    // because the reconcile gate is still held.
+    for (let i = 0; i < 20; i++) {
+      // eslint-disable-next-line no-await-in-loop
+      await Promise.resolve();
+    }
+    await vi.advanceTimersByTimeAsync(100);
+    for (let i = 0; i < 20; i++) {
+      // eslint-disable-next-line no-await-in-loop
+      await Promise.resolve();
+    }
+
+    expect(reconcileFinished).toBe(false);
+    expect(stopResolved).toBe(false);
+
+    // Release the reconcile pass. Now stop() must resolve, and the
+    // reconciliation must finish before stop() returns.
+    releaseReconcile();
+    await stopPromise;
+
+    expect(reconcileFinished).toBe(true);
+    expect(stopResolved).toBe(true);
   });
 });
 

--- a/tests/agent-dispatch-engine.test.ts
+++ b/tests/agent-dispatch-engine.test.ts
@@ -6078,6 +6078,60 @@ describe("Post-invocation re-evaluation", () => {
   });
 });
 
+// ─── Periodic Dispatch Reconciliation ─────────────────────────────────────────
+
+describe("Periodic dispatch reconciliation", () => {
+  let testDir: string;
+
+  beforeEach(async () => {
+    vi.useFakeTimers();
+    testDir = await createTempDir("kspec-dispatch-reconcile-");
+  });
+
+  afterEach(async () => {
+    vi.useRealTimers();
+    await cleanupTempDir(testDir);
+  });
+
+  // AC: @agent-dispatch-engine ac-19, ac-20
+  it("does not start overlapping reconcile passes when a previous pass is still running", async () => {
+    await setupProjectWithAgents(testDir, []);
+
+    const engine = new DispatchEngine({
+      projectDir: testDir,
+      specDir: testDir,
+      kspecCliPath: MOCK_KSPEC_CLI,
+      reconcileIntervalMs: 10,
+      coalesceWindowMs: 0,
+    });
+
+    let releaseReconcile!: () => void;
+    const reconcileGate = new Promise<void>((resolve) => {
+      releaseReconcile = resolve;
+    });
+    let runningReconciles = 0;
+    let maxConcurrentReconciles = 0;
+    const reconcileSpy = vi
+      .spyOn(engine as unknown as { _reconcile: () => Promise<void> }, "_reconcile")
+      .mockImplementation(async () => {
+        runningReconciles += 1;
+        maxConcurrentReconciles = Math.max(maxConcurrentReconciles, runningReconciles);
+        await reconcileGate;
+        runningReconciles -= 1;
+      });
+
+    await engine.start();
+
+    await vi.advanceTimersByTimeAsync(35);
+
+    expect(reconcileSpy).toHaveBeenCalledTimes(1);
+    expect(maxConcurrentReconciles).toBe(1);
+
+    releaseReconcile();
+    await engine.stop();
+  });
+});
+
 // ─── Per-Task Dispatch Drain Coalescing ────────────────────────────────────────
 
 describe("Per-task dispatch drain coalescing", () => {

--- a/tests/cli-daemon-proxy.test.ts
+++ b/tests/cli-daemon-proxy.test.ts
@@ -11,6 +11,7 @@
  * - @cli-daemon-proxy ac-read-from-cache: reads served from daemon cache
  * - @cli-daemon-proxy ac-timeout-fallback: read-only timeout falls back to direct
  * - @cli-daemon-proxy ac-timeout-mutation-error: mutation timeout returns error
+ * - @cli-daemon-proxy ac-daemon-internal-proxy-suppression-is-scoped: suppression is scoped to the request that activated it
  * - @daemon-proxy-detection ac-legacy-port-file-fallback: reads legacy daemon.port file and health-checks 127.0.0.1:port
  * - @daemon-proxy-detection ac-fast-detection: fast fail on missing port/refused
  * - @daemon-proxy-detection ac-project-registered: registers project before routing
@@ -53,6 +54,7 @@ import {
   shouldProxyCommand,
   proxyCommand,
   extractCommandPayload,
+  runWithDaemonProxySuppressed,
   _resetDetectionCacheForTesting,
   _setDetectionCacheForTesting,
 } from "../src/cli/daemon-proxy.js";
@@ -388,6 +390,113 @@ describe("shouldProxyCommand", () => {
 
     const result = await shouldProxyCommand({ forceDaemon: false });
     expect(result.proxy).toBe(false);
+  });
+
+  // AC: @cli-daemon-proxy ac-daemon-internal-proxy-suppression-is-scoped
+  it("returns proxy:false with daemon-internal reason inside runWithDaemonProxySuppressed", async () => {
+    delete process.env.KSPEC_NO_DAEMON;
+    _setDetectionCacheForTesting({ available: true, port: 3456 });
+
+    const result = await runWithDaemonProxySuppressed(() =>
+      shouldProxyCommand({ forceDaemon: false }),
+    );
+
+    expect(result.proxy).toBe(false);
+    if (!result.proxy) {
+      expect(result.reason).toBe("daemon command API execution");
+    }
+  });
+
+  // AC: @cli-daemon-proxy ac-daemon-internal-proxy-suppression-is-scoped
+  it("suppression even overrides --daemon force-proxy inside the guarded scope", async () => {
+    delete process.env.KSPEC_NO_DAEMON;
+    _setDetectionCacheForTesting({ available: true, port: 3456 });
+
+    const result = await runWithDaemonProxySuppressed(() =>
+      shouldProxyCommand({ forceDaemon: true }),
+    );
+
+    expect(result.proxy).toBe(false);
+  });
+
+  // AC: @cli-daemon-proxy ac-daemon-internal-proxy-suppression-is-scoped
+  it("normal auto-detect routing resumes outside the guarded scope", async () => {
+    delete process.env.KSPEC_NO_DAEMON;
+    _setDetectionCacheForTesting({ available: true, port: 4567 });
+
+    const insideResult = await runWithDaemonProxySuppressed(() =>
+      shouldProxyCommand({ forceDaemon: false }),
+    );
+    expect(insideResult.proxy).toBe(false);
+
+    const outsideResult = await shouldProxyCommand({ forceDaemon: false });
+    expect(outsideResult.proxy).toBe(true);
+    if (outsideResult.proxy) {
+      expect(outsideResult.port).toBe(4567);
+    }
+  });
+
+  // AC: @cli-daemon-proxy ac-daemon-internal-proxy-suppression-is-scoped
+  it("force-direct (KSPEC_NO_DAEMON) still wins outside the guarded scope", async () => {
+    _setDetectionCacheForTesting({ available: true, port: 3456 });
+
+    // Activate then exit the guard so subsequent evaluations are unguarded.
+    await runWithDaemonProxySuppressed(() => shouldProxyCommand({ forceDaemon: false }));
+
+    process.env.KSPEC_NO_DAEMON = "1";
+    const outsideResult = await shouldProxyCommand({ forceDaemon: false });
+    expect(outsideResult.proxy).toBe(false);
+    if (!outsideResult.proxy) {
+      expect(outsideResult.reason).toBe("KSPEC_NO_DAEMON is set");
+    }
+  });
+
+  // AC: @cli-daemon-proxy ac-daemon-internal-proxy-suppression-is-scoped
+  it("force-proxy (--daemon) error path is preserved outside the guarded scope", async () => {
+    delete process.env.KSPEC_NO_DAEMON;
+    _setDetectionCacheForTesting({ available: false, reason: "no port file" });
+
+    // Suppression guard runs to completion in isolation.
+    await runWithDaemonProxySuppressed(() => shouldProxyCommand({ forceDaemon: false }));
+
+    const outsideResult = await shouldProxyCommand({ forceDaemon: true });
+    expect(outsideResult.proxy).toBe(false);
+    if (!outsideResult.proxy) {
+      expect(outsideResult.reason).toContain("daemon required but unavailable");
+    }
+  });
+
+  // AC: @cli-daemon-proxy ac-daemon-internal-proxy-suppression-is-scoped
+  it("suppression does not leak into a concurrent async chain", async () => {
+    delete process.env.KSPEC_NO_DAEMON;
+    _setDetectionCacheForTesting({ available: true, port: 3456 });
+
+    // Block the suppressed chain until the unguarded chain has been observed.
+    let releaseSuppressed: () => void = () => {};
+    const suppressedGate = new Promise<void>((resolve) => {
+      releaseSuppressed = resolve;
+    });
+    let releaseUnguarded: () => void = () => {};
+    const unguardedGate = new Promise<void>((resolve) => {
+      releaseUnguarded = resolve;
+    });
+
+    const suppressedRun = runWithDaemonProxySuppressed(async () => {
+      releaseUnguarded();
+      await suppressedGate;
+      return shouldProxyCommand({ forceDaemon: false });
+    });
+
+    await unguardedGate;
+    const unguardedResult = await shouldProxyCommand({ forceDaemon: false });
+    releaseSuppressed();
+    const suppressedResult = await suppressedRun;
+
+    expect(unguardedResult.proxy).toBe(true);
+    expect(suppressedResult.proxy).toBe(false);
+    if (!suppressedResult.proxy) {
+      expect(suppressedResult.reason).toBe("daemon command API execution");
+    }
   });
 });
 

--- a/tests/cli-no-daemon.test.ts
+++ b/tests/cli-no-daemon.test.ts
@@ -103,8 +103,9 @@ describe("KSPEC_NO_DAEMON", () => {
     // Allocate an ephemeral port so the auto-started daemon never collides
     // with the default 3456 (host dispatch daemon, other concurrent tests).
     // A bind failure surfaces only after PidFileManager.writePid() runs in
-    // packages/daemon/src/server.ts, leaving a stale PID file that points at
-    // an already-exited process and makes the later `ps -p …` non-deterministic.
+    // packages/daemon/src/server.ts; without an ephemeral port, a port
+    // collision would write the PID file, fail bind, never write
+    // daemon.connection.json, and force the metadata wait below to time out.
     const port = await new Promise<number>((resolve, reject) => {
       const probe = createServer();
       probe.once("error", reject);
@@ -162,7 +163,7 @@ describe("KSPEC_NO_DAEMON", () => {
 
     // The bun CLI subprocess implicitly auto-started the daemon. Capture
     // its pid and register SIGTERM cleanup BEFORE any later observation
-    // (`execSync("ps -p …")`, `expect(processCommand)…`) — otherwise an
+    // (metadata read, `expect(metadata.runtime)…`) — otherwise an
     // assertion failure between pid capture and the trailing
     // `kspec serve stop` leaves the auto-started daemon running. Matches
     // the safe boundary documented for
@@ -179,17 +180,18 @@ describe("KSPEC_NO_DAEMON", () => {
 
     // The PID file is written before listen() succeeds. Wait for
     // daemon.connection.json (written only after awaitListenSuccess in
-    // packages/daemon/src/server.ts) before inspecting the process — that
-    // is the on-disk proof that the daemon survived bind and is still alive.
+    // packages/daemon/src/server.ts) before asserting on runtime — that
+    // is the on-disk proof that the daemon survived bind and recorded
+    // its self-detected runtime.
     const metadataPath = join(isolatedHome.configDir, "daemon.connection.json");
     await waitForStartup(
       "auto-started daemon connection metadata",
       async () => {
         try {
           const raw = readTestOutputSync(metadataPath);
-          const parsed = JSON.parse(raw) as { connect_host?: string };
+          const parsed = JSON.parse(raw) as { connect_host?: string; runtime?: string };
           return {
-            ok: typeof parsed.connect_host === "string",
+            ok: typeof parsed.connect_host === "string" && typeof parsed.runtime === "string",
             details: `metadata=${raw.slice(0, 200)}`,
           };
         } catch (err) {
@@ -200,10 +202,25 @@ describe("KSPEC_NO_DAEMON", () => {
       { timeoutMs: 10_000 },
     );
 
-    const processCommand = execSync(`ps -p ${pid} -o command=`, { encoding: "utf-8" }).trim();
-
-    expect(processCommand).toContain("node");
-    expect(processCommand).toContain("dist/daemon/index.js");
+    // Assert runtime via the persisted connection metadata, not `ps -p`.
+    // The metadata is written by the daemon process itself after
+    // awaitListenSuccess, so:
+    //   - the `runtime` field reflects what the daemon detected via
+    //     `typeof process.versions.bun` (a bun-spawned daemon would
+    //     write runtime=bun, not node), and
+    //   - the file persists across daemon exit, eliminating the race
+    //     where `ps -p <pid>` would return `<defunct>` or fail entirely
+    //     if the daemon process exited between metadata write and the
+    //     trailing assertion (observed flakiness under full-suite load).
+    // The metadata.pid field also confirms the same process wrote both
+    // daemon.pid and daemon.connection.json, so the runtime claim is
+    // bound to the captured pid rather than read from an unrelated file.
+    const metadata = JSON.parse(readTestOutputSync(metadataPath)) as {
+      pid: number;
+      runtime: string;
+    };
+    expect(metadata.runtime).toBe("node");
+    expect(metadata.pid).toBe(pid);
 
     kspec(`serve stop --kspec-dir ${join(tempDir, ".kspec")}`, tempDir, {
       env: isolatedHome.env,

--- a/tests/cli-no-daemon.test.ts
+++ b/tests/cli-no-daemon.test.ts
@@ -100,10 +100,29 @@ describe("KSPEC_NO_DAEMON", () => {
       return;
     }
 
+    // Allocate an ephemeral port so the auto-started daemon never collides
+    // with the default 3456 (host dispatch daemon, other concurrent tests).
+    // A bind failure surfaces only after PidFileManager.writePid() runs in
+    // packages/daemon/src/server.ts, leaving a stale PID file that points at
+    // an already-exited process and makes the later `ps -p …` non-deterministic.
+    const port = await new Promise<number>((resolve, reject) => {
+      const probe = createServer();
+      probe.once("error", reject);
+      probe.listen(0, "127.0.0.1", () => {
+        const address = probe.address();
+        if (!address || typeof address === "string") {
+          probe.close(() => reject(new Error("Failed to allocate ephemeral port")));
+          return;
+        }
+        const allocatedPort = address.port;
+        probe.close((err) => (err ? reject(err) : resolve(allocatedPort)));
+      });
+    });
+
     const isolatedHome = await createIsolatedKspecHome(tempDir);
     writeFileSync(
       join(tempDir, "kspec.config.yaml"),
-      ["daemon:", "  runtime: node", ""].join("\n"),
+      ["daemon:", "  runtime: node", `  port: ${port}`, ""].join("\n"),
       "utf-8",
     );
     const {
@@ -157,6 +176,29 @@ describe("KSPEC_NO_DAEMON", () => {
         // Already gone — fine.
       }
     });
+
+    // The PID file is written before listen() succeeds. Wait for
+    // daemon.connection.json (written only after awaitListenSuccess in
+    // packages/daemon/src/server.ts) before inspecting the process — that
+    // is the on-disk proof that the daemon survived bind and is still alive.
+    const metadataPath = join(isolatedHome.configDir, "daemon.connection.json");
+    await waitForStartup(
+      "auto-started daemon connection metadata",
+      async () => {
+        try {
+          const raw = readTestOutputSync(metadataPath);
+          const parsed = JSON.parse(raw) as { connect_host?: string };
+          return {
+            ok: typeof parsed.connect_host === "string",
+            details: `metadata=${raw.slice(0, 200)}`,
+          };
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          return { ok: false, details: message };
+        }
+      },
+      { timeoutMs: 10_000 },
+    );
 
     const processCommand = execSync(`ps -p ${pid} -o command=`, { encoding: "utf-8" }).trim();
 

--- a/tests/daemon-api/task-storage-incompatibility-helper.test.ts
+++ b/tests/daemon-api/task-storage-incompatibility-helper.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Unit tests for the daemon route helper that maps deterministic task-storage
+ * compatibility/migration errors into a structured 409 response.
+ *
+ * AC: @api-contract ac-task-storage-incompatibility-conflict-status
+ * AC: @api-contract ac-task-storage-incompatibility-error-code
+ * AC: @api-contract ac-task-storage-incompatibility-guidance
+ * AC: @api-contract ac-task-storage-incompatibility-field-context
+ * AC: @api-contract ac-task-storage-incompatibility-cache-domain-context
+ * AC: @api-contract ac-task-storage-incompatibility-cache-state-context
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  TaskDataManagerError,
+  TASK_STORAGE_LEGACY_REMOVED_CODE,
+  TASK_STORAGE_SPLIT_UNMIGRATED_CODE,
+} from "../../dist/parser/task-data-manager.js";
+import {
+  taskStorageIncompatibilityResponse,
+  TASK_STORAGE_INCOMPATIBLE_ERROR_CODE,
+  TASK_STORAGE_INCOMPATIBLE_STATUS,
+} from "../../dist/daemon/routes/task-storage-error.js";
+
+function legacyRemovedError(): TaskDataManagerError {
+  return new TaskDataManagerError(
+    'This project uses kynetic version "1.0" without split task storage. The monolithic task storage format has been removed.',
+    {
+      suggestion:
+        'Run "kspec task migrate" to convert to per-task directory storage, then tasks will work normally.',
+      field: "task_storage.format",
+      code: TASK_STORAGE_LEGACY_REMOVED_CODE,
+    },
+  );
+}
+
+function splitUnmigratedError(): TaskDataManagerError {
+  return new TaskDataManagerError(
+    "Project task storage is configured for split format but project.tasks.yaml still contains unmigrated monolithic entries.",
+    {
+      suggestion:
+        'Run "kspec task migrate" to complete the conversion, or restore a compatible task-storage state.',
+      field: "task_storage.format",
+      code: TASK_STORAGE_SPLIT_UNMIGRATED_CODE,
+    },
+  );
+}
+
+describe("taskStorageIncompatibilityResponse", () => {
+  // AC: @api-contract ac-task-storage-incompatibility-conflict-status
+  // AC: @api-contract ac-task-storage-incompatibility-error-code
+  // AC: @api-contract ac-task-storage-incompatibility-guidance
+  // AC: @api-contract ac-task-storage-incompatibility-field-context
+  it("maps the legacy_task_storage_removed code to a structured 409", () => {
+    const result = taskStorageIncompatibilityResponse(legacyRemovedError());
+
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe(TASK_STORAGE_INCOMPATIBLE_STATUS);
+    expect(result!.status).toBe(409);
+    expect(result!.body.error).toBe(TASK_STORAGE_INCOMPATIBLE_ERROR_CODE);
+    expect(result!.body.error).toBe("task_storage_incompatible");
+    expect(result!.body.code).toBe(TASK_STORAGE_LEGACY_REMOVED_CODE);
+    expect(result!.body.message).toContain("monolithic task storage format has been removed");
+    expect(result!.body.suggestion).toContain("kspec task migrate");
+    expect(result!.body.field).toBe("task_storage.format");
+  });
+
+  // AC: @api-contract ac-task-storage-incompatibility-error-code
+  // AC: @api-contract ac-task-storage-incompatibility-guidance
+  it("maps the split_task_storage_unmigrated code to a structured 409", () => {
+    const result = taskStorageIncompatibilityResponse(splitUnmigratedError());
+
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe(409);
+    expect(result!.body.error).toBe("task_storage_incompatible");
+    expect(result!.body.code).toBe(TASK_STORAGE_SPLIT_UNMIGRATED_CODE);
+    expect(result!.body.suggestion).toBeTruthy();
+    expect(result!.body.field).toBe("task_storage.format");
+  });
+
+  // AC: @api-contract ac-task-storage-incompatibility-cache-domain-context
+  // AC: @api-contract ac-task-storage-incompatibility-cache-state-context
+  it("defaults cache_domain to 'tasks' and reads cache_domain_state from the cache", () => {
+    // Minimal stub matching the getDomainState contract the helper relies on.
+    const cache = {
+      getDomainState: (domain: string) => (domain === "tasks" ? "degraded" : "ready"),
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- minimal cache stub for helper
+    const result = taskStorageIncompatibilityResponse(legacyRemovedError(), { cache: cache as any });
+
+    expect(result).not.toBeNull();
+    expect(result!.body.cache_domain).toBe("tasks");
+    expect(result!.body.cache_domain_state).toBe("degraded");
+  });
+
+  // AC: @api-contract ac-task-storage-incompatibility-cache-domain-context
+  // AC: @api-contract ac-task-storage-incompatibility-cache-state-context
+  it("honors an explicit cacheDomain and cacheDomainState override", () => {
+    const result = taskStorageIncompatibilityResponse(legacyRemovedError(), {
+      cacheDomain: "items",
+      cacheDomainState: "loading",
+    });
+
+    expect(result).not.toBeNull();
+    expect(result!.body.cache_domain).toBe("items");
+    expect(result!.body.cache_domain_state).toBe("loading");
+  });
+
+  // AC: @api-contract ac-task-storage-incompatibility-cache-state-context
+  it("omits cache_domain_state when neither cache nor explicit state is provided", () => {
+    const result = taskStorageIncompatibilityResponse(legacyRemovedError());
+
+    expect(result).not.toBeNull();
+    expect(result!.body.cache_domain_state).toBeUndefined();
+    expect(result!.body.cache_domain).toBe("tasks");
+  });
+
+  // AC: @api-contract ac-task-storage-incompatibility-not-not-found
+  it("returns null for generic TaskDataManagerError without a deterministic code", () => {
+    const genericNotFound = new TaskDataManagerError("Task not found: @some-ref", {
+      suggestion: 'Check the reference with: kspec search "@some-ref" or kspec task list',
+    });
+
+    expect(taskStorageIncompatibilityResponse(genericNotFound)).toBeNull();
+  });
+
+  // AC: @api-contract ac-task-storage-incompatibility-not-not-found
+  it("returns null for TaskDataManagerError with an unrelated code", () => {
+    const unrelated = new TaskDataManagerError("Some other failure", {
+      code: "some_other_code",
+    });
+
+    expect(taskStorageIncompatibilityResponse(unrelated)).toBeNull();
+  });
+
+  it("returns null for non-TaskDataManagerError values", () => {
+    expect(taskStorageIncompatibilityResponse(new Error("boom"))).toBeNull();
+    expect(taskStorageIncompatibilityResponse("nope")).toBeNull();
+    expect(taskStorageIncompatibilityResponse(undefined)).toBeNull();
+    expect(taskStorageIncompatibilityResponse(null)).toBeNull();
+  });
+});

--- a/tests/daemon-api/task-storage-incompatibility-helper.test.ts
+++ b/tests/daemon-api/task-storage-incompatibility-helper.test.ts
@@ -87,7 +87,9 @@ describe("taskStorageIncompatibilityResponse", () => {
     };
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- minimal cache stub for helper
-    const result = taskStorageIncompatibilityResponse(legacyRemovedError(), { cache: cache as any });
+    const result = taskStorageIncompatibilityResponse(legacyRemovedError(), {
+      cache: cache as any,
+    });
 
     expect(result).not.toBeNull();
     expect(result!.body.cache_domain).toBe("tasks");

--- a/tests/daemon-api/task-storage-incompatibility-routes.test.ts
+++ b/tests/daemon-api/task-storage-incompatibility-routes.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Integration tests for the task-storage incompatibility 409 contract across
+ * the daemon API surface.
+ *
+ * Each test mounts a project on a legacy (kynetic 1.0, monolithic) manifest
+ * that resolveTaskDataManager() rejects deterministically, then asserts that
+ * routes which need task data return a structured 409 with the
+ * task_storage_incompatible discriminator instead of:
+ *   - collapsing into 404 not_found (the pre-fix behavior for /api/tasks/:ref
+ *     and mutation routes), or
+ *   - escaping as an unhandled 500 (the pre-fix behavior for GET /api/tasks,
+ *     /api/aggregation/tasks/summary, /api/refs, etc.).
+ *
+ * AC: @api-contract ac-task-storage-incompatibility-conflict-status
+ * AC: @api-contract ac-task-storage-incompatibility-error-code
+ * AC: @api-contract ac-task-storage-incompatibility-guidance
+ * AC: @api-contract ac-task-storage-incompatibility-not-not-found
+ * AC: @api-contract ac-task-storage-incompatibility-field-context
+ * AC: @api-contract ac-task-storage-incompatibility-cache-domain-context
+ * AC: @api-contract ac-task-storage-incompatibility-cache-state-context
+ */
+
+import type { Elysia } from "elysia";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  cleanupTempDir,
+  createTempDir,
+  createTestApp,
+  initGitRepo,
+  LEGACY_INLINE_MANIFEST,
+  makeRequest,
+  requestJson,
+  setupInlineFixtures,
+  testUlid,
+} from "./helpers.js";
+
+const TASK_ULID = testUlid("TASK", 1);
+const SPEC_ULID = testUlid("SPEC", 2);
+
+let tempDir: string;
+let app: Elysia;
+
+function setupLegacyFixtures(dir: string) {
+  setupInlineFixtures(dir, {
+    manifest: LEGACY_INLINE_MANIFEST,
+    modules: {
+      "test.yaml": `features:
+  - _ulid: "${SPEC_ULID}"
+    slugs:
+      - test-feature
+    title: "Test Feature"
+    type: feature
+    description: "A test feature"
+    created: "2026-01-01T00:00:00Z"
+`,
+    },
+    tasksFile: `tasks:
+  - _ulid: "${TASK_ULID}"
+    slugs:
+      - task-test
+    title: "Test Task"
+    description: "A test task"
+    status: pending
+    type: task
+    spec_ref: "@test-feature"
+    created_at: "2026-01-01T00:00:00Z"
+`,
+  });
+}
+
+interface TaskStorageIncompatibleBody {
+  error: string;
+  message?: string;
+  suggestion?: string;
+  code?: string;
+  field?: string;
+  cache_domain?: string;
+  cache_domain_state?: string;
+}
+
+function assertIsTaskStorageConflict(body: unknown): TaskStorageIncompatibleBody {
+  expect(body).toBeTypeOf("object");
+  const typed = body as TaskStorageIncompatibleBody;
+  expect(typed.error).toBe("task_storage_incompatible");
+  expect(typed.message).toMatch(/monolithic task storage format has been removed/i);
+  expect(typed.suggestion).toMatch(/kspec task migrate/i);
+  expect(typed.code).toBe("legacy_task_storage_removed");
+  expect(typed.field).toBe("task_storage.format");
+  expect(typed.cache_domain).toBe("tasks");
+  return typed;
+}
+
+beforeEach(async () => {
+  tempDir = await createTempDir("kspec-daemon-api-task-storage-conflict-");
+  initGitRepo(tempDir);
+  setupLegacyFixtures(tempDir);
+  ({ app } = createTestApp());
+});
+
+afterEach(async () => {
+  await cleanupTempDir(tempDir);
+});
+
+function request(urlPath: string, init?: RequestInit) {
+  return makeRequest(app, tempDir, urlPath, init);
+}
+
+describe("Task storage incompatibility — tasks routes", () => {
+  // AC: @api-contract ac-task-storage-incompatibility-conflict-status
+  // AC: @api-contract ac-task-storage-incompatibility-error-code
+  // AC: @api-contract ac-task-storage-incompatibility-guidance
+  // AC: @api-contract ac-task-storage-incompatibility-field-context
+  it("GET /api/tasks returns 409 with structured migration guidance", async () => {
+    const response = await request("/api/tasks");
+    expect(response.status).toBe(409);
+    const body = await response.json();
+    assertIsTaskStorageConflict(body);
+  });
+
+  // AC: @api-contract ac-task-storage-incompatibility-not-not-found
+  // AC: @api-contract ac-task-storage-incompatibility-conflict-status
+  it("GET /api/tasks/:ref is 409 (not 404) with structured guidance", async () => {
+    const response = await request("/api/tasks/@task-test");
+    expect(response.status).not.toBe(404);
+    expect(response.status).toBe(409);
+    const body = await response.json();
+    const typed = assertIsTaskStorageConflict(body);
+    // Must not echo a not_found error code even if the underlying load failed.
+    expect(typed.error).not.toBe("not_found");
+  });
+
+  // AC: @api-contract ac-task-storage-incompatibility-not-not-found
+  // AC: @api-contract ac-task-storage-incompatibility-conflict-status
+  it("POST /api/tasks/:ref/start surfaces structured 409 instead of 404", async () => {
+    const response = await requestJson(app, tempDir, "POST", "/api/tasks/@task-test/start");
+    expect(response.status).toBe(409);
+    const body = await response.json();
+    const typed = assertIsTaskStorageConflict(body);
+    expect(typed.error).not.toBe("not_found");
+  });
+
+  // AC: @api-contract ac-task-storage-incompatibility-not-not-found
+  it("POST /api/tasks/:ref/note surfaces structured 409 instead of 404", async () => {
+    const response = await requestJson(app, tempDir, "POST", "/api/tasks/@task-test/note", {
+      content: "hello",
+    });
+    expect(response.status).toBe(409);
+    const body = await response.json();
+    assertIsTaskStorageConflict(body);
+  });
+});
+
+describe("Task storage incompatibility — non-tasks.ts routes", () => {
+  // AC: @api-contract ac-task-storage-incompatibility-conflict-status
+  // AC: @api-contract ac-task-storage-incompatibility-error-code
+  // AC: @api-contract ac-task-storage-incompatibility-guidance
+  // AC: @api-contract ac-task-storage-incompatibility-cache-domain-context
+  it("GET /api/aggregation/tasks/summary returns 409 with structured guidance", async () => {
+    const response = await request("/api/aggregation/tasks/summary");
+    expect(response.status).toBe(409);
+    const body = await response.json();
+    assertIsTaskStorageConflict(body);
+  });
+
+  // AC: @api-contract ac-task-storage-incompatibility-conflict-status
+  // AC: @api-contract ac-task-storage-incompatibility-error-code
+  it("GET /api/aggregation/validation returns 409 with structured guidance", async () => {
+    const response = await request("/api/aggregation/validation");
+    expect(response.status).toBe(409);
+    const body = await response.json();
+    assertIsTaskStorageConflict(body);
+  });
+
+  // AC: @api-contract ac-task-storage-incompatibility-conflict-status
+  it("GET /api/plans returns 409 with structured guidance", async () => {
+    const response = await request("/api/plans");
+    expect(response.status).toBe(409);
+    const body = await response.json();
+    assertIsTaskStorageConflict(body);
+  });
+
+  // AC: @api-contract ac-task-storage-incompatibility-conflict-status
+  it("GET /api/alignment returns 409 with structured guidance", async () => {
+    const response = await request("/api/alignment");
+    expect(response.status).toBe(409);
+    const body = await response.json();
+    assertIsTaskStorageConflict(body);
+  });
+
+  // AC: @api-contract ac-task-storage-incompatibility-conflict-status
+  it("GET /api/items/:ref/tasks returns 409 with structured guidance", async () => {
+    const response = await request(`/api/items/@test-feature/tasks`);
+    expect(response.status).toBe(409);
+    const body = await response.json();
+    assertIsTaskStorageConflict(body);
+  });
+});
+
+describe("Task storage incompatibility — context fields", () => {
+  // AC: @api-contract ac-task-storage-incompatibility-cache-domain-context
+  // AC: @api-contract ac-task-storage-incompatibility-cache-state-context
+  it("includes cache_domain context on the structured response", async () => {
+    const response = await request("/api/tasks");
+    expect(response.status).toBe(409);
+    const body = await response.json();
+    const typed = assertIsTaskStorageConflict(body);
+    expect(typed.cache_domain).toBe("tasks");
+  });
+
+  // AC: @api-contract ac-task-storage-incompatibility-field-context
+  it("identifies the affected configuration field", async () => {
+    const response = await request("/api/tasks");
+    const body = await response.json();
+    const typed = assertIsTaskStorageConflict(body);
+    expect(typed.field).toBe("task_storage.format");
+  });
+});

--- a/tests/daemon-api/websocket-protocol.test.ts
+++ b/tests/daemon-api/websocket-protocol.test.ts
@@ -476,9 +476,24 @@ describe("daemon websocket protocol — runtime parity", { timeout: 90_000 }, ()
       let daemon: StartedTestDaemon;
       let runtimeAvailable = false;
 
-      // Same hookTimeout widening as the parent describe — daemon cold-start
-      // plus fixture copy can exceed Vitest's 10s default under shared-worker
-      // load.
+      // The parity describe runs after the parent describe's ~14 daemon
+      // spawn/teardown cycles in the same file, so by the time the second
+      // runtime's beforeEach fires the process has accumulated port-reuse
+      // pressure and disk IO contention from the prior daemons. Two budgets
+      // must coexist:
+      //   - The hook budget must exceed the fixture's combined readiness
+      //     budget so a stuck daemon surfaces as a DaemonReadinessError with
+      //     the full diagnostic bundle (per
+      //     @daemon-backed-test-fixture-contract ac-readiness-diagnostics)
+      //     instead of a bare "beforeEach timed out" that hides which stage
+      //     hung.
+      //   - The per-stage readiness budget must absorb cold-start jitter
+      //     under the file-level daemon churn without masking a daemon that
+      //     genuinely never reaches health or cache readiness.
+      // 90s hook + 25s per probe (50s combined readiness) keeps a 40s margin
+      // for fixture copy + spawn while still bounding the actual readiness
+      // wait to ~50s; a real launch failure (ENOENT/EACCES) still surfaces
+      // immediately via startTestDaemon's launch-error race.
       beforeEach(async () => {
         runtimeAvailable = await isDaemonRuntimeAvailable(runtimeName);
         if (!runtimeAvailable) {
@@ -496,13 +511,14 @@ describe("daemon websocket protocol — runtime parity", { timeout: 90_000 }, ()
         project = await createTestDaemonProject();
         daemon = await startTestDaemon(project, {
           runtime: runtimeName,
+          timeoutMs: 25_000,
           registerCleanup: (stop) => {
             onTestFinished(async () => {
               await stop();
             });
           },
         });
-      }, 60_000);
+      }, 90_000);
 
       afterEach(async () => {
         if (project) {

--- a/tests/daemon-command-api.test.ts
+++ b/tests/daemon-command-api.test.ts
@@ -505,6 +505,55 @@ describe("Daemon Command API", () => {
   });
 
   // AC: @daemon-command-api ac-command-endpoint
+  it("executes daemon-internal commands without proxying back to /api/command", async () => {
+    await withInjectedCommand(
+      (program) => {
+        program.command("debug-proxy-decision").action(async () => {
+          const {
+            shouldProxyCommand,
+            _resetDetectionCacheForTesting,
+            _setDetectionCacheForTesting,
+          } = await import("../dist/cli/daemon-proxy.js");
+
+          const originalNoDaemon = process.env.KSPEC_NO_DAEMON;
+          _resetDetectionCacheForTesting();
+          _setDetectionCacheForTesting({ available: true, port: 3456 });
+          delete process.env.KSPEC_NO_DAEMON;
+          try {
+            const result = await shouldProxyCommand({ forceDaemon: false });
+            console.log(JSON.stringify(result));
+          } finally {
+            if (originalNoDaemon === undefined) {
+              delete process.env.KSPEC_NO_DAEMON;
+            } else {
+              process.env.KSPEC_NO_DAEMON = originalNoDaemon;
+            }
+            _resetDetectionCacheForTesting();
+          }
+        });
+      },
+      async () => {
+        const response = await makeRequest("/api/command", {
+          method: "POST",
+          body: JSON.stringify({
+            command: "debug-proxy-decision",
+            args: {},
+          }),
+        });
+
+        expect(response.status).toBe(200);
+        const body = await response.json();
+        expect(body.exitCode).toBe(0);
+        const decision = JSON.parse(body.stdout);
+        expect(decision).toMatchObject({
+          proxy: false,
+          reason: "daemon command API execution",
+        });
+      },
+    );
+  });
+
+  // AC: @daemon-command-api ac-command-endpoint
   it("returns non-zero exitCode for unknown commands", async () => {
     const response = await makeRequest("/api/command", {
       method: "POST",

--- a/tests/daemon-command-api.test.ts
+++ b/tests/daemon-command-api.test.ts
@@ -8,6 +8,7 @@
  * - @daemon-command-api ac-concurrent-mutations: serialized mutation execution
  * - @daemon-command-api ac-response-parity: stdout/stderr/exitCode match direct CLI
  * - @daemon-command-api ac-cache-context-propagation: command execution receives entity cache async context
+ * - @daemon-command-api ac-no-recursive-command-proxy: daemon-internal command execution sees proxying suppressed
  * - @trait-api-endpoint ac-1: returns 2xx with JSON body
  * - @trait-api-endpoint ac-3: returns 400 on invalid body
  * - @trait-api-endpoint ac-6: includes X-Request-Id header
@@ -504,7 +505,7 @@ describe("Daemon Command API", () => {
     expect(body.stdout).toBeTruthy();
   });
 
-  // AC: @daemon-command-api ac-command-endpoint
+  // AC: @daemon-command-api ac-no-recursive-command-proxy
   it("executes daemon-internal commands without proxying back to /api/command", async () => {
     await withInjectedCommand(
       (program) => {

--- a/tests/daemon-debug-routes.test.ts
+++ b/tests/daemon-debug-routes.test.ts
@@ -57,6 +57,9 @@ function createMockCache(
     detailCount: 0,
     lastError: null,
     lastInvalidatedAt: null,
+    errorReason: null,
+    recoveryGuidance: null,
+    recoveryWaitingOnProjectState: false,
   };
 
   const domains: Record<string, DomainDiagnostic> = {
@@ -155,6 +158,9 @@ describe("Debug API routes", () => {
       detailCount: 3,
       lastError: null,
       lastInvalidatedAt: null,
+      errorReason: null,
+      recoveryGuidance: null,
+      recoveryWaitingOnProjectState: false,
     });
     expect(project.domains.items.indexCount).toBe(10);
     expect(project.domains.meta.indexCount).toBe(1);
@@ -313,6 +319,77 @@ describe("Debug API routes", () => {
     expect(domains.tasks.state).toBe("loading");
     expect(domains.items.state).toBe("loading");
     expect(domains.meta.state).toBe("unloaded");
+  });
+
+  // AC: @daemon-server ac-cache-diagnostics-degraded-reason
+  // AC: @daemon-server ac-cache-diagnostics-recovery-guidance
+  // AC: @daemon-server ac-cache-diagnostics-recovery-readiness
+  it("GET /api/debug/cache-status surfaces deterministic task-storage incompatibility diagnostics", async () => {
+    tempDir = await createTempDir("kspec-debug-task-storage-");
+    await initGitRepo(tempDir);
+    setupProjectFixture(tempDir);
+
+    const { manager: projectManager, middleware } = projectContextMiddleware({
+      startupProject: tempDir,
+    });
+
+    const mockCache = createMockCache(tempDir, {
+      tasks: {
+        state: "degraded",
+        indexCount: 0,
+        detailCount: 0,
+        lastError:
+          'This project uses kynetic version "1.0" without split task storage. The monolithic task storage format has been removed.',
+        lastInvalidatedAt: "2026-05-01T12:00:00.000Z",
+        errorReason: "legacy_task_storage_removed",
+        recoveryGuidance:
+          'Run "kspec task migrate" to convert to per-task directory storage, then tasks will work normally.',
+        recoveryWaitingOnProjectState: true,
+      },
+    });
+    const getEntityCache: EntityCacheAccessor = (p: string) => (p === tempDir ? mockCache : null);
+
+    app = new Elysia().use(middleware).use(createDebugRoutes({ projectManager, getEntityCache }));
+
+    const res = await makeRequest("/api/debug/cache-status");
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    const tasksDomain = body.projects[0].domains.tasks;
+    expect(tasksDomain.state).toBe("degraded");
+    expect(tasksDomain.errorReason).toBe("legacy_task_storage_removed");
+    expect(tasksDomain.recoveryGuidance).toContain("kspec task migrate");
+    expect(tasksDomain.recoveryWaitingOnProjectState).toBe(true);
+    expect(tasksDomain.lastError).toContain("monolithic task storage format has been removed");
+  });
+
+  it("GET /api/debug/cache-status reports recoveryWaitingOnProjectState=false for healthy domains", async () => {
+    tempDir = await createTempDir("kspec-debug-healthy-");
+    await initGitRepo(tempDir);
+    setupProjectFixture(tempDir);
+
+    const { manager: projectManager, middleware } = projectContextMiddleware({
+      startupProject: tempDir,
+    });
+
+    const mockCache = createMockCache(tempDir);
+    const getEntityCache: EntityCacheAccessor = (p: string) => (p === tempDir ? mockCache : null);
+
+    app = new Elysia().use(middleware).use(createDebugRoutes({ projectManager, getEntityCache }));
+
+    const res = await makeRequest("/api/debug/cache-status");
+    const body = await res.json();
+
+    // Every healthy domain should report null error fields and false recovery flag.
+    for (const domain of Object.values<{
+      errorReason: string | null;
+      recoveryGuidance: string | null;
+      recoveryWaitingOnProjectState: boolean;
+    }>(body.projects[0].domains)) {
+      expect(domain.errorReason).toBeNull();
+      expect(domain.recoveryGuidance).toBeNull();
+      expect(domain.recoveryWaitingOnProjectState).toBe(false);
+    }
   });
 
   // AC: @trait-json-output ac-1 — N/A: This is a debug endpoint; it does not support --json CLI flag.

--- a/tests/daemon-entity-cache.test.ts
+++ b/tests/daemon-entity-cache.test.ts
@@ -169,10 +169,13 @@ describe("ProjectEntityCache", () => {
       expect(fileToDomain("project.triage.yaml")).toEqual(["triage"]);
     });
 
-    it("should map manifest to both meta and items domains", () => {
+    it("should map manifest to meta, items, and tasks domains", () => {
+      // kynetic.yaml carries the project manifest (meta), is the root of the
+      // item include tree (items), and holds task_storage compatibility
+      // settings (tasks) — see ac-manifest-task-storage-settings-affect-tasks-domain.
       const domains = fileToDomain("kynetic.yaml");
-      expect(domains).toEqual(expect.arrayContaining(["meta", "items"]));
-      expect(domains).toHaveLength(2);
+      expect(domains).toEqual(expect.arrayContaining(["meta", "items", "tasks"]));
+      expect(domains).toHaveLength(3);
     });
 
     it("should map session context file to meta domain", () => {
@@ -1406,11 +1409,15 @@ describe("ProjectEntityCache", () => {
 
         const initContextSpy = vi.spyOn(yamlModule, "initContext");
         const kspecDir = join(projectA, ".kspec");
-        const manifestPath = join(kspecDir, "kynetic.yaml");
+        // Use a generic .yaml change for the first window so it touches only
+        // items+meta (catch-all mapping). kynetic.yaml now also invalidates
+        // the tasks domain (task-storage compatibility re-evaluation), so it
+        // would overlap with the second window's tasks invalidation.
+        const genericYamlPath = join(kspecDir, "settings.yaml");
 
         setTestDelay(projectA);
 
-        const firstWindowReload = cache.handleFileChange(kspecDir, manifestPath);
+        const firstWindowReload = cache.handleFileChange(kspecDir, genericYamlPath);
         await vi.waitFor(() => {
           expect((cache as any).inFlightReloads.has("meta")).toBe(true);
           expect((cache as any).inFlightReloads.has("items")).toBe(true);
@@ -3835,6 +3842,342 @@ describe("ProjectEntityCache", () => {
 
       // Clean up — unregister so other tests aren't affected
       unregisterEntityCache(projectA);
+    });
+  });
+
+  // ─── Task-storage compatibility / migration suppression ─────────────────
+  describe("task-storage incompatibility suppression", () => {
+    /**
+     * Build a legacy (kynetic 1.0 without split task_storage) project on
+     * top of an existing multi-dir fixture by overwriting kynetic.yaml.
+     * Returns the project path to be used.
+     */
+    async function makeLegacyProject(): Promise<string> {
+      const legacyDir = await createTempDir("kspec-legacy-");
+      await fs.mkdir(join(legacyDir, ".kspec"), { recursive: true });
+      await setupShadowDetection(legacyDir);
+      await fs.writeFile(
+        join(legacyDir, ".kspec", "kynetic.yaml"),
+        yamlStringify({
+          kynetic: "1.0",
+          project: { name: "Legacy", version: "0.1.0", status: "draft" },
+        }),
+        "utf-8",
+      );
+      // Legacy projects had project.tasks.yaml with full task entries; the
+      // file's presence isn't required for the version gate to fire, but
+      // include a representative file so watcher tests have something to
+      // change.
+      await fs.writeFile(
+        join(legacyDir, ".kspec", "project.tasks.yaml"),
+        yamlStringify([
+          {
+            _ulid: "01LEGACY00000000000000000A",
+            slugs: ["task-legacy"],
+            title: "Legacy task",
+            type: "task",
+            status: "pending",
+            priority: 3,
+            depends_on: [],
+            created_at: "2026-01-01T00:00:00.000Z",
+            notes: [],
+            todos: [],
+          },
+        ]),
+        "utf-8",
+      );
+      return legacyDir;
+    }
+
+    /**
+     * Build a split-configured project that has an unmigrated entry — the
+     * index has a task without notes_count and no matching per-task dir,
+     * which is exactly what the split backend's ensureMigrated() guards
+     * against.
+     */
+    async function makeUnmigratedSplitProject(): Promise<string> {
+      const dir = await createTempDir("kspec-unmigrated-");
+      await fs.mkdir(join(dir, ".kspec"), { recursive: true });
+      await setupShadowDetection(dir);
+      await fs.writeFile(
+        join(dir, ".kspec", "kynetic.yaml"),
+        yamlStringify({
+          kynetic: "1.1",
+          project: { name: "Unmigrated", version: "0.1.0", status: "draft" },
+          task_storage: { format: "split" },
+        }),
+        "utf-8",
+      );
+      // Unmigrated entry: lacks notes_count scalar and has no per-task dir.
+      await fs.writeFile(
+        join(dir, ".kspec", "project.tasks.yaml"),
+        yamlStringify([
+          {
+            _ulid: "01UNMIG0000000000000000000",
+            slugs: ["task-unmig"],
+            title: "Unmigrated entry",
+            type: "task",
+            status: "pending",
+            priority: 3,
+            depends_on: [],
+            created_at: "2026-01-01T00:00:00.000Z",
+            notes: [],
+            todos: [],
+          },
+        ]),
+        "utf-8",
+      );
+      return dir;
+    }
+
+    /** Patch a project so its manifest declares split task storage at kynetic 1.1. */
+    async function migrateToSplit(projectDir: string): Promise<void> {
+      await fs.writeFile(
+        join(projectDir, ".kspec", "kynetic.yaml"),
+        yamlStringify({
+          kynetic: "1.1",
+          project: { name: "Migrated", version: "0.1.0", status: "draft" },
+          task_storage: { format: "split" },
+        }),
+        "utf-8",
+      );
+      // Clear the legacy tasks file so split mode finds no tasks (empty
+      // project is valid for split per ensureMigrated()).
+      await fs.writeFile(join(projectDir, ".kspec", "project.tasks.yaml"), "[]\n", "utf-8");
+    }
+
+    // AC: @daemon-entity-cache ac-task-storage-incompatibility-degraded-state
+    it("degrades tasks domain when legacy kynetic 1.0 monolithic storage is detected", async () => {
+      const legacyDir = await makeLegacyProject();
+      try {
+        const cache = new ProjectEntityCache(legacyDir);
+        await cache.loadDomain("tasks");
+
+        expect(cache.getDomainState("tasks")).toBe("degraded");
+        const diagnostics = cache.getCacheDiagnostics();
+        expect(diagnostics.domains.tasks.state).toBe("degraded");
+        expect(diagnostics.domains.tasks.errorReason).toBe("legacy_task_storage_removed");
+        expect(diagnostics.domains.tasks.recoveryGuidance).toContain("kspec task migrate");
+        expect(diagnostics.domains.tasks.recoveryWaitingOnProjectState).toBe(true);
+        expect(diagnostics.domains.tasks.lastError).toBeTruthy();
+      } finally {
+        await fs.rm(legacyDir, { recursive: true, force: true });
+      }
+    });
+
+    // AC: @daemon-entity-cache ac-task-storage-incompatibility-degraded-state
+    it("classifies split-configured-but-unmigrated tasks as deterministic migration error", async () => {
+      const dir = await makeUnmigratedSplitProject();
+      try {
+        const cache = new ProjectEntityCache(dir);
+        await cache.loadDomain("tasks");
+
+        expect(cache.getDomainState("tasks")).toBe("degraded");
+        const diagnostics = cache.getCacheDiagnostics();
+        expect(diagnostics.domains.tasks.errorReason).toBe("split_task_storage_unmigrated");
+        expect(diagnostics.domains.tasks.recoveryGuidance).toContain("kspec task migrate");
+        expect(diagnostics.domains.tasks.recoveryWaitingOnProjectState).toBe(true);
+      } finally {
+        await fs.rm(dir, { recursive: true, force: true });
+      }
+    });
+
+    // AC: @daemon-entity-cache ac-task-storage-incompatibility-stable-reporting
+    it("suppresses repeated failure reports for the same unchanged condition", async () => {
+      const legacyDir = await makeLegacyProject();
+      const consoleErrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      try {
+        const cache = new ProjectEntityCache(legacyDir);
+        await cache.loadDomain("tasks");
+
+        const firstReportCount = consoleErrSpy.mock.calls.filter((c) =>
+          String(c[0]).includes('domain "tasks"'),
+        ).length;
+        expect(firstReportCount).toBe(1);
+
+        // Repeated explicit loads: each goes through the lower-level reload
+        // path, so suppression must kick in and prevent another report.
+        await cache.loadDomain("tasks");
+        await cache.loadDomain("tasks");
+        await cache.loadDomain("tasks");
+
+        const totalReports = consoleErrSpy.mock.calls.filter((c) =>
+          String(c[0]).includes('domain "tasks"'),
+        ).length;
+        expect(totalReports).toBe(firstReportCount);
+
+        // State is still degraded and surfaces the deterministic reason.
+        const diag = cache.getCacheDiagnostics();
+        expect(diag.domains.tasks.state).toBe("degraded");
+        expect(diag.domains.tasks.errorReason).toBe("legacy_task_storage_removed");
+        expect(diag.domains.tasks.recoveryWaitingOnProjectState).toBe(true);
+      } finally {
+        consoleErrSpy.mockRestore();
+        await fs.rm(legacyDir, { recursive: true, force: true });
+      }
+    });
+
+    // AC: @daemon-entity-cache ac-task-storage-incompatibility-stable-reporting
+    it("does not bypass suppression for concurrent/queued reloads or writeThrough fallback", async () => {
+      const legacyDir = await makeLegacyProject();
+      const consoleErrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      try {
+        const cache = new ProjectEntityCache(legacyDir);
+        await cache.loadDomain("tasks");
+
+        const baselineReports = consoleErrSpy.mock.calls.filter((c) =>
+          String(c[0]).includes('domain "tasks"'),
+        ).length;
+
+        // Concurrent reload paths must not each emit their own failure
+        // report. writeThrough without a hint falls through to the
+        // non-meta reload path; queued reloads go through the in-flight
+        // dedup so any waiting work also sees suppression after the first
+        // observation.
+        await Promise.all([
+          cache.loadDomain("tasks"),
+          cache.loadDomain("tasks"),
+          cache.writeThrough("tasks"),
+          cache.writeThrough("tasks"),
+        ]);
+
+        const totalReports = consoleErrSpy.mock.calls.filter((c) =>
+          String(c[0]).includes('domain "tasks"'),
+        ).length;
+        expect(totalReports).toBe(baselineReports);
+        expect(cache.getDomainState("tasks")).toBe("degraded");
+      } finally {
+        consoleErrSpy.mockRestore();
+        await fs.rm(legacyDir, { recursive: true, force: true });
+      }
+    });
+
+    // AC: @daemon-entity-cache ac-task-storage-incompatibility-rechecked-after-storage-change
+    // AC: @daemon-entity-cache ac-manifest-task-storage-settings-affect-tasks-domain
+    it("re-evaluates tasks domain when kynetic.yaml task-storage settings change", async () => {
+      const legacyDir = await makeLegacyProject();
+      const consoleErrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      try {
+        const cache = new ProjectEntityCache(legacyDir);
+        await cache.loadDomain("tasks");
+        expect(cache.getDomainState("tasks")).toBe("degraded");
+
+        // Migrate the project: update kynetic.yaml to declare split storage
+        // and empty out the legacy tasks file. The watcher will emit a
+        // change for kynetic.yaml, which lifts suppression and triggers a
+        // recheck.
+        await migrateToSplit(legacyDir);
+
+        const kspecDir = join(legacyDir, ".kspec");
+        await cache.handleFileChange(kspecDir, join(kspecDir, "kynetic.yaml"));
+
+        // Recheck should restore the domain to ready without daemon restart.
+        expect(cache.getDomainState("tasks")).toBe("ready");
+        const diag = cache.getCacheDiagnostics();
+        expect(diag.domains.tasks.errorReason).toBeNull();
+        expect(diag.domains.tasks.recoveryWaitingOnProjectState).toBe(false);
+        expect(diag.domains.tasks.lastError).toBeNull();
+      } finally {
+        consoleErrSpy.mockRestore();
+        await fs.rm(legacyDir, { recursive: true, force: true });
+      }
+    });
+
+    // AC: @daemon-entity-cache ac-task-storage-incompatibility-rechecked-after-storage-change
+    it("re-evaluates tasks domain when task-storage files change", async () => {
+      const legacyDir = await makeLegacyProject();
+      const consoleErrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      try {
+        const cache = new ProjectEntityCache(legacyDir);
+        await cache.loadDomain("tasks");
+
+        const kspecDir = join(legacyDir, ".kspec");
+        // Simulate a watcher event for the legacy tasks file. The domain
+        // re-evaluates against current state, and since the legacy gate
+        // still fails, stays degraded — but the recheck path must run.
+        await cache.handleFileChange(kspecDir, join(kspecDir, "project.tasks.yaml"));
+        expect(cache.getDomainState("tasks")).toBe("degraded");
+
+        // Now migrate and emit a task-file watcher event to confirm
+        // recovery via the task-file change signal alone.
+        await migrateToSplit(legacyDir);
+        await cache.handleFileChange(kspecDir, join(kspecDir, "project.tasks.yaml"));
+        expect(cache.getDomainState("tasks")).toBe("ready");
+      } finally {
+        consoleErrSpy.mockRestore();
+        await fs.rm(legacyDir, { recursive: true, force: true });
+      }
+    });
+
+    // AC: @daemon-entity-cache ac-task-storage-incompatibility-recovers-after-migration
+    it("returns tasks domain to available state after successful migration without restart", async () => {
+      const legacyDir = await makeLegacyProject();
+      try {
+        const cache = new ProjectEntityCache(legacyDir);
+        await cache.loadDomain("tasks");
+        expect(cache.getDomainState("tasks")).toBe("degraded");
+
+        await migrateToSplit(legacyDir);
+        const kspecDir = join(legacyDir, ".kspec");
+        await cache.handleFileChange(kspecDir, join(kspecDir, "kynetic.yaml"));
+
+        expect(cache.getDomainState("tasks")).toBe("ready");
+        // Re-runs of loadDomain on the now-healthy project must continue to
+        // work normally (suppression cleared).
+        await cache.loadDomain("tasks");
+        expect(cache.getDomainState("tasks")).toBe("ready");
+      } finally {
+        await fs.rm(legacyDir, { recursive: true, force: true });
+      }
+    });
+
+    // AC: @daemon-entity-cache ac-task-storage-incompatibility-persists-when-unresolved
+    it("keeps tasks domain degraded when a recheck finds the same incompatibility", async () => {
+      const legacyDir = await makeLegacyProject();
+      const consoleErrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      try {
+        const cache = new ProjectEntityCache(legacyDir);
+        await cache.loadDomain("tasks");
+        const firstObservedAt = cache.getCacheDiagnostics().domains.tasks;
+        expect(firstObservedAt.errorReason).toBe("legacy_task_storage_removed");
+
+        // Edit the legacy tasks file (e.g., the user touched it but did NOT
+        // migrate). The watcher event lifts suppression and triggers a
+        // recheck — but the underlying gate still fires.
+        const kspecDir = join(legacyDir, ".kspec");
+        await fs.writeFile(
+          join(kspecDir, "project.tasks.yaml"),
+          yamlStringify([
+            {
+              _ulid: "01LEGACY00000000000000000A",
+              slugs: ["task-legacy"],
+              title: "Legacy task edited",
+              type: "task",
+              status: "pending",
+              priority: 3,
+              depends_on: [],
+              created_at: "2026-01-01T00:00:00.000Z",
+              notes: [],
+              todos: [],
+            },
+          ]),
+          "utf-8",
+        );
+        await cache.handleFileChange(kspecDir, join(kspecDir, "project.tasks.yaml"));
+
+        expect(cache.getDomainState("tasks")).toBe("degraded");
+        const diag = cache.getCacheDiagnostics().domains.tasks;
+        expect(diag.errorReason).toBe("legacy_task_storage_removed");
+        expect(diag.recoveryWaitingOnProjectState).toBe(true);
+        // Suppression for the same code must not duplicate the failure log.
+        const reportCount = consoleErrSpy.mock.calls.filter((c) =>
+          String(c[0]).includes('domain "tasks"'),
+        ).length;
+        expect(reportCount).toBe(1);
+      } finally {
+        consoleErrSpy.mockRestore();
+        await fs.rm(legacyDir, { recursive: true, force: true });
+      }
     });
   });
 });

--- a/tests/dispatch-workspace-cleanup.test.ts
+++ b/tests/dispatch-workspace-cleanup.test.ts
@@ -717,6 +717,112 @@ describe("dispatch workspace cleanup", () => {
     ).toBe(true);
   });
 
+  // AC: @dispatch-workspace-cleanup-policy ac-preservation-diagnostics-quiet-by-default
+  it("does not emit preservation diagnostics when detailed cleanup diagnostics are not opted in", async () => {
+    await seedRepo(tempDir);
+    git(tempDir, "checkout -b agent-dev");
+
+    const taskRef = `@${testUlid("TASK", 27)}`;
+    const workspace = await provisionDispatchWorkspace({
+      projectDir: tempDir,
+      taskRef,
+      task: {
+        title: "Quiet Preservation Diagnostics",
+        slugs: ["task-quiet-preservation-diagnostics"],
+      },
+    });
+
+    // Force a preservation scenario: metadata removed and registry cleared,
+    // but the task is active. The protection helper must preserve the
+    // metadata-less worktree and its canonical dispatch branch — exactly the
+    // path that would otherwise emit a `[dispatch-cleanup]` diagnostic.
+    await fs.rm(workspaceMetadataPath(workspace.cwd), { force: true });
+    await fs.writeFile(
+      path.join(tempDir, "project.dispatch-workspaces.yaml"),
+      YAML.stringify({ kynetic_dispatch_workspaces: "1.0", workspaces: [] }),
+      "utf-8",
+    );
+
+    // Explicitly clear the opt-in so an inherited env var cannot leak into
+    // the assertion. The diagnostic gate must default to quiet.
+    const previousDiagnostics = process.env.KSPEC_DISPATCH_CLEANUP_DIAGNOSTICS;
+    delete process.env.KSPEC_DISPATCH_CLEANUP_DIAGNOSTICS;
+    const debugSpy = vi.spyOn(console, "debug").mockImplementation(() => undefined);
+    try {
+      await reconcileDispatchWorkspaceArtifacts(tempDir, { activeTaskRefs: [taskRef] });
+    } finally {
+      debugSpy.mockRestore();
+      if (previousDiagnostics === undefined) {
+        delete process.env.KSPEC_DISPATCH_CLEANUP_DIAGNOSTICS;
+      } else {
+        process.env.KSPEC_DISPATCH_CLEANUP_DIAGNOSTICS = previousDiagnostics;
+      }
+    }
+
+    // Preservation must still have occurred — workspace and branch survive.
+    await fs.access(workspace.cwd);
+    expect(
+      git(tempDir, "branch --list dispatch/task/task-quiet-preservation-diagnostics/01task00"),
+    ).toContain("dispatch/task/task-quiet-preservation-diagnostics/01task00");
+
+    // No `[dispatch-cleanup]` diagnostic was emitted on the quiet path.
+    const diagnosticCalls = debugSpy.mock.calls.filter((args) =>
+      String(args[0] ?? "").includes("[dispatch-cleanup]"),
+    );
+    expect(diagnosticCalls).toEqual([]);
+  });
+
+  // AC: @dispatch-workspace-cleanup-policy ac-preservation-diagnostics-opt-in
+  it("emits a preservation diagnostic identifying surface, artifact, and reason when the opt-in is enabled", async () => {
+    await seedRepo(tempDir);
+    git(tempDir, "checkout -b agent-dev");
+
+    const taskRef = `@${testUlid("TASK", 28)}`;
+    const workspace = await provisionDispatchWorkspace({
+      projectDir: tempDir,
+      taskRef,
+      task: {
+        title: "Opt In Preservation Diagnostics",
+        slugs: ["task-opt-in-preservation-diagnostics"],
+      },
+    });
+
+    // Same preservation scenario as the quiet-by-default test so the only
+    // observable difference is the opt-in env var.
+    await fs.rm(workspaceMetadataPath(workspace.cwd), { force: true });
+    await fs.writeFile(
+      path.join(tempDir, "project.dispatch-workspaces.yaml"),
+      YAML.stringify({ kynetic_dispatch_workspaces: "1.0", workspaces: [] }),
+      "utf-8",
+    );
+
+    const diag = captureDispatchCleanupDiagnostics();
+    let capturedCalls: string[] = [];
+    try {
+      await reconcileDispatchWorkspaceArtifacts(tempDir, { activeTaskRefs: [taskRef] });
+      capturedCalls = diag.capture();
+    } finally {
+      diag.restore();
+    }
+
+    // Preservation occurred — workspace and branch survive.
+    await fs.access(workspace.cwd);
+    expect(
+      git(tempDir, "branch --list dispatch/task/task-opt-in-preservation-diagnostics/01task00"),
+    ).toContain("dispatch/task/task-opt-in-preservation-diagnostics/01task00");
+
+    // At least one diagnostic identifies surface, artifact, and reason.
+    const diagnosticMessages = capturedCalls.filter((line) => line.includes("[dispatch-cleanup]"));
+    expect(diagnosticMessages.length).toBeGreaterThan(0);
+    const surfaceLabeled = diagnosticMessages.find(
+      (line) =>
+        line.includes("metadata-less-worktree") &&
+        line.includes(workspace.cwd) &&
+        /active or in-flight/.test(line),
+    );
+    expect(surfaceLabeled).toBeDefined();
+  });
+
   // AC: @dispatch-workspace-cleanup-policy ac-6
   // AC: @dispatch-workspace-cleanup-policy ac-7
   it("reconstructs a missing registry record and normalizes legacy branch layouts from metadata-backed worktrees", async () => {

--- a/tests/dispatch-workspace-cleanup.test.ts
+++ b/tests/dispatch-workspace-cleanup.test.ts
@@ -748,8 +748,16 @@ describe("dispatch workspace cleanup", () => {
     const previousDiagnostics = process.env.KSPEC_DISPATCH_CLEANUP_DIAGNOSTICS;
     delete process.env.KSPEC_DISPATCH_CLEANUP_DIAGNOSTICS;
     const debugSpy = vi.spyOn(console, "debug").mockImplementation(() => undefined);
+    let diagnosticCalls: string[] = [];
     try {
       await reconcileDispatchWorkspaceArtifacts(tempDir, { activeTaskRefs: [taskRef] });
+      // Snapshot the spy's call history BEFORE mockRestore(): mockRestore
+      // clears the recorded calls, so reading them after restore would
+      // always observe an empty array and silently pass even if a
+      // diagnostic line had been emitted.
+      diagnosticCalls = debugSpy.mock.calls
+        .map((args) => String(args[0] ?? ""))
+        .filter((line) => line.includes("[dispatch-cleanup]"));
     } finally {
       debugSpy.mockRestore();
       if (previousDiagnostics === undefined) {
@@ -766,9 +774,6 @@ describe("dispatch workspace cleanup", () => {
     ).toContain("dispatch/task/task-quiet-preservation-diagnostics/01task00");
 
     // No `[dispatch-cleanup]` diagnostic was emitted on the quiet path.
-    const diagnosticCalls = debugSpy.mock.calls.filter((args) =>
-      String(args[0] ?? "").includes("[dispatch-cleanup]"),
-    );
     expect(diagnosticCalls).toEqual([]);
   });
 

--- a/tests/dispatch-workspace-cleanup.test.ts
+++ b/tests/dispatch-workspace-cleanup.test.ts
@@ -109,6 +109,8 @@ function captureDispatchCleanupDiagnostics(): {
   capture: () => string[];
   restore: () => void;
 } {
+  const previousDiagnostics = process.env.KSPEC_DISPATCH_CLEANUP_DIAGNOSTICS;
+  process.env.KSPEC_DISPATCH_CLEANUP_DIAGNOSTICS = "1";
   const spy = vi.spyOn(console, "debug").mockImplementation(() => undefined);
   return {
     capture: () =>
@@ -116,6 +118,11 @@ function captureDispatchCleanupDiagnostics(): {
         .map((args) => String(args[0] ?? ""))
         .filter((line) => line.includes("[dispatch-cleanup]")),
     restore: () => {
+      if (previousDiagnostics === undefined) {
+        delete process.env.KSPEC_DISPATCH_CLEANUP_DIAGNOSTICS;
+      } else {
+        process.env.KSPEC_DISPATCH_CLEANUP_DIAGNOSTICS = previousDiagnostics;
+      }
       spy.mockRestore();
     },
   };
@@ -546,13 +553,13 @@ describe("dispatch workspace cleanup", () => {
       "utf-8",
     );
 
-    const debugSpy = vi.spyOn(console, "debug").mockImplementation(() => undefined);
+    const diag = captureDispatchCleanupDiagnostics();
     let capturedCalls: string[] = [];
     try {
       await reconcileDispatchWorkspaceArtifacts(tempDir);
-      capturedCalls = debugSpy.mock.calls.map((args) => String(args[0] ?? ""));
+      capturedCalls = diag.capture();
     } finally {
-      debugSpy.mockRestore();
+      diag.restore();
     }
 
     // Every dispatcher-managed artifact under the worktree root must survive.
@@ -618,15 +625,15 @@ describe("dispatch workspace cleanup", () => {
       "utf-8",
     );
 
-    const debugSpy = vi.spyOn(console, "debug").mockImplementation(() => undefined);
+    const diag = captureDispatchCleanupDiagnostics();
     let capturedCalls: string[] = [];
     try {
       await reconcileDispatchWorkspaceArtifacts(tempDir, {
         activeTaskRefs: [taskRef],
       });
-      capturedCalls = debugSpy.mock.calls.map((args) => String(args[0] ?? ""));
+      capturedCalls = diag.capture();
     } finally {
-      debugSpy.mockRestore();
+      diag.restore();
     }
 
     const diagnosticMessages = capturedCalls.filter((line) => line.includes("[dispatch-cleanup]"));
@@ -680,15 +687,15 @@ describe("dispatch workspace cleanup", () => {
       },
     });
 
-    const debugSpy = vi.spyOn(console, "debug").mockImplementation(() => undefined);
+    const diag = captureDispatchCleanupDiagnostics();
     let capturedCalls: string[] = [];
     try {
       await reconcileDispatchWorkspaceArtifacts(tempDir, {
         activeTaskRefs: [taskRef],
       });
-      capturedCalls = debugSpy.mock.calls.map((args) => String(args[0] ?? ""));
+      capturedCalls = diag.capture();
     } finally {
-      debugSpy.mockRestore();
+      diag.restore();
     }
 
     // Reap is skipped, so the worktree and canonical branch must survive.

--- a/tests/dispatch-workspace-registry.test.ts
+++ b/tests/dispatch-workspace-registry.test.ts
@@ -1034,9 +1034,12 @@ describe("dispatch workspace registry", () => {
       timestamps: { ...existing.timestamps, updated_at: now },
     });
 
+    const debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
+
     // Artifact cleanup must NOT reap or prune the provisioning workspace.
     await reconcileDispatchWorkspaceArtifacts(tempDir);
 
+    expect(debugSpy).not.toHaveBeenCalledWith(expect.stringContaining("[dispatch-cleanup]"));
     await fs.access(workspace.metadata.workerWorktreeDir);
     expect(
       git(tempDir, "branch --list dispatch/task/task-partial-provisioning-classification/01task00"),

--- a/tests/e2e-fixture-daemon-cleanup.test.ts
+++ b/tests/e2e-fixture-daemon-cleanup.test.ts
@@ -37,6 +37,7 @@ import {
   runDaemonFixtureLifecycle,
   runPlaywrightFixtureBody,
   startPlaywrightFixtureDaemon,
+  type AcquireTestDaemonPortStartLockImpl,
   type AllocateTestDaemonPortImpl,
   type CreateTestDaemonProjectImpl,
   type PlaywrightFixtureSetupStage,
@@ -75,6 +76,7 @@ function makeFakeStartedDaemon(stop: () => Promise<void>): StartedTestDaemon {
       port: 1234,
       bindHost: "127.0.0.1",
       connectHost: "127.0.0.1",
+      externallyReachable: false,
     },
     runtime: "node",
     // The wrapper only reads `child.exitCode` / `child.signalCode` from this
@@ -214,6 +216,30 @@ describe("startPlaywrightFixtureDaemon — cleanup registration contract", () =>
     expect(stopCalls).toEqual(["stop-invoked"]);
   });
 
+  it("preserves startup failure when releasing the startup lock also fails", async () => {
+    const startupFailure = new Error("simulated readiness failure");
+    const lockFailure = new Error("simulated startup lock release failure");
+    const fakeStart: StartTestDaemonImpl = (async () => {
+      throw startupFailure;
+    }) as StartTestDaemonImpl;
+
+    await expect(
+      startPlaywrightFixtureDaemon({
+        project: FAKE_PROJECT,
+        runtime: "node",
+        port: 1234,
+        registerCleanup: () => {},
+        releasePortStartLock: () => {
+          throw lockFailure;
+        },
+        startTestDaemonImpl: fakeStart,
+      }),
+    ).rejects.toMatchObject({
+      message: expect.stringContaining("simulated readiness failure"),
+      cause: lockFailure,
+    });
+  });
+
   it("forwards the runtime, port, and KSPEC_TEST env contract to the shared core", async () => {
     // Light coverage that the wrapper still passes the test-only env vars
     // and the pre-allocated port through to the shared core. The
@@ -223,6 +249,7 @@ describe("startPlaywrightFixtureDaemon — cleanup registration contract", () =>
     let receivedRuntime: string | undefined;
     let receivedPort: number | undefined;
     let receivedExtraEnv: Record<string, string> | undefined;
+    let lockReleased = false;
 
     const fakeStart: StartTestDaemonImpl = (async (_project, opts) => {
       receivedRuntime = opts.runtime;
@@ -237,11 +264,15 @@ describe("startPlaywrightFixtureDaemon — cleanup registration contract", () =>
       runtime: "node",
       port: 1234,
       registerCleanup: () => {},
+      releasePortStartLock: () => {
+        lockReleased = true;
+      },
       startTestDaemonImpl: fakeStart,
     });
 
     expect(receivedRuntime).toBe("node");
     expect(receivedPort).toBe(1234);
+    expect(lockReleased).toBe(true);
     expect(receivedExtraEnv).toEqual({
       KSPEC_TEST: "1",
       KSPEC_TEST_RUNTIME: "node",
@@ -370,6 +401,10 @@ describe("acquirePlaywrightFixtureResources — wrapper setup-failure cleanup", 
         project) as CreateTestDaemonProjectImpl;
       const fakeAllocate: AllocateTestDaemonPortImpl = (async () =>
         4321) as AllocateTestDaemonPortImpl;
+      let lockReleased = false;
+      const fakeAcquireLock: AcquireTestDaemonPortStartLockImpl = (async () => () => {
+        lockReleased = true;
+      }) as AcquireTestDaemonPortStartLockImpl;
 
       const stages: PlaywrightFixtureSetupStage[] = [];
       const resources = await acquirePlaywrightFixtureResources({
@@ -381,6 +416,7 @@ describe("acquirePlaywrightFixtureResources — wrapper setup-failure cleanup", 
         webUiDir: "/tmp/fake-web-ui",
         __testCreateProjectImpl: fakeCreate,
         __testAllocatePortImpl: fakeAllocate,
+        __testAcquirePortStartLockImpl: fakeAcquireLock,
         __testStageHook: (stage) => {
           stages.push(stage);
         },
@@ -388,6 +424,9 @@ describe("acquirePlaywrightFixtureResources — wrapper setup-failure cleanup", 
 
       expect(resources.project).toBe(project);
       expect(resources.port).toBe(4321);
+      expect(lockReleased).toBe(false);
+      resources.releasePortStartLock();
+      expect(lockReleased).toBe(true);
       expect(stages).toEqual([
         "after-create-project",
         "after-copy-project-tests",

--- a/tests/e2e/fixtures/daemon-fixture.ts
+++ b/tests/e2e/fixtures/daemon-fixture.ts
@@ -19,6 +19,7 @@ import { cpSync, existsSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 import {
+  acquireTestDaemonPortStartLock as defaultAcquireTestDaemonPortStartLock,
   allocateTestDaemonPort as defaultAllocateTestDaemonPort,
   attachCleanupFailure,
   createTestDaemonProject as defaultCreateTestDaemonProject,
@@ -29,6 +30,7 @@ import {
 } from "../../helpers/daemon.js";
 
 export type StartTestDaemonImpl = typeof defaultStartTestDaemon;
+export type AcquireTestDaemonPortStartLockImpl = typeof defaultAcquireTestDaemonPortStartLock;
 
 export interface StartPlaywrightFixtureDaemonOptions {
   project: TestDaemonProject;
@@ -42,6 +44,8 @@ export interface StartPlaywrightFixtureDaemonOptions {
    * cleanup on both success and startup-failure paths.
    */
   registerCleanup: (stop: () => Promise<void>) => void;
+  /** Release a setup-held dynamic-port lock after startup succeeds or fails. */
+  releasePortStartLock?: () => void;
   /**
    * Test seam for unit-level coverage of the cleanup-registration contract.
    * Production callers (`test-base.ts`) leave this undefined and the helper
@@ -68,17 +72,40 @@ export async function startPlaywrightFixtureDaemon(
   opts: StartPlaywrightFixtureDaemonOptions,
 ): Promise<StartedTestDaemon> {
   const start = opts.startTestDaemonImpl ?? defaultStartTestDaemon;
-  return await start(opts.project, {
-    runtime: opts.runtime,
-    port: opts.port,
-    extraEnv: {
-      // KSPEC_TEST=1 enables the daemon's test-only cache-delay primitive
-      // (src/daemon/entity-cache.ts). Preserved from the prior fixture.
-      KSPEC_TEST: "1",
-      KSPEC_TEST_RUNTIME: opts.runtime,
-    },
-    registerCleanup: opts.registerCleanup,
-  });
+  const releasePortStartLock = opts.releasePortStartLock;
+  let releaseAttempted = false;
+  try {
+    const started = await start(opts.project, {
+      runtime: opts.runtime,
+      port: opts.port,
+      extraEnv: {
+        // KSPEC_TEST=1 enables the daemon's test-only cache-delay primitive
+        // (src/daemon/entity-cache.ts). Preserved from the prior fixture.
+        KSPEC_TEST: "1",
+        KSPEC_TEST_RUNTIME: opts.runtime,
+      },
+      registerCleanup: opts.registerCleanup,
+    });
+    if (releasePortStartLock) {
+      releaseAttempted = true;
+      releasePortStartLock();
+    }
+    return started;
+  } catch (primary) {
+    if (releasePortStartLock && !releaseAttempted) {
+      try {
+        releaseAttempted = true;
+        releasePortStartLock();
+      } catch (cleanupError) {
+        const err = primary instanceof Error ? primary : new Error(String(primary));
+        const secondary =
+          cleanupError instanceof Error ? cleanupError : new Error(String(cleanupError));
+        attachCleanupFailure(err, secondary);
+        throw err;
+      }
+    }
+    throw primary;
+  }
 }
 
 /**
@@ -115,6 +142,8 @@ export interface AcquirePlaywrightFixtureResourcesOptions {
   __testCreateProjectImpl?: CreateTestDaemonProjectImpl;
   /** Test seam: override `allocateTestDaemonPort` for setup-failure injection. */
   __testAllocatePortImpl?: AllocateTestDaemonPortImpl;
+  /** Test seam: override the dynamic-port startup lock for ordering/cleanup tests. */
+  __testAcquirePortStartLockImpl?: AcquireTestDaemonPortStartLockImpl;
 }
 
 export interface PlaywrightFixtureResources {
@@ -122,6 +151,8 @@ export interface PlaywrightFixtureResources {
   project: TestDaemonProject;
   /** Pre-allocated dynamic port the daemon should bind on. */
   port: number;
+  /** Releases the dynamic-port startup lock after the daemon finishes startup. */
+  releasePortStartLock: () => void;
 }
 
 /**
@@ -149,12 +180,15 @@ export async function acquirePlaywrightFixtureResources(
 ): Promise<PlaywrightFixtureResources> {
   const createProject = opts.__testCreateProjectImpl ?? defaultCreateTestDaemonProject;
   const allocatePort = opts.__testAllocatePortImpl ?? defaultAllocateTestDaemonPort;
+  const acquirePortStartLock =
+    opts.__testAcquirePortStartLockImpl ?? defaultAcquireTestDaemonPortStartLock;
 
   const project = await createProject({
     fixturesSource: opts.fixturesSource,
     webUiDir: opts.webUiDir,
   });
 
+  let releasePortStartLock: (() => void) | null = null;
   try {
     opts.__testStageHook?.("after-create-project");
 
@@ -181,11 +215,32 @@ export async function acquirePlaywrightFixtureResources(
     // cycles re-bind to the same endpoint that the browser already loaded —
     // losing the port across a restart would force every test that exercises
     // reconnection behavior to reload.
+    releasePortStartLock = await acquirePortStartLock();
     const port = await allocatePort();
     opts.__testStageHook?.("after-allocate-port");
 
-    return { project, port };
+    return { project, port, releasePortStartLock };
   } catch (primary) {
+    if (releasePortStartLock) {
+      try {
+        releasePortStartLock();
+      } catch (cleanupError) {
+        const err = primary instanceof Error ? primary : new Error(String(primary));
+        const secondary =
+          cleanupError instanceof Error ? cleanupError : new Error(String(cleanupError));
+        attachCleanupFailure(err, secondary);
+        try {
+          await project.cleanup();
+        } catch (projectCleanupError) {
+          const projectSecondary =
+            projectCleanupError instanceof Error
+              ? projectCleanupError
+              : new Error(String(projectCleanupError));
+          attachCleanupFailure(err, projectSecondary);
+        }
+        throw err;
+      }
+    }
     // Release the owned project handle so a later-step failure does not
     // leak the temp project + isolated HOME. project.cleanup is
     // idempotent, so a later teardown that also calls cleanup is safe.

--- a/tests/e2e/fixtures/test-base.ts
+++ b/tests/e2e/fixtures/test-base.ts
@@ -6,7 +6,9 @@ import { fileURLToPath } from "url";
 import { parse as parseYaml } from "yaml";
 
 import {
+  acquireTestDaemonPortStartLock,
   isDaemonRuntimeAvailable,
+  reserveTestDaemonPort,
   type DaemonTestRuntime,
   type StartedTestDaemon,
 } from "../../helpers/daemon.js";
@@ -167,12 +169,14 @@ export const test = base.extend<{ daemon: DaemonFixture }>({
       // so the setup-failure cleanup contract can be exercised at the unit level
       // (tests/e2e-fixture-daemon-cleanup.test.ts) against the same code path the
       // wrapper executes.
-      const { project, port } = await acquirePlaywrightFixtureResources({
+      const { project, port, releasePortStartLock } = await acquirePlaywrightFixtureResources({
         fixturesSource: E2E_FIXTURES,
         webUiDir: WEB_UI_BUILD,
       });
 
       let started: StartedTestDaemon | null = null;
+      let releasePendingPortStartLock: (() => void) | null = releasePortStartLock;
+      let releaseStoppedPortReservation: (() => Promise<void>) | null = null;
       // Stop hook captured via our own `registerCleanup` callback passed
       // through to the shared core. Owning the captured reference here
       // (rather than reading it back from the helper's return value) lets
@@ -187,6 +191,22 @@ export const test = base.extend<{ daemon: DaemonFixture }>({
         if (started && started.child.exitCode === null && started.child.signalCode === null) {
           return;
         }
+
+        if (releaseStoppedPortReservation) {
+          const releaseRestartLock = await acquireTestDaemonPortStartLock();
+          try {
+            await releaseStoppedPortReservation();
+            releaseStoppedPortReservation = null;
+            releasePendingPortStartLock = releaseRestartLock;
+          } catch (error) {
+            releaseRestartLock();
+            throw error;
+          }
+        }
+
+        const releasePortStartLockForThisStart = releasePendingPortStartLock ?? undefined;
+        releasePendingPortStartLock = null;
+
         // AC: @e2e-test-daemon-isolation ac-uses-shared-fixture
         // AC: @daemon-backed-test-fixture-contract ac-real-daemon-tests-use-shared-fixture
         // AC: @daemon-backed-test-fixture-contract ac-bounded-readiness
@@ -198,6 +218,7 @@ export const test = base.extend<{ daemon: DaemonFixture }>({
           project,
           runtime,
           port,
+          releasePortStartLock: releasePortStartLockForThisStart,
           registerCleanup: (stop) => {
             earlyStop = stop;
           },
@@ -211,7 +232,15 @@ export const test = base.extend<{ daemon: DaemonFixture }>({
         earlyStop ??= started.stop;
       }
 
-      async function stopDaemon(): Promise<void> {
+      async function stopDaemon(opts: { reservePort?: boolean } = {}): Promise<void> {
+        const reservePort = opts.reservePort ?? true;
+        if (releaseStoppedPortReservation) {
+          if (!reservePort) {
+            await releaseStoppedPortReservation();
+            releaseStoppedPortReservation = null;
+          }
+          return;
+        }
         if (!earlyStop) return;
         // AC: @e2e-test-daemon-isolation ac-e2e-scoped-cleanup
         // AC: @daemon-backed-test-fixture-contract ac-scoped-cleanup
@@ -220,7 +249,18 @@ export const test = base.extend<{ daemon: DaemonFixture }>({
         // The captured stop is idempotent (see startTestDaemon's `stopped`
         // guard) so calling it again from the finally block below after
         // the test invoked daemon.stop() is safe.
-        await earlyStop();
+        if (!reservePort) {
+          await earlyStop();
+          return;
+        }
+
+        const releaseStopLock = await acquireTestDaemonPortStartLock();
+        try {
+          await earlyStop();
+          releaseStoppedPortReservation = await reserveTestDaemonPort(port);
+        } finally {
+          releaseStopLock();
+        }
       }
 
       // Helper to create a valid second project for multi-project tests
@@ -325,7 +365,7 @@ tasks: []
           // AC: @e2e-test-daemon-isolation ac-e2e-scoped-cleanup
           // AC: @daemon-backed-test-fixture-contract ac-scoped-cleanup
           // AC: @daemon-test-startup-failure-hygiene ac-owned-child-stopped-after-startup-failure
-          await stopDaemon();
+          await stopDaemon({ reservePort: false });
           try {
             rmSync(`${project.tempDir}-second`, { recursive: true, force: true });
           } catch {

--- a/tests/event-bus.test.ts
+++ b/tests/event-bus.test.ts
@@ -424,6 +424,7 @@ describe("ac-4: per-source sequential delivery ordering", () => {
     expect(aEnd).toBeLessThan(bStart);
   });
 
+  // AC: @dispatch-event-envelope ac-completed-source-ordering-is-released
   it("should release settled per-source delivery chains after subscriber delivery", async () => {
     const bus = new EventBus();
     const retainedChains = () =>
@@ -630,10 +631,10 @@ describe("ac-5: chain depth limit", () => {
     vi.restoreAllMocks();
   });
 
-  it("should bound retained chain-depth entries to recent correlated events", () => {
+  // AC: @dispatch-event-envelope ac-retained-event-lineage-is-bounded
+  it("should release chain-depth entries for correlations whose events have aged out", () => {
     const bus = new EventBus({ ringBufferCapacity: 5, maxChainDepth: 20 });
-    const retainedDepths = () =>
-      (bus as unknown as { chainDepths: Map<string, number> }).chainDepths.size;
+    const chainDepths = (bus as unknown as { chainDepths: Map<string, number> }).chainDepths;
 
     for (let i = 0; i < 25; i++) {
       const correlationId = `correlation-${i}`;
@@ -647,7 +648,53 @@ describe("ac-5: chain depth limit", () => {
       expect(result.accepted).toBe(true);
     }
 
-    expect(retainedDepths()).toBeLessThanOrEqual(5);
+    // Aged-out correlations must be released — not merely bounded by capacity.
+    const retainedCorrelationIds = new Set(
+      bus
+        .getRecentEvents()
+        .map((event) => event.correlation_id)
+        .filter((id): id is string => typeof id === "string"),
+    );
+    for (let i = 0; i < 20; i++) {
+      expect(chainDepths.has(`correlation-${i}`)).toBe(false);
+      expect(bus.getChainDepth(`correlation-${i}`)).toBe(0);
+    }
+    for (const correlationId of chainDepths.keys()) {
+      expect(retainedCorrelationIds.has(correlationId)).toBe(true);
+    }
+    expect(chainDepths.size).toBeLessThanOrEqual(5);
+  });
+
+  // AC: @dispatch-event-envelope ac-retained-event-lineage-is-bounded
+  it("should release a correlated event's chain depth after later uncorrelated events age it out", () => {
+    const bus = new EventBus({ ringBufferCapacity: 5, maxChainDepth: 20 });
+
+    bus.emit({
+      event_type: "test.correlated",
+      source_type: "manual",
+      source_id: "source-correlated",
+      causation_id: "cause-stale",
+      correlation_id: "correlation-stale",
+    });
+
+    expect(bus.getChainDepth("correlation-stale")).toBe(1);
+
+    for (let i = 0; i < 5; i++) {
+      bus.emit({
+        event_type: "test.uncorrelated",
+        source_type: "manual",
+        source_id: `source-${i}`,
+      });
+    }
+
+    // The correlated event has aged out of the ring buffer; its chain-depth
+    // entry must be released so daemon memory does not grow with stale lineage.
+    const retained = bus.getRecentEvents();
+    expect(retained.every((event) => event.correlation_id === null)).toBe(true);
+    expect(bus.getChainDepth("correlation-stale")).toBe(0);
+    expect(
+      (bus as unknown as { chainDepths: Map<string, number> }).chainDepths.has("correlation-stale"),
+    ).toBe(false);
   });
 });
 

--- a/tests/event-bus.test.ts
+++ b/tests/event-bus.test.ts
@@ -423,6 +423,29 @@ describe("ac-4: per-source sequential delivery ordering", () => {
     const bStart = log.indexOf("handler1:start:test.b");
     expect(aEnd).toBeLessThan(bStart);
   });
+
+  it("should release settled per-source delivery chains after subscriber delivery", async () => {
+    const bus = new EventBus();
+    const retainedChains = () =>
+      (bus as unknown as { sourceDeliveryChains: Map<string, Promise<void>> }).sourceDeliveryChains
+        .size;
+
+    bus.subscribe("test.*", async () => {
+      await Promise.resolve();
+    });
+
+    for (let i = 0; i < 25; i++) {
+      bus.emit({
+        event_type: "test.high-cardinality-source",
+        source_type: "manual",
+        source_id: `unique-source-${i}`,
+      });
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(retainedChains()).toBe(0);
+  });
 });
 
 // ─── AC-5: Chain Depth Limit ────────────────────────────────────────────────
@@ -605,6 +628,26 @@ describe("ac-5: chain depth limit", () => {
     expect(afterReset.accepted).toBe(true);
 
     vi.restoreAllMocks();
+  });
+
+  it("should bound retained chain-depth entries to recent correlated events", () => {
+    const bus = new EventBus({ ringBufferCapacity: 5, maxChainDepth: 20 });
+    const retainedDepths = () =>
+      (bus as unknown as { chainDepths: Map<string, number> }).chainDepths.size;
+
+    for (let i = 0; i < 25; i++) {
+      const correlationId = `correlation-${i}`;
+      const result = bus.emit({
+        event_type: "test.correlated",
+        source_type: "manual",
+        source_id: `source-${i}`,
+        causation_id: `cause-${i}`,
+        correlation_id: correlationId,
+      });
+      expect(result.accepted).toBe(true);
+    }
+
+    expect(retainedDepths()).toBeLessThanOrEqual(5);
   });
 });
 

--- a/tests/helpers/daemon.test.ts
+++ b/tests/helpers/daemon.test.ts
@@ -17,6 +17,8 @@ import {
   buildDaemonChildEnv,
   createTestDaemonProject,
   DaemonReadinessError,
+  allocateTestDaemonPort,
+  reserveTestDaemonPort,
   startTestDaemon,
   type CreateTestDaemonProjectStage,
 } from "./daemon.js";
@@ -218,6 +220,22 @@ describe("createTestDaemonProject", () => {
     expect(existsSync(project.tempDir)).toBe(false);
     // Idempotent.
     await project.cleanup();
+  });
+});
+
+describe("test daemon port reservation", () => {
+  it("holds a preallocated port until the reservation is released", async () => {
+    const port = await allocateTestDaemonPort();
+    const release = await reserveTestDaemonPort(port);
+    onTestFinished(async () => {
+      await release();
+    });
+
+    await expect(reserveTestDaemonPort(port)).rejects.toMatchObject({ code: "EADDRINUSE" });
+
+    await release();
+    const releaseAgain = await reserveTestDaemonPort(port);
+    await releaseAgain();
   });
 });
 

--- a/tests/helpers/daemon.ts
+++ b/tests/helpers/daemon.ts
@@ -20,9 +20,10 @@
  *     never kills by port number or by reading the ambient pid file.
  */
 import { execSync, spawn, type ChildProcess } from "node:child_process";
-import { existsSync, mkdirSync } from "node:fs";
+import { existsSync, mkdirSync, rmSync } from "node:fs";
 import { cp as fsCp } from "node:fs/promises";
 import { createServer as createNetServer } from "node:net";
+import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -57,6 +58,8 @@ const WEB_UI_BUILD_CANDIDATES = [
   join(PROJECT_ROOT, "dist", "web-ui"),
   join(PROJECT_ROOT, "packages", "web-ui", "build"),
 ];
+const PORT_START_LOCK_DIR = join(tmpdir(), "kspec-test-daemon-port-start.lock");
+const PORT_START_LOCK_MIN_TIMEOUT_MS = 120_000;
 
 // ── Public types ──────────────────────────────────────────────────────
 
@@ -335,6 +338,63 @@ export async function allocateTestDaemonPort(host = DEFAULT_BIND_HOST): Promise<
       }
       const { port } = address;
       server.close((err) => (err ? rejectErr(err) : resolveOk(port)));
+    });
+  });
+}
+
+function computePortStartLockTimeout(opts: StartTestDaemonOptions): number {
+  const readiness = opts.readiness ?? { mode: "health-and-cache" };
+  const readinessStages = readiness.mode === "health-and-cache" ? 2 : 1;
+  const readinessBudgetMs = (opts.timeoutMs ?? DEFAULT_TIMEOUT_MS) * readinessStages;
+  return Math.max(PORT_START_LOCK_MIN_TIMEOUT_MS, readinessBudgetMs + 15_000);
+}
+
+export async function acquireTestDaemonPortStartLock(
+  timeoutMs = PORT_START_LOCK_MIN_TIMEOUT_MS,
+): Promise<() => void> {
+  const deadline = Date.now() + timeoutMs;
+
+  while (true) {
+    try {
+      mkdirSync(PORT_START_LOCK_DIR);
+      let released = false;
+      return () => {
+        if (released) return;
+        rmSync(PORT_START_LOCK_DIR, { recursive: true, force: true });
+        released = true;
+      };
+    } catch (error) {
+      const code = (error as { code?: string }).code;
+      if (code !== "EEXIST") throw error;
+
+      if (Date.now() >= deadline) {
+        throw new Error(
+          `Timed out waiting ${timeoutMs}ms for daemon port startup lock at ${PORT_START_LOCK_DIR}`,
+        );
+      }
+
+      await new Promise<void>((resolveSleep) => setTimeout(resolveSleep, 25));
+    }
+  }
+}
+
+export async function reserveTestDaemonPort(
+  port: number,
+  host = DEFAULT_BIND_HOST,
+): Promise<() => Promise<void>> {
+  return await new Promise<() => Promise<void>>((resolveOk, rejectErr) => {
+    const server = createNetServer();
+    server.once("error", rejectErr);
+    server.listen(port, host, () => {
+      server.removeListener("error", rejectErr);
+      let released = false;
+      resolveOk(async () => {
+        if (released) return;
+        released = true;
+        await new Promise<void>((resolveClose, rejectClose) => {
+          server.close((err) => (err ? rejectClose(err) : resolveClose()));
+        });
+      });
     });
   });
 }
@@ -786,6 +846,47 @@ function formatDiagnostics(d: DaemonReadinessDiagnostics): string {
  * readiness wait.
  */
 export async function startTestDaemon(
+  project: TestDaemonProject,
+  opts: StartTestDaemonOptions = {},
+): Promise<StartedTestDaemon> {
+  const releasePortStartLock =
+    opts.port === undefined
+      ? await acquireTestDaemonPortStartLock(computePortStartLockTimeout(opts))
+      : null;
+  let started: StartedTestDaemon;
+  try {
+    started = await startTestDaemonUnlocked(project, opts);
+  } catch (primary) {
+    if (releasePortStartLock) {
+      try {
+        releasePortStartLock();
+      } catch (cleanupError) {
+        const err = toError(primary);
+        attachCleanupFailure(err, toError(cleanupError));
+        throw err;
+      }
+    }
+    throw primary;
+  }
+
+  if (releasePortStartLock) {
+    try {
+      releasePortStartLock();
+    } catch (cleanupError) {
+      const err = toError(cleanupError);
+      try {
+        await started.stop();
+      } catch (stopError) {
+        attachCleanupFailure(err, toError(stopError));
+      }
+      throw err;
+    }
+  }
+
+  return started;
+}
+
+async function startTestDaemonUnlocked(
   project: TestDaemonProject,
   opts: StartTestDaemonOptions = {},
 ): Promise<StartedTestDaemon> {

--- a/tests/invocation-daemon-isolation.test.ts
+++ b/tests/invocation-daemon-isolation.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import * as path from "node:path";
+import { runInvocation } from "../src/agent-runtime/invocation.js";
+import { registerAdapter } from "../src/agents/adapters.js";
+import type { Agent } from "../src/schema/meta.js";
+import { cleanupTempDir, createTempDir, readTestOutputSync, testUlid } from "./helpers/cli.js";
+
+const MOCK_ACP = path.join(__dirname, "mocks", "acp-mock.js");
+const MOCK_KSPEC_CLI = path.join(__dirname, "mocks", "kspec-capture-mock.cjs");
+
+function makeTestAgent(overrides: Partial<Agent> = {}): Agent {
+  return {
+    _ulid: testUlid("AGNT"),
+    id: "test-worker",
+    name: "Test Worker Agent",
+    capabilities: [],
+    tools: [],
+    conventions: [],
+    dispatch: [],
+    skills: [],
+    auto_approve: false,
+    concurrency: { max_concurrent: 1 },
+    adapter: "daemon-isolation-mock-acp",
+    ...overrides,
+  };
+}
+
+describe("agent invocation daemon isolation", () => {
+  const tempDirs: string[] = [];
+  let originalNoDaemon: string | undefined;
+  let originalCaptureFile: string | undefined;
+  let originalCaptureEnvVars: string | undefined;
+
+  beforeEach(() => {
+    originalNoDaemon = process.env.KSPEC_NO_DAEMON;
+    originalCaptureFile = process.env.KSPEC_CAPTURE_FILE;
+    originalCaptureEnvVars = process.env.KSPEC_CAPTURE_ENV_VARS;
+    process.env.KSPEC_NO_DAEMON = "0";
+    delete process.env.KSPEC_CAPTURE_FILE;
+    delete process.env.KSPEC_CAPTURE_ENV_VARS;
+  });
+
+  afterEach(async () => {
+    if (originalNoDaemon === undefined) {
+      delete process.env.KSPEC_NO_DAEMON;
+    } else {
+      process.env.KSPEC_NO_DAEMON = originalNoDaemon;
+    }
+    if (originalCaptureFile === undefined) {
+      delete process.env.KSPEC_CAPTURE_FILE;
+    } else {
+      process.env.KSPEC_CAPTURE_FILE = originalCaptureFile;
+    }
+    if (originalCaptureEnvVars === undefined) {
+      delete process.env.KSPEC_CAPTURE_ENV_VARS;
+    } else {
+      process.env.KSPEC_CAPTURE_ENV_VARS = originalCaptureEnvVars;
+    }
+    for (const dir of tempDirs.splice(0)) {
+      await cleanupTempDir(dir);
+    }
+  });
+
+  async function tempDir(prefix: string): Promise<string> {
+    const dir = await createTempDir(prefix);
+    tempDirs.push(dir);
+    return dir;
+  }
+
+  it("spawns dispatched agents with daemon proxying disabled", async () => {
+    const testDir = await tempDir("kspec-invocation-daemon-env-");
+    const verifyEnvFile = path.join(testDir, "agent-env.json");
+    const mutationLockFile = path.join(testDir, "dispatch-shadow-mutation");
+
+    registerAdapter("daemon-isolation-mock-acp", {
+      command: "node",
+      args: [MOCK_ACP],
+      env: {
+        MOCK_ACP_VERIFY_ENV_FILE: verifyEnvFile,
+        MOCK_ACP_VERIFY_ENV_VARS: "KSPEC_NO_DAEMON,KSPEC_SHADOW_MUTATION_LOCK_FILE,CUSTOM_AGENT_ENV",
+      },
+      description: "Mock ACP that captures environment for daemon isolation tests",
+    });
+
+    const result = await runInvocation({
+      agent: makeTestAgent(),
+      specDir: testDir,
+      sessionsDir: path.join(testDir, "sessions"),
+      cwd: testDir,
+      prompt: "Verify daemon isolation env",
+      trigger: "task.ready",
+      kspecCliPath: MOCK_KSPEC_CLI,
+      mutationLockFile,
+      env: { CUSTOM_AGENT_ENV: "preserved" },
+    });
+
+    expect(result.outcome).toBe("success");
+    const capturedEnv = JSON.parse(readTestOutputSync(verifyEnvFile));
+    expect(capturedEnv).toMatchObject({
+      KSPEC_NO_DAEMON: "1",
+      KSPEC_SHADOW_MUTATION_LOCK_FILE: mutationLockFile,
+      CUSTOM_AGENT_ENV: "preserved",
+    });
+  });
+
+  it("writes invocation failure notes with daemon proxying disabled", async () => {
+    const testDir = await tempDir("kspec-invocation-note-env-");
+    const captureFile = path.join(testDir, "kspec-calls.json");
+    const mutationLockFile = path.join(testDir, "dispatch-shadow-mutation");
+
+    registerAdapter("daemon-isolation-fail-mock-acp", {
+      command: "node",
+      args: [MOCK_ACP],
+      env: {
+        MOCK_ACP_EXIT_CODE: "1",
+      },
+      description: "Mock ACP that fails so invocation writes task notes",
+    });
+
+    process.env.KSPEC_CAPTURE_FILE = captureFile;
+    process.env.KSPEC_CAPTURE_ENV_VARS = "KSPEC_NO_DAEMON,KSPEC_SHADOW_MUTATION_LOCK_FILE";
+
+    const result = await runInvocation({
+      agent: makeTestAgent({ adapter: "daemon-isolation-fail-mock-acp" }),
+      specDir: testDir,
+      sessionsDir: path.join(testDir, "sessions"),
+      cwd: testDir,
+      taskRef: `@${testUlid("TASK")}`,
+      prompt: "Force failure note",
+      trigger: "task.ready",
+      kspecCliPath: MOCK_KSPEC_CLI,
+      mutationLockFile,
+      env: { KSPEC_CAPTURE_FILE: captureFile },
+    });
+
+    expect(result.outcome).toBe("failed");
+    const calls = JSON.parse(readTestOutputSync(captureFile));
+    expect(calls.length).toBeGreaterThan(0);
+    expect(calls[0].args.slice(0, 2)).toEqual(["task", "note"]);
+    expect(calls[0].env.KSPEC_NO_DAEMON).toBe("1");
+    expect(calls[0].env.KSPEC_SHADOW_MUTATION_LOCK_FILE).toBe(mutationLockFile);
+  });
+});

--- a/tests/invocation-daemon-isolation.test.ts
+++ b/tests/invocation-daemon-isolation.test.ts
@@ -67,6 +67,7 @@ describe("agent invocation daemon isolation", () => {
     return dir;
   }
 
+  // AC: @agent-invocation-lifecycle ac-invocation-commands-do-not-proxy-to-supervising-daemon
   it("spawns dispatched agents with daemon proxying disabled", async () => {
     const testDir = await tempDir("kspec-invocation-daemon-env-");
     const verifyEnvFile = path.join(testDir, "agent-env.json");
@@ -103,6 +104,7 @@ describe("agent invocation daemon isolation", () => {
     });
   });
 
+  // AC: @agent-invocation-lifecycle ac-invocation-lifecycle-helper-commands-do-not-proxy
   it("writes invocation failure notes with daemon proxying disabled", async () => {
     const testDir = await tempDir("kspec-invocation-note-env-");
     const captureFile = path.join(testDir, "kspec-calls.json");

--- a/tests/invocation-daemon-isolation.test.ts
+++ b/tests/invocation-daemon-isolation.test.ts
@@ -78,7 +78,8 @@ describe("agent invocation daemon isolation", () => {
       args: [MOCK_ACP],
       env: {
         MOCK_ACP_VERIFY_ENV_FILE: verifyEnvFile,
-        MOCK_ACP_VERIFY_ENV_VARS: "KSPEC_NO_DAEMON,KSPEC_SHADOW_MUTATION_LOCK_FILE,CUSTOM_AGENT_ENV",
+        MOCK_ACP_VERIFY_ENV_VARS:
+          "KSPEC_NO_DAEMON,KSPEC_SHADOW_MUTATION_LOCK_FILE,CUSTOM_AGENT_ENV",
       },
       description: "Mock ACP that captures environment for daemon isolation tests",
     });

--- a/tests/mocks/kspec-capture-mock.cjs
+++ b/tests/mocks/kspec-capture-mock.cjs
@@ -18,6 +18,10 @@ const fs = require("node:fs");
 
 const captureFile = process.env.KSPEC_CAPTURE_FILE;
 const args = process.argv.slice(2);
+const captureEnvVars = (process.env.KSPEC_CAPTURE_ENV_VARS || "")
+  .split(",")
+  .map((name) => name.trim())
+  .filter(Boolean);
 
 if (captureFile) {
   let calls = [];
@@ -26,7 +30,11 @@ if (captureFile) {
   } catch {
     // File doesn't exist yet
   }
-  calls.push({ args, timestamp: Date.now() });
+  const env = {};
+  for (const name of captureEnvVars) {
+    env[name] = process.env[name] || null;
+  }
+  calls.push({ args, env, timestamp: Date.now() });
   fs.writeFileSync(captureFile, JSON.stringify(calls, null, 2));
 }
 


### PR DESCRIPTION
## Summary

Consolidates 27 commits from `dev` into `main` across 40 files (+2,684 / -165 lines). This dev promotion is anchored by structured task-storage incompatibility responses, daemon cache suppression for repeated compatibility failures, recursive daemon-proxy suppression, dispatch/event-bus stability fixes, and daemon-backed test startup hardening.

Commit breakdown: 2 features, 9 fixes, 6 tests, 10 merge commits.

## Major Changes

### Task Storage Compatibility and Cache Degradation

- Adds a shared daemon route helper for legacy task-storage incompatibility errors.
- Returns structured `task_storage_incompatible` API responses across affected daemon route surfaces.
- Suppresses repeated entity-cache reports for known task-storage incompatibility states while preserving diagnostics and degraded-cache behavior.
- Adds route/helper/entity-cache coverage for the new incompatibility response path.

### Daemon Proxy and Agent Invocation Isolation

- Suppresses recursive daemon command proxying so daemon-handled commands do not call back into the same daemon command proxy path.
- Disables daemon proxying inside agent invocations with environment-level isolation coverage.
- Expands CLI daemon proxy tests for recursive suppression and invocation isolation regressions.

### Dispatch and Event-Bus Stability

- Prevents overlapping dispatch reconciliation cycles and adds stop-awaits-reconciliation coverage.
- Bounds event-bus lineage/source-ordering lifetime so correlated event chain-depth state is released after aging out.
- Gates cleanup-preservation diagnostics and snapshots diagnostic spy calls before `mockRestore()` to stabilize assertions.

### Test Runtime and Daemon Startup Hardening

- Stabilizes `cli-no-daemon` runtime assertions by using metadata rather than `ps -p`, and pins auto-start ports to ephemeral values for deterministic tests.
- Widens the Bun websocket runtime parity startup-hook budget so readiness diagnostics can surface instead of timing out too early.
- Serializes dynamic test daemon port startup with a filesystem lock so parallel test workers cannot race between port selection and bind.
- Holds the daemon startup lock across Playwright fixture startup/restart windows and preserves primary failures when cleanup also fails.

## Completed Workstreams

1. Structured task-storage incompatibility API response and cache-report suppression.
2. Recursive daemon command proxy suppression and agent invocation isolation.
3. Dispatch reconciliation/event-bus lifetime stabilization.
4. CLI no-daemon and Bun websocket parity test stabilization.
5. Parallel test daemon port-start serialization and Playwright restart safety.

## Review Notes

- The final daemon test-helper changes received an independent external review after fixes; review passed with no security concerns or logic errors.
- The review's earlier lock-release concerns were fixed before commit `6076c6f44d`.

## Test Plan

- [ ] CI passes on this PR
- [x] `npm run format:check` — all matched files use the correct format
- [x] `npm run lint` — 0 errors, 724 warnings
- [x] `npm run typecheck` — passes
- [x] `npm run test -- tests/e2e-fixture-daemon-cleanup.test.ts tests/helpers/daemon.test.ts` — 33 tests passed
- [x] `npm run test` — 2,451 test suites passed; 9,296 tests passed, 5 skipped; full log: `/tmp/kspec-test-cache/_default/e011efb1bbb5e2bc.log`
