### PR TITLE
fix(release): support npm 12 pack JSON

### DIFF
--- a/scripts/verify-package.cjs
+++ b/scripts/verify-package.cjs
@@ -53,16 +53,125 @@ function findMissingArtifacts(packedPaths) {
   return problems;
 }
 
+/** Return whether a parsed value has npm's package-record shape. */
+function isPackResult(value) {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    Array.isArray(value.files) &&
+    value.files.every(
+      (file) =>
+        file !== null &&
+        typeof file === "object" &&
+        !Array.isArray(file) &&
+        typeof file.path === "string",
+    )
+  );
+}
+
+/** Normalize npm <=11's array and npm 12's package-name-keyed object. */
+function normalizePackPayload(value) {
+  if (Array.isArray(value)) {
+    return value.length > 0 && value.every(isPackResult) ? value : null;
+  }
+  if (value !== null && typeof value === "object") {
+    const records = Object.values(value);
+    return records.length > 0 && records.every(isPackResult) ? records : null;
+  }
+  return null;
+}
+
 /**
- * Extract the JSON payload from `npm pack --json` stdout. npm may print
- * notice/log lines around the JSON array, so parse from the first `[`.
+ * Extract balanced top-level object/array candidates without treating brackets
+ * inside JSON strings as structure. Text outside a candidate is ignored so npm
+ * notice lines before or after the payload remain harmless.
+ */
+function extractJsonCandidates(stdout) {
+  const candidates = [];
+  const malformed = [];
+
+  for (let start = 0; start < stdout.length; start += 1) {
+    const opening = stdout[start];
+    if (opening !== "[" && opening !== "{") continue;
+
+    const stack = [opening];
+    let inString = false;
+    let escaped = false;
+    let end = start + 1;
+    let mismatch = false;
+
+    for (; end < stdout.length; end += 1) {
+      const char = stdout[end];
+      if (inString) {
+        if (escaped) {
+          escaped = false;
+        } else if (char === "\\") {
+          escaped = true;
+        } else if (char === '"') {
+          inString = false;
+        }
+        continue;
+      }
+
+      if (char === '"') {
+        inString = true;
+      } else if (char === "[" || char === "{") {
+        stack.push(char);
+      } else if (char === "]" || char === "}") {
+        const expected = char === "]" ? "[" : "{";
+        if (stack.pop() !== expected) {
+          mismatch = true;
+          break;
+        }
+        if (stack.length === 0) break;
+      }
+    }
+
+    if (mismatch || stack.length > 0) {
+      malformed.push(`unbalanced JSON value beginning at character ${start}`);
+      start = end;
+      continue;
+    }
+
+    const text = stdout.slice(start, end + 1);
+    try {
+      candidates.push(JSON.parse(text));
+    } catch (err) {
+      malformed.push(`invalid JSON value beginning at character ${start}: ${err.message}`);
+    }
+    start = end;
+  }
+
+  return { candidates, malformed };
+}
+
+/**
+ * Parse and normalize the package listing from `npm pack --json` stdout.
+ * npm <=11 emits an array; npm 12 emits an object keyed by package name.
  */
 function parsePackJson(stdout) {
-  const jsonStart = stdout.indexOf("[");
-  if (jsonStart < 0) {
-    throw new Error(`npm pack produced no JSON output:\n${stdout}`);
+  const { candidates, malformed } = extractJsonCandidates(stdout);
+  const payloads = candidates.map(normalizePackPayload).filter((value) => value !== null);
+
+  if (payloads.length > 1) {
+    throw new Error(`ambiguous npm pack output: found ${payloads.length} package JSON payloads`);
   }
-  return JSON.parse(stdout.slice(jsonStart));
+  if (payloads.length === 1) {
+    if (payloads[0].length !== 1) {
+      throw new Error(
+        `ambiguous npm pack output: found ${payloads[0].length} package records in one payload`,
+      );
+    }
+    return payloads[0];
+  }
+  if (candidates.length > 0) {
+    throw new Error("npm pack JSON payload contained no package records with valid files entries");
+  }
+  if (malformed.length > 0) {
+    throw new Error(`malformed JSON payload in npm pack output: ${malformed[0]}`);
+  }
+  throw new Error("npm pack produced no JSON payload");
 }
 
 /**
@@ -125,4 +234,10 @@ if (require.main === module) {
   main();
 }
 
-module.exports = { REQUIRED_FILES, REQUIRED_PREFIXES, findMissingArtifacts, parsePackJson };
+module.exports = {
+  REQUIRED_FILES,
+  REQUIRED_PREFIXES,
+  findMissingArtifacts,
+  normalizePackPayload,
+  parsePackJson,
+};

--- a/scripts/verify-package.cjs
+++ b/scripts/verify-package.cjs
@@ -53,19 +53,28 @@ function findMissingArtifacts(packedPaths) {
   return problems;
 }
 
-/** Return whether a parsed value has npm's package-record shape. */
+/** Return whether a value is a non-empty string. */
+function isNonEmptyString(value) {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+/** Return whether a parsed value has npm's stable package-record shape. */
 function isPackResult(value) {
   return (
     value !== null &&
     typeof value === "object" &&
     !Array.isArray(value) &&
+    isNonEmptyString(value.name) &&
+    isNonEmptyString(value.version) &&
+    isNonEmptyString(value.filename) &&
     Array.isArray(value.files) &&
+    value.files.length > 0 &&
     value.files.every(
       (file) =>
         file !== null &&
         typeof file === "object" &&
         !Array.isArray(file) &&
-        typeof file.path === "string",
+        isNonEmptyString(file.path),
     )
   );
 }
@@ -75,11 +84,25 @@ function normalizePackPayload(value) {
   if (Array.isArray(value)) {
     return value.length > 0 && value.every(isPackResult) ? value : null;
   }
-  if (value !== null && typeof value === "object") {
-    const records = Object.values(value);
-    return records.length > 0 && records.every(isPackResult) ? records : null;
+  if (value !== null && typeof value === "object" && !Array.isArray(value)) {
+    const entries = Object.entries(value);
+    if (entries.length !== 1) return null;
+
+    const [packageName, record] = entries[0];
+    return isPackResult(record) && packageName === record.name ? [record] : null;
   }
   return null;
+}
+
+/** Return whether an npm 12 object contains multiple identity-bound records. */
+function isMultiRecordObjectPayload(value) {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+
+  const entries = Object.entries(value);
+  return (
+    entries.length > 1 &&
+    entries.every(([packageName, record]) => isPackResult(record) && packageName === record.name)
+  );
 }
 
 /**
@@ -153,7 +176,14 @@ function extractJsonCandidates(stdout) {
 function parsePackJson(stdout) {
   const { candidates, malformed } = extractJsonCandidates(stdout);
   const payloads = candidates.map(normalizePackPayload).filter((value) => value !== null);
+  const multiRecordPayloads = candidates.filter(isMultiRecordObjectPayload);
 
+  if (multiRecordPayloads.length > 0) {
+    const recordCount = Object.keys(multiRecordPayloads[0]).length;
+    throw new Error(
+      `ambiguous npm pack output: found ${recordCount} package records in one payload`,
+    );
+  }
   if (payloads.length > 1) {
     throw new Error(`ambiguous npm pack output: found ${payloads.length} package JSON payloads`);
   }

--- a/tests/release-packaging.test.ts
+++ b/tests/release-packaging.test.ts
@@ -204,10 +204,42 @@ describe("pack JSON output parsing", () => {
     expect(parsePackJson(stdout)).toEqual([packageRecord]);
   });
 
-  it("normalizes npm 12's package-name-keyed object without selecting its nested files array", () => {
+  it("normalizes npm 12's scoped package-name-keyed object without selecting its nested files array", () => {
     const stdout = JSON.stringify({ "@kynetic-ai/spec": packageRecord }, null, 2);
 
     expect(parsePackJson(stdout)).toEqual([packageRecord]);
+  });
+
+  it("rejects an npm 12-shaped record under an arbitrary log key", () => {
+    expect(() => parsePackJson(JSON.stringify({ status: packageRecord }))).toThrow(
+      /no package records/i,
+    );
+  });
+
+  it("rejects an npm 12 package key that does not match the record name", () => {
+    expect(() => parsePackJson(JSON.stringify({ "@kynetic-ai/other": packageRecord }))).toThrow(
+      /no package records/i,
+    );
+  });
+
+  it.each([
+    ["missing", undefined],
+    ["empty", ""],
+  ])("rejects a package record with a %s name", (_label, name) => {
+    const record = { ...packageRecord, name };
+
+    expect(() => parsePackJson(JSON.stringify([record]))).toThrow(/no package records/i);
+  });
+
+  it.each([
+    ["missing version", { ...packageRecord, version: undefined }],
+    ["empty version", { ...packageRecord, version: "" }],
+    ["missing filename", { ...packageRecord, filename: undefined }],
+    ["empty filename", { ...packageRecord, filename: "" }],
+    ["empty files array", { ...packageRecord, files: [] }],
+    ["empty file path", { ...packageRecord, files: [{ path: "", size: 0, mode: 0o644 }] }],
+  ])("rejects a generic object with %s", (_label, record) => {
+    expect(() => parsePackJson(JSON.stringify([record]))).toThrow(/no package records/i);
   });
 
   it("rejects output without a JSON payload with a clear diagnostic", () => {

--- a/tests/release-packaging.test.ts
+++ b/tests/release-packaging.test.ts
@@ -17,6 +17,7 @@ import { describe, it, expect, afterEach } from "vitest";
 import { spawnSync } from "node:child_process";
 import { mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
 import { join, dirname, relative } from "node:path";
+import { createRequire } from "node:module";
 import { fileURLToPath } from "node:url";
 import { buildTestSubprocessEnv, cleanupTempDir, createTempDir } from "./helpers/cli";
 import packageJson from "../package.json" with { type: "json" };
@@ -37,6 +38,11 @@ interface PackFileEntry {
 interface PackResult {
   files: PackFileEntry[];
 }
+
+const require = createRequire(import.meta.url);
+const { parsePackJson } = require(VERIFY_PACKAGE_SCRIPT) as {
+  parsePackJson(stdout: string): PackResult[];
+};
 
 /** Run scripts/verify-package.cjs against the package rooted at `cwd`. */
 function runVerifyPackage(cwd: string) {
@@ -180,6 +186,62 @@ describe("Workspace package privacy", () => {
   });
 });
 
+describe("pack JSON output parsing", () => {
+  const packageRecord = {
+    id: "@kynetic-ai/spec@0.15.0",
+    name: "@kynetic-ai/spec",
+    version: "0.15.0",
+    filename: "kynetic-ai-spec-0.15.0.tgz",
+    files: [
+      { path: "LICENSE", size: 1067, mode: 0o644 },
+      { path: "dist/[generated]/index.js", size: 2048, mode: 0o644 },
+    ],
+  };
+
+  it("normalizes npm 11's package array with harmless surrounding log text", () => {
+    const stdout = `npm notice packing\n${JSON.stringify([packageRecord])}\nnpm notice done\n`;
+
+    expect(parsePackJson(stdout)).toEqual([packageRecord]);
+  });
+
+  it("normalizes npm 12's package-name-keyed object without selecting its nested files array", () => {
+    const stdout = JSON.stringify({ "@kynetic-ai/spec": packageRecord }, null, 2);
+
+    expect(parsePackJson(stdout)).toEqual([packageRecord]);
+  });
+
+  it("rejects output without a JSON payload with a clear diagnostic", () => {
+    expect(() => parsePackJson("npm notice packing completed\n")).toThrow(/no JSON payload/i);
+  });
+
+  it("rejects malformed JSON payloads with a clear diagnostic", () => {
+    expect(() => parsePackJson('{"@kynetic-ai/spec":{"files":[}')).toThrow(
+      /malformed JSON payload/i,
+    );
+  });
+
+  it("rejects JSON that contains no package records", () => {
+    expect(() => parsePackJson('{"status":"ok"}')).toThrow(/no package records/i);
+  });
+
+  it("rejects ambiguous output containing multiple package payloads", () => {
+    const arrayPayload = JSON.stringify([packageRecord]);
+    const objectPayload = JSON.stringify({ "@kynetic-ai/spec": packageRecord });
+
+    expect(() => parsePackJson(`${arrayPayload}\n${objectPayload}`)).toThrow(/ambiguous/i);
+  });
+
+  it("rejects a payload containing multiple package records", () => {
+    const otherRecord = { ...packageRecord, name: "other-package", id: "other-package@0.15.0" };
+    const stdout = JSON.stringify({
+      "@kynetic-ai/spec": packageRecord,
+      "other-package": otherRecord,
+    });
+
+    expect(() => parsePackJson(stdout)).toThrow(/ambiguous/i);
+  });
+});
+
 describe("Release packaging", () => {
   // AC: @published-artifact-completeness ac-1
   it("includes LICENSE at the package root when packed for publication", () => {
@@ -195,12 +257,7 @@ describe("Release packaging", () => {
     expect(result.error).toBeUndefined();
     expect(result.status).toBe(0);
 
-    // npm may print notice/log lines to stdout before the JSON array,
-    // so parse from the array's opening bracket.
-    const stdout = result.stdout;
-    const jsonStart = stdout.indexOf("[");
-    expect(jsonStart).toBeGreaterThanOrEqual(0);
-    const parsed = JSON.parse(stdout.slice(jsonStart)) as PackResult[];
+    const parsed = parsePackJson(result.stdout);
 
     const paths = parsed[0].files.map((file) => file.path);
     expect(paths).toContain("LICENSE");


### PR DESCRIPTION
## Summary
- Supports npm 12's package-name-keyed `npm pack --json` output while retaining npm 11 array compatibility.
- Centralizes package-output parsing for the verifier and release-packaging test.
- Fails closed on malformed, missing, ambiguous, multi-package, invalid-file, arbitrary-key, or key/name-mismatched payloads.

## Incident
The v0.15.0 publication workflow upgraded to npm 12.0.1 and failed in `npm run verify-package` before `npm publish`. npm 12 changed the root JSON shape from an array to an object keyed by package name. The GitHub Release exists, but npm `0.15.0` remains unpublished and `latest` remains `0.14.0`.

Failed run: https://github.com/lepahc/kynetic-spec/actions/runs/29898171811

## Verification
- [x] TDD regressions: **30/30 passed**
- [x] Exact captured npm 12 output: 1 package / **1,216 files** / required artifacts present
- [x] Real `verify-package` under npm **12.0.1**
- [x] Real `verify-package` under npm **11.16.0**
- [x] npm 12 `verify-clean-pack`: **1,216 files**
- [x] Format, changed-file lint, typecheck, build, and `git diff --check`
- [x] Independent review after one fix cycle: **APPROVED**

## Recovery
After merge and green post-merge `main` CI, replace the unpublished `v0.15.0` tag/GitHub Release so they bind to the corrected merged commit, then rerun and verify the immutable-source publication workflow.
