### PR TITLE
chore: bump version to 0.14.0

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -18,6 +18,78 @@ release workflow before tagging.
 
 - None.
 
+## v0.14.0
+
+Stability release focused on daemon endpoint coherence, dispatch workspace
+cleanup safety, task-storage compatibility responses, docs/search/release-notes
+rendering, AC annotation validation, and CI/publish reliability.
+
+### New or changed configuration
+
+- `daemon.host` now defaults to numeric IPv4 loopback `127.0.0.1` instead of
+  `localhost` to avoid `/etc/hosts` and DNS resolution drift.
+- `daemon.connect_host` — optional host advertised to local clients when the
+  daemon binds a wildcard address such as `0.0.0.0` or `::`. It can also be set
+  with `KSPEC_DAEMON_CONNECT_HOST`.
+
+### Breaking changes
+
+- None.
+
+### Features & Additions
+
+- **Daemon endpoint resolution** — shared endpoint metadata and resolution now
+  flow through daemon startup, CLI lifecycle metadata, auto-start, clients, and
+  web UI daemon access. Endpoint validation rejects unreachable bind/connect
+  combinations while preserving loopback aliases and wildcard-bind use cases.
+- **Docs and release-note surfaces** — added Pagefind-backed docs search,
+  docs navigation integration, release-notes rendering in the web UI, and
+  canonical `RELEASE_NOTES.md` wiring tests.
+- **Task-storage compatibility API responses** — daemon routes now return
+  structured `task_storage_incompatible` responses for legacy task-storage
+  projects, with shared route helpers and coverage across affected surfaces.
+- **Detached reviewer merge helper** — merge/reviewer skills gained detached
+  review helper support plus portable supporting-file references.
+- **AC annotation validation** — acceptance-criteria annotations now enforce
+  the `ac-*` identifier format, normalize catalog IDs, and report malformed
+  annotation and stale-mapping cases more precisely.
+
+### Bug Fixes
+
+- Recursive daemon command proxying is suppressed, including inside agent
+  invocations, so daemon-handled commands do not call back into the same proxy
+  path.
+- Dispatch cleanup preserves active/in-flight task workspaces across branches,
+  reviewer snapshots, corrupt metadata, unknown worktree roots, and bootstrap
+  race windows while surfacing labeled diagnostics for skipped artifacts.
+- Dispatch reconciliation no longer overlaps active cycles; event-bus lineage
+  and source-ordering state is bounded so aged correlated chains are released.
+- Entity-cache diagnostics suppress repeated known task-storage incompatibility
+  reports while preserving degraded-cache behavior.
+- Daemon/web UI startup asset resolution, runtime readiness, configured host
+  validation, and CLI serve lifecycle metadata were hardened.
+- Publish workflow now installs Bun before running the full suite, and package
+  repository/discussion URLs now point at `lepahc/kynetic-spec`, unblocking npm
+  provenance publication.
+
+### Documentation
+
+- README was trimmed into a concise landing page with docs cross-links.
+- Added and refreshed Getting Started, Concepts, Guides, and Troubleshooting
+  pages, including corrected CLI guidance and recovery procedures.
+- Updated merge/reviewer guidance, dispatch-compatible branch guidance, and
+  rendered skill outputs.
+
+### Other Changes
+
+- Expanded the daemon-cleanup lint rule and test fixtures to catch unscoped
+  daemon ownership, alias/wrapper edge cases, lifecycle hooks, and startup
+  failure cleanup leaks.
+- Serialized dynamic test-daemon port startup with filesystem locks and held
+  Playwright fixture locks across restart windows to remove parallel bind races.
+- Applied final `oxfmt`, lint, typecheck, and full-test stability sweeps across
+  the dev merge delta.
+
 ## v0.13.0
 
 Significant release focused on a daemon entity cache, multi-turn session

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kynetic-ai/spec",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kynetic-ai/spec",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kynetic-ai/spec",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Kynetic Spec - Structured specification format for human-AI collaboration",
   "keywords": [
     "agent",


### PR DESCRIPTION
## Summary
- Bumps `@kynetic-ai/spec` from `0.13.0` to `0.14.0` in `package.json` and `package-lock.json`.
- Adds the `v0.14.0` section to `RELEASE_NOTES.md`.
- Release delta since `v0.13.0`: 367 commits / 254 non-merge commits, 257 files changed, 56,041 insertions, 5,061 deletions.

## Changes Since Last Release
- **Daemon endpoint coherence** — `daemon.host` now defaults to `127.0.0.1`; shared endpoint metadata/resolution now flows through daemon startup, CLI lifecycle metadata, auto-start, clients, and web UI access. Added `daemon.connect_host` / `KSPEC_DAEMON_CONNECT_HOST` for wildcard bind cases.
- **Task-storage compatibility** — daemon API routes now return structured `task_storage_incompatible` responses for legacy task-storage projects, and entity-cache diagnostics suppress repeated known incompatibility reports while preserving degraded-cache behavior.
- **Dispatch stability and cleanup safety** — dispatch workspace cleanup now preserves active/in-flight task workspaces across branches, reviewer snapshots, corrupt metadata, unknown roots, and bootstrap races; reconciliation no longer overlaps active cycles.
- **Daemon proxy isolation** — recursive daemon command proxying is suppressed, including inside agent invocations.
- **Docs and release surfaces** — added Pagefind-backed docs search, release-note rendering in the web UI, docs navigation integration, and refreshed Getting Started/Concepts/Guides/Troubleshooting content.
- **AC annotation validation** — AC annotation handling now enforces `ac-*` identifier format, normalizes catalog IDs, and reports malformed/stale mappings more precisely.
- **Reviewer/merge workflow support** — detached reviewer merge helper support and portable supporting-file references were added to merge/reviewer skills.
- **CI/publish reliability** — publish workflow installs Bun before the full suite, repository/discussion URLs point at `lepahc/kynetic-spec`, test daemon port startup is serialized, and Playwright daemon fixture locks cover restart windows.

## Merged PRs Included
- #915 — `fix(ci): add Setup Bun to publish workflow`
- #916 — `fix: update repository URLs from kynetic-ai to lepahc org`
- #917 — `Merge dev: daemon cleanup guardrails, dispatch protection, docs search, endpoint hardening`
- #918 — `Merge dev: task-storage compatibility, proxy isolation, dispatch stability`

## Release Audit / Test Plan
- [x] `npm run build`
- [x] `node dist/cli/index.js --version` → `0.14.0`
- [x] `node dist/cli/index.js release-notes --from 0.14.0 --to 0.14.0`
- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test` → 2,451 suites passed; 9,296 tests passed; 5 skipped
- [x] Fresh install / upgrade audit completed in `/tmp/kspec-release-test/audit.log`
- [x] `npm pack --dry-run`
- [x] Installed generated tarball `kynetic-ai-spec-0.14.0.tgz` into a clean temp project and verified `kspec --version` plus release-note extraction

## Publish Follow-up
- After this PR is approved and merged, publish the GitHub release/npm package and verify the published artifact.
