### PR TITLE
Merge dev: update Codex ACP for GPT-5.6

### DIFF
--- a/src/agents/adapters.ts
+++ b/src/agents/adapters.ts
@@ -22,6 +22,8 @@ interface AgentAdapterBase {
   description?: string;
   /** Arguments to append for auto-approve / yolo mode */
   autoApproveArgs?: string[];
+  /** Environment variables to set only for auto-approve / yolo mode */
+  autoApproveEnv?: Record<string, string>;
 }
 
 /**
@@ -140,10 +142,10 @@ const ADAPTERS: Record<string, AgentAdapter> = {
    */
   "codex-acp": {
     command: PKG_RUNNER_CMD,
-    args: [...PKG_RUNNER_PREPEND, "@zed-industries/codex-acp@0.12.0"],
+    args: [...PKG_RUNNER_PREPEND, "@agentclientprotocol/codex-acp@1.1.2"],
     shell: process.platform === "win32" && !IS_BUN,
     description: "Codex agent via ACP protocol",
-    autoApproveArgs: ["-c", 'approval_policy="never"', "-c", 'sandbox_mode="danger-full-access"'],
+    autoApproveEnv: { INITIAL_AGENT_MODE: "agent-full-access" },
   },
 
   /**

--- a/src/agents/runners.ts
+++ b/src/agents/runners.ts
@@ -501,6 +501,7 @@ function withResolvedCommand(adapter: AgentAdapter, executable: string): Command
     ...(adapter.shell !== undefined ? { shell: adapter.shell } : {}),
     ...(adapter.description !== undefined ? { description: adapter.description } : {}),
     ...(adapter.autoApproveArgs !== undefined ? { autoApproveArgs: adapter.autoApproveArgs } : {}),
+    ...(adapter.autoApproveEnv !== undefined ? { autoApproveEnv: adapter.autoApproveEnv } : {}),
     command: executable,
     requiresProcessExecutable: false,
   };
@@ -579,6 +580,9 @@ function buildImplicitContract(inputs: ImplicitContractInputs): RunnerInvocation
   // host process env directly.
   // AC: @runner-invocation-semantics ac-session-env-injected-through-runner
   const contractEnv: Record<string, string> = { ...env };
+  if (autoApprove) {
+    Object.assign(contractEnv, adapter.autoApproveEnv);
+  }
   applyKspecRequiredEnv(contractEnv, sessionId, mutationLockFile);
   const mutationEnv = buildKspecRequiredEnv(sessionId, mutationLockFile);
 
@@ -701,6 +705,9 @@ function buildRunnerContract(inputs: RunnerContractInputs): RunnerInvocation {
     ? (effectiveAdapter.autoApproveArgs ?? [])
     : [];
   const extraArgs: readonly string[] = [...autoApproveArgs, ...runner.process.args];
+  if (autoApprove) {
+    Object.assign(composedEnv, effectiveAdapter.autoApproveEnv);
+  }
 
   const sourceLayer = computeSourceLayer(runner);
 

--- a/tests/agent-runner-env.test.ts
+++ b/tests/agent-runner-env.test.ts
@@ -677,6 +677,28 @@ describe("resolveRunnerInvocation: contract redactor + routed session id", () =>
     expect(result.env.KSPEC_NO_DAEMON).toBe("1");
   });
 
+  // AC: @ralph-adapter-auto-approve ac-1
+  it("applies codex-acp auto-approve environment on the runner-backed path", () => {
+    const registry = buildRegistry(null, {
+      runners: { codex: { kind: "acp_process", adapter: "codex-acp" } },
+    });
+    const agent = makeAgent({ runner: "codex", auto_approve: true });
+    const result = resolveRunnerInvocation(makeInput({ agent, registry, autoApprove: true }));
+
+    expect(result.env.INITIAL_AGENT_MODE).toBe("agent-full-access");
+  });
+
+  // AC: @ralph-adapter-auto-approve ac-3
+  it("omits codex-acp auto-approve environment when auto-approve is disabled", () => {
+    const registry = buildRegistry(null, {
+      runners: { codex: { kind: "acp_process", adapter: "codex-acp" } },
+    });
+    const agent = makeAgent({ runner: "codex", auto_approve: false });
+    const result = resolveRunnerInvocation(makeInput({ agent, registry, autoApprove: false }));
+
+    expect(result.env.INITIAL_AGENT_MODE).toBeUndefined();
+  });
+
   // AC: @runner-invocation-semantics ac-session-env-injected-through-runner
   it("threads mutationLockFile into the contract env on the runner-backed path", () => {
     const registry = buildRegistry(null, {

--- a/tests/agent-runner-resolver.test.ts
+++ b/tests/agent-runner-resolver.test.ts
@@ -276,7 +276,7 @@ describe("resolveRunnerInvocation: runner precedence over adapter", () => {
   });
 
   // AC: @runner-invocation-semantics ac-auto-approve-from-resolved-contract
-  it("uses the runner-resolved adapter's autoApproveArgs, not the agent.adapter's", () => {
+  it("uses the runner-resolved adapter's auto-approve config, not the agent.adapter's", () => {
     const registry = buildRegistry(null, {
       runners: {
         codex: { kind: "acp_process", adapter: "codex-acp" },
@@ -285,9 +285,8 @@ describe("resolveRunnerInvocation: runner precedence over adapter", () => {
     const agent = makeAgent({ runner: "codex", adapter: "claude-agent-acp" });
     const result = resolveRunnerInvocation(makeInput({ agent, registry, autoApprove: true }));
 
-    // codex-acp uses `-c` flag args, not --dangerously-skip-permissions
     expect(result.extraArgs).not.toContain("--dangerously-skip-permissions");
-    expect(result.extraArgs).toContain("-c");
+    expect(result.env.INITIAL_AGENT_MODE).toBe("agent-full-access");
   });
 });
 

--- a/tests/agent-runtime/adapter-auto-approve.test.ts
+++ b/tests/agent-runtime/adapter-auto-approve.test.ts
@@ -33,18 +33,14 @@ async function cleanShutdown(agent: SpawnedAgent): Promise<void> {
 // Adapter Registry Tests
 // ============================================================================
 
-describe("Adapter auto-approve args registry", () => {
+describe("Adapter auto-approve configuration registry", () => {
   // AC: @ralph-adapter-auto-approve ac-1
-  it("codex-acp pins latest Zed package and has correct autoApproveArgs", () => {
+  it("codex-acp pins the current ACP package and selects full-access mode for auto-approve", () => {
     const adapter = getAdapter("codex-acp");
     expect(adapter).toBeDefined();
-    expect(adapter!.args).toContain("@zed-industries/codex-acp@0.12.0");
-    expect(adapter!.autoApproveArgs).toEqual([
-      "-c",
-      'approval_policy="never"',
-      "-c",
-      'sandbox_mode="danger-full-access"',
-    ]);
+    expect(adapter!.args).toContain("@agentclientprotocol/codex-acp@1.1.2");
+    expect(adapter!.autoApproveArgs).toBeUndefined();
+    expect(adapter!.autoApproveEnv).toEqual({ INITIAL_AGENT_MODE: "agent-full-access" });
   });
 
   // AC: @ralph-adapter-auto-approve ac-2

--- a/tests/session-create.test.ts
+++ b/tests/session-create.test.ts
@@ -918,7 +918,9 @@ describe("Environment Injection", () => {
       expect(adapter.command).toMatch(/\b(bun|npx)\b/);
       // Registered codex-acp pins a specific package version; ad-hoc resolution would
       // pass through the bare adapter id without a version suffix.
-      expect(adapter.args.some((arg) => arg.startsWith("@zed-industries/codex-acp@"))).toBe(true);
+      expect(adapter.args.some((arg) => arg.startsWith("@agentclientprotocol/codex-acp@"))).toBe(
+        true,
+      );
     });
 
     // AC: @droid-acp-adapter ac-1


### PR DESCRIPTION
## Summary

Promotes the one commit that landed on `dev` after #921 into `main`.

This updates the built-in Codex ACP adapter for GPT-5.6 compatibility and moves Codex auto-approval from legacy command-line configuration flags to the ACP package's supported initial agent-mode environment contract.

## Changes Since the Last Dev Promotion

### Codex ACP package update

- Replaces `@zed-industries/codex-acp@0.12.0` with `@agentclientprotocol/codex-acp@1.1.2`.
- Keeps the adapter package pinned to an explicit version.

### Adapter-scoped auto-approve environment

- Adds optional `autoApproveEnv` metadata to agent adapters.
- Configures `codex-acp` auto-approval with:
  - `INITIAL_AGENT_MODE=agent-full-access`
- Removes the old Codex-specific `-c approval_policy="never"` and `-c sandbox_mode="danger-full-access"` arguments.
- Applies adapter auto-approve environment variables only when auto-approve is enabled.

### Runner invocation parity

- Carries adapter `autoApproveEnv` through executable resolution.
- Applies the environment on both implicit adapter invocations and named runner-backed invocations.
- Preserves runner precedence over a conflicting legacy `agent.adapter` selection.

### Regression coverage

- Verifies the new Codex ACP package and full-access environment contract.
- Verifies the auto-approve environment is present for runner-backed auto-approved invocations.
- Verifies it is absent when auto-approve is disabled.
- Updates runner-precedence and session adapter-resolution expectations for the new package and environment semantics.

## Scope

- **1 non-merge commit** since the `dev` head promoted by #921.
- **6 files changed**: 43 insertions, 15 deletions.
- Production changes are limited to `src/agents/adapters.ts` and `src/agents/runners.ts`; the remaining four files are focused regression tests.
- `main` is otherwise ahead of `dev` only by the merge commit created for #921, so this PR does not replay the prior 448-file promotion delta.

## Included Commit

- `d914ab51d4` — `fix: update Codex ACP for GPT-5.6`

## Test Plan

- [ ] PR CI: lint and format
- [ ] PR CI: Node 20 test shards
- [ ] PR CI: Node 24 test shards
- [ ] PR CI: Playwright shards
- [ ] PR CI: unresolved-comment gate

## Release Follow-up

PR #922 was closed and its remote release branch was deleted. A replacement v0.15.0 release candidate should be prepared only after this promotion is reviewed, merged, and green on post-merge `main` CI.
